### PR TITLE
Support OpenAPI 3 in Fury CLI

### DIFF
--- a/packages/fury-cli/lib/fury.js
+++ b/packages/fury-cli/lib/fury.js
@@ -11,23 +11,26 @@ const { highlight } = require('cardinal');
 const theme = require('cardinal/themes/tomorrow-night');
 const { JSON06Serialiser } = require('minim');
 const fury = require('fury');
-const swagger = require('fury-adapter-swagger');
 const apiBlueprintParser = require('fury-adapter-apib-parser');
 const apiBlueprintSerializer = require('fury-adapter-apib-serializer');
 const apiaryBlueprintParser = require('fury-adapter-apiary-blueprint-parser');
+const oas2Parser = require('fury-adapter-swagger');
+const oas3Parser = require('fury-adapter-oas3-parser');
 const pkg = require('../package.json');
 
 const adapters = [
-  'fury-adapter-swagger',
   'fury-adapter-apib-parser',
   'fury-adapter-apib-serializer',
   'fury-adapter-apiary-blueprint-parser',
+  'fury-adapter-swagger',
+  'fury-adapter-oas3-parser',
 ];
 
-fury.use(swagger);
 fury.use(apiBlueprintParser);
 fury.use(apiBlueprintSerializer);
 fury.use(apiaryBlueprintParser);
+fury.use(oas2Parser);
+fury.use(oas3Parser);
 
 function isRefract(source) {
   let parseResult;

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -24,6 +24,7 @@
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.5",
     "fury-adapter-apib-parser": "^0.12.0",
     "fury-adapter-apib-serializer": "^0.8.0",
+    "fury-adapter-oas3-parser": "^0.2.0",
     "fury-adapter-swagger": "^0.23.0",
     "js-yaml": "^3.6",
     "minim": "^0.22.1"


### PR DESCRIPTION
```shell
$ npx fury packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.yaml

...

warning: 'Info Object' contains unsupported key 'license' - line 5
warning: 'OpenAPI Object' contains unsupported key 'servers' - line 7
warning: 'Operation Object' contains unsupported key 'tags' - line 14
warning: 'Operation Object' contains unsupported key 'parameters' - line 16
warning: 'Response Object' contains unsupported key 'description' - line 26
warning: 'Response Object' contains unsupported key 'headers' - line 27
warning: 'Response Object' default responses unsupported
warning: 'Operation Object' contains unsupported key 'tags' - line 45
warning: 'Response Object' contains unsupported key 'description' - line 49
warning: 'Response Object' default responses unsupported
warning: 'Parameter Object' contains invalid key 'schema' - line 62
warning: 'Operation Object' contains unsupported key 'tags' - line 67
warning: 'Response Object' contains unsupported key 'description' - line 71
warning: 'Response Object' default responses unsupported
warning: 'Schema Object' contains unsupported key 'required' - line 86
warning: 'Schema Object' contains unsupported key 'properties' - line 89
warning: 'Schema Object' contains unsupported key 'items' - line 99
warning: 'Schema Object' contains unsupported key 'required' - line 103
warning: 'Schema Object' contains unsupported key 'properties' - line 106
```


Closes #47 
