### PR TITLE
Update minim-parse-result to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "minim": "^0.20.5",
-    "minim-parse-result": "^0.10.0"
+    "minim-parse-result": "^0.10.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This brings in jsdoc updates to fix documentation website.