### PR TITLE
Ignore development files for NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+venv/
+docs/
+.readthedocs.yml
+.travis.yml


### PR DESCRIPTION
This PR removes the docs, any configured virtualenv and the `.readthedocs.yml` and `.travis.yml` files from the distributed NPM package. These are not needed in the NPM package.