### PR TITLE
Permit `null` as an enum value in referenced schemas

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a case where having `null` as an enum value or having
+  `x-nullable: true` on a schema with `enum` will cause an obscure error:
+
+  > Cannot read property '$ref' of null
+
 ## 0.23.0 (2018-12-21)
 
 ### Breaking

--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.23.1 (2019-01-10)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -213,6 +213,10 @@ const convertSubSchema = (schema, references, swagger) => {
 /** Returns true if the given schema contains any references
  */
 const checkSchemaHasReferences = (schema) => {
+  if (!schema) {
+    return false;
+  }
+
   if (schema.$ref) {
     return true;
   }

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-swagger/test/fixtures/schema-reference-nullable-enum.json
+++ b/packages/fury-adapter-swagger/test/fixtures/schema-reference-nullable-enum.json
@@ -1,0 +1,217 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "nullable enum"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "OK"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\"type\":\"object\",\"properties\":{\"color\":{\"type\":[\"string\",\"null\"],\"enum\":[\"red\",\"blue\",\"green\",null]}}}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "definitions/NullableEnum"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "definitions/NullableEnum"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "optional"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "color"
+                      },
+                      "value": {
+                        "element": "enum",
+                        "attributes": {
+                          "enumerations": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "red"
+                              },
+                              {
+                                "element": "string",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "blue"
+                              },
+                              {
+                                "element": "string",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "green"
+                              }
+                            ]
+                          },
+                          "typeAttributes": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "content": "nullable"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/fury-adapter-swagger/test/fixtures/schema-reference-nullable-enum.yaml
+++ b/packages/fury-adapter-swagger/test/fixtures/schema-reference-nullable-enum.yaml
@@ -1,0 +1,23 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: nullable enum
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/NullableEnum'
+definitions:
+  NullableEnum:
+    type: object
+    properties:
+      color:
+        type: string
+        x-nullable: true
+        enum:
+          - red
+          - blue
+          - green


### PR DESCRIPTION
The logic to check if we need to dereference a schema was failing in a case where we would find `null` as a value on an enum. As we're checking for the presence of `null.$ref` which causes an error to be thrown:

> Cannot read property '$ref' of null

This is a little tricky to test as it is a combination of things happen and thus I have not created a unit regression test but only a regression integration fixture. This problem can only happen when you reference another schema, for example the following tests pass without these fixes:

```js
it('translates x-nullable to enum value', () => {
  const schema = convertSchema({ enum: ['north', 'east', 'south', 'west'], 'x-nullable': true });
  expect(schema).to.deep.equal({ enum: ['north', 'east', 'south', 'west', null] });
});

it('translates x-nullable to enum value with existing null in enum', () => {
  const schema = convertSchema({ enum: ['north', 'east', 'south', 'west', null], 'x-nullable': true });
  expect(schema).to.deep.equal({ enum: ['north', 'east', 'south', 'west', null] });
});
```

It's only when `convertSchema` is used when the schema references another schema where you'd be able to reproduce.