### PR TITLE
Schema Object parser should not accept member

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -33,7 +33,7 @@ function parseComponentsObject(context, element) {
 
   const parseSchemasObject = pipeParseResult(namespace,
     validateIsObject('schemas'),
-    parseObject(context, parseSchemaObject(context)));
+    parseObject(context, R.compose(parseSchemaObject(context), getValue)));
 
   const parseParametersObjectMember = (member) => {
     // Create a Member Element with `member.key` as the key

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -78,7 +78,11 @@ function parseOASObject(context, object) {
         const schemas = components.get('schemas');
         if (schemas) {
           const dataStructures = new namespace.elements.Category(
-            schemas.content.map(getValue),
+            schemas.content.map((member) => {
+              const dataStructure = member.value.clone();
+              dataStructure.content.id = member.key.clone();
+              return dataStructure;
+            }),
             { classes: ['dataStructures'] }
           );
           api.push(dataStructures);

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSchemaObject.js
@@ -36,12 +36,12 @@ const isValidType = R.anyPass(R.map(hasValue, types));
  * Parse Schema Object
  *
  * @param namespace {Namespace}
- * @param element {MemberElement}
+ * @param element {Element}
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
  */
-function parseSchemaObject(context, member) {
+function parseSchemaObject(context, element) {
   const { namespace } = context;
 
   const ensureValidType = R.unless(isValidType, createWarning(namespace,
@@ -84,12 +84,10 @@ function parseSchemaObject(context, member) {
         return new namespace.elements.ParseResult();
       }
 
-      element.id = member.key.clone();
-
       return new namespace.elements.DataStructure(element);
     });
 
-  return parseSchema(member.value);
+  return parseSchema(element);
 }
 
 module.exports = R.curry(parseSchemaObject);

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseSchemaObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseSchemaObject-test.js
@@ -12,7 +12,7 @@ describe('Schema Object', () => {
   });
 
   it('provides a warning when schema is non-object', () => {
-    const schema = new namespace.elements.Member('User', 'my schema');
+    const schema = new namespace.elements.String('my schema');
     const result = parse(context, schema);
 
     expect(result.length).to.equal(1);
@@ -21,7 +21,7 @@ describe('Schema Object', () => {
 
   describe('#type', () => {
     it('warns when type is not a string', () => {
-      const schema = new namespace.elements.Member('User', {
+      const schema = new namespace.elements.Object({
         type: ['null'],
       });
       const result = parse(context, schema);
@@ -30,7 +30,7 @@ describe('Schema Object', () => {
     });
 
     it('warns when type is not a valid type', () => {
-      const schema = new namespace.elements.Member('User', {
+      const schema = new namespace.elements.Object({
         type: 'invalid',
       });
       const result = parse(context, schema);
@@ -41,7 +41,7 @@ describe('Schema Object', () => {
     });
 
     it('returns a null structure for null type', () => {
-      const schema = new namespace.elements.Member('User', {
+      const schema = new namespace.elements.Object({
         type: 'null',
       });
       const result = parse(context, schema);
@@ -52,11 +52,10 @@ describe('Schema Object', () => {
 
       const element = result.get(0).content;
       expect(element).to.be.instanceof(namespace.elements.Null);
-      expect(element.id.toValue()).to.equal('User');
     });
 
     it('returns a boolean structure for boolean type', () => {
-      const schema = new namespace.elements.Member('name', {
+      const schema = new namespace.elements.Object({
         type: 'boolean',
       });
       const result = parse(context, schema);
@@ -67,11 +66,10 @@ describe('Schema Object', () => {
 
       const string = result.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.Boolean);
-      expect(string.id.toValue()).to.equal('name');
     });
 
     it('returns an object structure for object type', () => {
-      const schema = new namespace.elements.Member('User', {
+      const schema = new namespace.elements.Object({
         type: 'object',
       });
       const result = parse(context, schema);
@@ -82,11 +80,10 @@ describe('Schema Object', () => {
 
       const object = result.get(0).content;
       expect(object).to.be.instanceof(namespace.elements.Object);
-      expect(object.id.toValue()).to.equal('User');
     });
 
     it('returns an array structure for array type', () => {
-      const schema = new namespace.elements.Member('Users', {
+      const schema = new namespace.elements.Object({
         type: 'array',
       });
       const result = parse(context, schema);
@@ -97,11 +94,10 @@ describe('Schema Object', () => {
 
       const array = result.get(0).content;
       expect(array).to.be.instanceof(namespace.elements.Array);
-      expect(array.id.toValue()).to.equal('Users');
     });
 
     it('returns a number structure for number type', () => {
-      const schema = new namespace.elements.Member('id', {
+      const schema = new namespace.elements.Object({
         type: 'number',
       });
       const result = parse(context, schema);
@@ -112,11 +108,10 @@ describe('Schema Object', () => {
 
       const string = result.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.Number);
-      expect(string.id.toValue()).to.equal('id');
     });
 
     it('returns a string structure for string type', () => {
-      const schema = new namespace.elements.Member('name', {
+      const schema = new namespace.elements.Object({
         type: 'string',
       });
       const result = parse(context, schema);
@@ -127,11 +122,10 @@ describe('Schema Object', () => {
 
       const string = result.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.String);
-      expect(string.id.toValue()).to.equal('name');
     });
 
     it('returns a number structure for integer type', () => {
-      const schema = new namespace.elements.Member('id', {
+      const schema = new namespace.elements.Object({
         type: 'integer',
       });
       const result = parse(context, schema);
@@ -142,7 +136,6 @@ describe('Schema Object', () => {
 
       const string = result.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.Number);
-      expect(string.id.toValue()).to.equal('id');
     });
   });
 });


### PR DESCRIPTION
The schema object parser shouldn't accept a member element with the ID name because we can parse schema objects from other locations. Right now this was only happening from components and thus there is always a member with an ID.

The ID should be attached by the caller at use.