### PR TITLE
Fix duplicate fields in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "mocha"
   },
-  "author": "Apiary",
+  "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
   "dependencies": {
     "minim": "git+https://github.com/refractproject/minim.git",
@@ -22,7 +22,5 @@
   },
   "engines": {
     "node": ">=4"
-  },
-  "author": "Apiary.io <support@apiary.io>",
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
`author` and `license` were duplicated in package.json. I've merged these duplicates together.