### PR TITLE
Update contributing instructions to not create venv inside docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ The documentation is built using Sphinx, a Python tool. Assuming you have
 Python 3 installed, the following steps can be used to build the site.
 
 ```shell
-$ cd docs/
 $ python3 -m venv venv
 $ source venv/bin/activate
+$ cd docs/
 $ pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
If the venv is created inside `docs/`, then all the dependencies will be installed on docs directory including Sphinx itself. When we try to build docs when there is Sphinx source inside the docs directory, it will attempt to build Sphinx docs as our own which will fail with a confusing error.

```
...
ted unindent.
/Users/kyle/Projects/apiaryio/api-elements.js/docs/venv/lib/python3.6/site-packages/sphinx_js/templates/class.rst:22: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/kyle/Projects/apiaryio/api-elements.js/docs/venv/lib/python3.6/site-packages/sphinx_js/templates/class.rst:29: WARNING: Definition list ends without a blank line; unexpected unindent.
/Users/kyle/Projects/apiaryio/api-elements.js/docs/venv/lib/python3.6/site-packages/sphinx/ext/autosummary/templates/autosummary/class.rst:3: WARNING: Unknown directive type "currentmodule".

.. currentmodule:: {{ module }}

Sphinx error:
No JSDoc documentation was found for object "{{ objname }}" or any path ending with that.
make: *** [html] Error 1
```