### PR TITLE
'description' and 'content' in request body

### DIFF
--- a/packages/fury-adapter-oas3-parser/STATUS.md
+++ b/packages/fury-adapter-oas3-parser/STATUS.md
@@ -111,7 +111,7 @@ Key:
 | Location | Support |
 |:--|:--|
 | description | ✓ |
-| content | ✕ |
+| content | ✓ |
 | required | ✕ |
 
 ## Responses Object

--- a/packages/fury-adapter-oas3-parser/STATUS.md
+++ b/packages/fury-adapter-oas3-parser/STATUS.md
@@ -110,7 +110,7 @@ Key:
 
 | Location | Support |
 |:--|:--|
-| description | ✕ |
+| description | ✓ |
 | content | ✕ |
 | required | ✕ |
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseRequestBodyObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseRequestBodyObject.js
@@ -1,16 +1,23 @@
 const R = require('ramda');
 const pipeParseResult = require('../../pipeParseResult');
-const { isExtension, hasKey } = require('../../predicates');
 const {
+  isObject,
+  isExtension,
+  hasKey,
+  getValue,
+} = require('../../predicates');
+const {
+  createWarning,
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
 } = require('../annotations');
 const parseObject = require('../parseObject');
+const parseMediaTypeObject = require('./parseMediaTypeObject');
 const parseCopy = require('../parseCopy');
 
 const name = 'Request Body Object';
 const unsupportedKeys = [
-  'content', 'required',
+  'required',
 ];
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 
@@ -26,7 +33,18 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 function parseRequestBodyObject(context, element) {
   const { namespace } = context;
 
+  const validateIsObject = key => R.unless(isObject,
+    createWarning(namespace, `'${name}' '${key}' is not an object`));
+
+  const parseContent = pipeParseResult(namespace,
+    validateIsObject('content'),
+    parseObject(context, name, parseMediaTypeObject(context, namespace.elements.HttpRequest)),
+    mediaTypes => new namespace.elements.ParseResult([
+      mediaTypes.content.map(getValue),
+    ]));
+
   const parseMember = R.cond([
+    [hasKey('content'), R.compose(parseContent, getValue)],
     [hasKey('description'), parseCopy(context, name, false)],
 
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],
@@ -41,14 +59,16 @@ function parseRequestBodyObject(context, element) {
   const parseRequestBodyObject = pipeParseResult(namespace,
     parseObject(context, name, parseMember),
     (requestBodyObject) => {
-      const request = new namespace.elements.HttpRequest();
+      const requests = R.or(requestBodyObject.get('content'), [new namespace.elements.HttpRequest()]);
       const description = requestBodyObject.get('description');
 
-      if (description) {
-        request.push(description);
-      }
+      return new namespace.elements.ParseResult(requests.map((request) => {
+        if (description) {
+          request.push(description);
+        }
 
-      return request;
+        return request;
+      }));
     });
 
   return parseRequestBodyObject(element);

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseRequestBodyObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseRequestBodyObject-test.js
@@ -44,16 +44,6 @@ describe('Request Body Object', () => {
   });
 
   describe('warnings for unsupported properties', () => {
-    it('provides warning for unsupported content key', () => {
-      const request = new namespace.elements.Object({
-        content: 'Example Request Body',
-      });
-
-      const result = parse(context, request);
-
-      expect(result).to.contain.warning("'Request Body Object' contains unsupported key 'content'");
-    });
-
     it('provides warning for unsupported required key', () => {
       const request = new namespace.elements.Object({
         required: true,
@@ -83,5 +73,38 @@ describe('Request Body Object', () => {
     const result = parse(context, request);
 
     expect(result).to.contain.warning("'Request Body Object' contains invalid key 'invalid'");
+  });
+
+  describe('#content', () => {
+    it('warns when content is not an object', () => {
+      const response = new namespace.elements.Object({
+        content: '',
+      });
+
+      const result = parse(context, response);
+
+      expect(result).to.contain.warning("'Request Body Object' 'content' is not an object");
+    });
+
+    it('returns a HTTP request elements matching the media types', () => {
+      const response = new namespace.elements.Object({
+        content: {
+          'application/json': {},
+          'text/plain': {},
+        },
+      });
+
+      const result = parse(context, response);
+
+      expect(result.length).to.equal(2);
+
+      const jsonRequest = result.get(0);
+      expect(jsonRequest).to.be.instanceof(namespace.elements.HttpRequest);
+      expect(jsonRequest.contentType.toValue()).to.equal('application/json');
+
+      const textRequest = result.get(1);
+      expect(textRequest).to.be.instanceof(namespace.elements.HttpRequest);
+      expect(textRequest.contentType.toValue()).to.equal('text/plain');
+    });
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseRequestBodyObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseRequestBodyObject-test.js
@@ -29,17 +29,21 @@ describe('Request Body Object', () => {
     expect(result).to.contain.warning("'Request Body Object' is not an object");
   });
 
-  describe('warnings for unsupported properties', () => {
-    it('provides warning for unsupported description key', () => {
+  describe('#description', () => {
+    it('it expose description in content', () => {
       const request = new namespace.elements.Object({
         description: 'Example Request Body',
       });
 
       const result = parse(context, request);
 
-      expect(result).to.contain.warning("'Request Body Object' contains unsupported key 'description'");
+      expect(result).to.not.contain.annotations;
+      expect(result.length).to.be.equal(1);
+      expect(result.get(0).copy.toValue()).to.deep.equal(['Example Request Body']);
     });
+  });
 
+  describe('warnings for unsupported properties', () => {
     it('provides warning for unsupported content key', () => {
       const request = new namespace.elements.Object({
         content: 'Example Request Body',


### PR DESCRIPTION
closes #103 
closes #104 

Handle `description` and `content` for RequestBody in same way like Response does