### PR TITLE
Warn on and ignore non-unique `operationId`

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/annotations.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/annotations.js
@@ -21,6 +21,10 @@ function createInvalidMemberWarning(namespace, path, member) {
   return createWarning(namespace, message, member.key);
 }
 
+function createIdentifierNotUniqueWarning(namespace, path, member) {
+  return createWarning(namespace, `'${path}' '${member.key.toValue()}' is not a unique identifier: '${member.value.toValue()}'`, member.value);
+}
+
 function createMemberValueNotStringWarning(namespace, path, member) {
   return createWarning(namespace, `'${path}' '${member.key.toValue()}' is not a string`, member.value);
 }
@@ -66,6 +70,7 @@ module.exports = {
   createWarning,
   createUnsupportedMemberWarning: R.curry(createUnsupportedMemberWarning),
   createInvalidMemberWarning: R.curry(createInvalidMemberWarning),
+  createIdentifierNotUniqueWarning: R.curry(createIdentifierNotUniqueWarning),
   createMemberValueNotStringWarning: R.curry(createMemberValueNotStringWarning),
   createMemberValueNotStringError: R.curry(createMemberValueNotStringError),
   createMemberValueNotBooleanWarning: R.curry(createMemberValueNotBooleanWarning),

--- a/packages/fury-adapter-oas3-parser/lib/state.js
+++ b/packages/fury-adapter-oas3-parser/lib/state.js
@@ -4,7 +4,12 @@ class State {
   }
 
   registerId(id) {
-    return this.registeredIds.add(id);
+    if (this.registeredIds.has(id)) {
+      return false;
+    }
+
+    this.registeredIds.add(id);
+    return true;
   }
 }
 

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOperationObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOperationObject-test.js
@@ -259,5 +259,34 @@ describe('Operation Object', () => {
       expect(transition).to.be.instanceof(namespace.elements.Transition);
       expect(transition.id.toValue()).to.equal('exampleId');
     });
+
+    it('warns when operationId is not unique', () => {
+      const operationA = new namespace.elements.Member('get', {
+        operationId: 'exampleId',
+        responses: {},
+      });
+
+      const operationB = new namespace.elements.Member('get', {
+        operationId: 'exampleId',
+        responses: {},
+      });
+
+      const resultA = parse(context, operationA);
+
+      {
+        expect(resultA.length).to.equal(1);
+        const transition = resultA.get(0);
+        expect(transition).to.be.instanceof(namespace.elements.Transition);
+        expect(transition.id.toValue()).to.equal('exampleId');
+      }
+
+      const resultB = parse(context, operationB);
+      {
+        expect(resultB.length).to.equal(2);
+        const transition = resultB.get(0);
+        expect(transition).to.be.instanceof(namespace.elements.Transition);
+        expect(resultB).to.contain.warning("'Operation Object' 'operationId' is not a unique identifier: 'exampleId'");
+      }
+    });
   });
 });


### PR DESCRIPTION
Leaves out `operationId`s with non-unique content, renders warning instead.