### PR TITLE
Add information about API Elements and subpackages to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
-# API Elements
+# API Elements: JavaScript
 
-## Using Lerna
+[API Elements](https://apielements.org/) is a uniform interface for dealing
+with API description formats ([API Blueprint](https://apiblueprint.org/), [OpenAPI](https://github.com/OAI/OpenAPI-Specification), ...). This repository contains tooling for handling API
+Elements in JavaScript along with parsers and serializers for API description
+languages.
+
+API Elements adapters:
+
+- [API Blueprint Parser](packages/fury-adapter-apib-parser)
+- [API Blueprint Serializer](packages/fury-adapter-apib-parser)
+- [OpenAPI 2 Parser](packages/fury-adapter-swagger)
+
+## Usage
+
+```javascript
+const { Fury } = require('fury');
+
+const fury = new Fury();
+
+// Load any parsers or serializer adapters you wish to use
+const apiBlueprintParser = require('fury-adapter-apib-parser');
+fury.use(apiBlueprintParser);
+
+const openAPI2Parser = require('fury-adapter-swagger');
+fury.use(openAPI2Parser);
+
+const source = `
+FORMAT: 1A
+
+# My API
+## GET /message
++ Response 200 (text/plain)
+
+        Hello World!
+`;
+
+fury.parse({source}, (error, parseResult) => {
+  console.log(parseResult.api.title);
+});
+```
+
+See [API Reference documentation](https://api-elements-js.readthedocs.io/en/latest/api.html#elements)
+for the details about the ParseResult object and other elements interface in
+JavaScript.
+
+[API Elements
+Reference](https://apielements.org/en/latest/element-definitions.html) contains
+information regarding the design of various API Elements.
+
+## Development
+
+### Using Lerna
 
 Install dependencies of all packages:
 
@@ -29,7 +79,7 @@ To run tests for a single package:
 $ npx lerna exec --scope='package_name' -- npm run test
 ```
 
-## Documentation
+### Documentation
 
 The documentation is built using Sphinx, a Python tool. Assuming you have
 Python 3 installed, the following steps can be used to build the site.
@@ -41,7 +91,7 @@ $ cd docs/
 $ pip install -r requirements.txt
 ```
 
-### Running the Development Server
+#### Running the Development Server
 
 You can run a local development server to preview changes using the following:
 


### PR DESCRIPTION
I'm sure we can improve on this more (#17), but I wanted to get something started in the README so we can start redirecting contributors from the existing Fury repositories over here as I've seen some PRs over in some of the adapters.

See [rendered version](https://github.com/apiaryio/api-elements.js/tree/kylef/readme).