### PR TITLE
Add API Reference documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+build:
+    image: latest

--- a/docs/conf.json
+++ b/docs/conf.json
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "include": [
+      "../node_modules/minim/lib/primitives",
+      "../node_modules/minim/lib/elements",
+      "../node_modules/minim-api-description/lib/elements",
+      "../node_modules/minim-parse-result/lib"
+    ]
+  }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+import subprocess
+
+IS_READTHEDOCS = os.environ.get('READTHEDOCS') == 'True'
+
+if IS_READTHEDOCS:
+    docs_dir = os.path.dirname(__file__)
+    project_dir = os.path.join(docs_dir, '..')
+    subprocess.check_call('npm install', cwd=project_dir, shell=True)
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -10,6 +20,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+extensions = ['sphinx_js']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -140,3 +151,9 @@ texinfo_documents = [
      author, 'APIElementsJS', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+
+# JS Doc
+
+primary_domain = 'js'
+jsdoc_config_path = 'conf.json'

--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -1,0 +1,121 @@
+Elements
+========
+
+.. contents::
+   :depth: 4
+
+Element
+-------
+
+.. autoclass:: Element
+   :members:
+
+Primitives
+----------
+
+String
+~~~~~~
+
+.. autoclass:: StringElement
+   :members:
+
+Number
+~~~~~~
+
+.. autoclass:: NumberElement
+   :members:
+
+Boolean
+~~~~~~~
+
+.. autoclass:: BooleanElement
+   :members:
+
+Null
+~~~~
+
+.. autoclass:: NullElement
+   :members:
+
+Collections
+-----------
+
+Array
+~~~~~
+
+.. autoclass:: ArrayElement
+   :members:
+
+Object
+~~~~~~
+
+.. autoclass:: ObjectElement
+   :members:
+
+Member
+~~~~~~
+
+.. autoclass:: MemberElement
+   :members:
+
+Profiles
+--------
+
+.. autoclass:: LinkElement
+   :members:
+
+Referencing
+-----------
+.. autoclass:: RefElement
+   :members:
+
+Parse Result
+------------
+
+.. class:: ParseResult
+
+Annotation
+~~~~~~~~~~
+
+.. class:: Annotation
+
+SourceMap
+~~~~~~~~~
+
+.. class:: SourceMap
+
+API Description
+---------------
+
+Category
+~~~~~~~~
+
+.. class:: Category
+
+Copy
+~~~~
+
+.. class:: Copy
+
+Data Structure
+~~~~~~~~~~~~~~
+
+.. class:: DataStructure
+.. class:: Enum
+
+Resource
+~~~~~~~~
+
+.. class:: Resource
+.. class:: Transition
+
+HTTP Transaction
+~~~~~~~~~~~~~~~~
+
+.. class:: HttpTransaction
+.. class:: HttpRequest
+.. class:: HttpResponse
+.. class:: HttpHeaders
+.. class:: Asset
+.. class:: HrefVariables
+.. class:: AuthScheme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,14 @@ Usage
     const parseResult = new namespace.elements.ParseResult();
     console.log(parseResult);
 
+API Reference
+-------------
+
+.. toctree::
+   :maxdepth: 2
+
+   elements
+
 Indices and tables
 ==================
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Pygments==2.2.0
 Sphinx==1.6.6
 sphinx-autobuild==0.7.1
+sphinx-js==2.4

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Apiary",
   "license": "MIT",
   "dependencies": {
-    "minim": "^0.20.4",
+    "minim": "git+https://github.com/refractproject/minim.git",
     "minim-parse-result": "^0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I changed the branch that readthedocs is building so we can test this branch (will restore after review).

This branch is built and published to http://api-elements-js.readthedocs.io/en/latest/elements.html. This includes decent documentation coverage for core minim elements. The API Description and Parse Result elements are lacking somewhat, but that is separate topic than this PR, this PR sets up the API Reference. Once we add further documentation to minim-api-description it will be shown here.