### PR TITLE
Respect generateSourceMap option

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+
 const R = require('ramda');
 
 const {
@@ -35,13 +37,13 @@ function filterSourceMaps(result) {
     if (!result.element) {
       return result;
     }
-    if (result.attributes) {
+    if (result._attributes) {
       result.attributes.remove('sourceMap');
       result.attributes.forEach((value, key, member) => {
         filterSourceMaps(member);
       });
     }
-    if (result.meta) {
+    if (result._meta) {
       result.meta.forEach((value, key, member) => {
         filterSourceMaps(member);
       });

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/path-item-object-parameters.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/path-item-object-parameters.json
@@ -15,102 +15,12 @@
         },
         "title": {
           "element": "string",
-          "attributes": {
-            "sourceMap": {
-              "element": "array",
-              "content": [
-                {
-                  "element": "sourceMap",
-                  "content": [
-                    {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 4
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 10
-                            }
-                          },
-                          "content": 49
-                        },
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 4
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 30
-                            }
-                          },
-                          "content": 20
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          },
           "content": "Parameter Components"
         }
       },
       "attributes": {
         "version": {
           "element": "string",
-          "attributes": {
-            "sourceMap": {
-              "element": "array",
-              "content": [
-                {
-                  "element": "sourceMap",
-                  "content": [
-                    {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 3
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 12
-                            }
-                          },
-                          "content": 34
-                        },
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 3
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 17
-                            }
-                          },
-                          "content": 5
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          },
           "content": "1.0.0"
         }
       },
@@ -120,51 +30,6 @@
           "attributes": {
             "href": {
               "element": "string",
-              "attributes": {
-                "sourceMap": {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "sourceMap",
-                      "content": [
-                        {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "number",
-                              "attributes": {
-                                "line": {
-                                  "element": "number",
-                                  "content": 6
-                                },
-                                "column": {
-                                  "element": "number",
-                                  "content": 3
-                                }
-                              },
-                              "content": 79
-                            },
-                            {
-                              "element": "number",
-                              "attributes": {
-                                "line": {
-                                  "element": "number",
-                                  "content": 6
-                                },
-                                "column": {
-                                  "element": "number",
-                                  "content": 8
-                                }
-                              },
-                              "content": 5
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
               "content": "/pets{?skip,limit}"
             },
             "hrefVariables": {
@@ -175,51 +40,6 @@
                   "meta": {
                     "description": {
                       "element": "string",
-                      "attributes": {
-                        "sourceMap": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "sourceMap",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "content": [
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 24
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 20
-                                        }
-                                      },
-                                      "content": 510
-                                    },
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 24
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 43
-                                        }
-                                      },
-                                      "content": 23
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "content": "number of items to skip"
                     }
                   },
@@ -237,51 +57,6 @@
                   "content": {
                     "key": {
                       "element": "string",
-                      "attributes": {
-                        "sourceMap": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "sourceMap",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "content": [
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 22
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 13
-                                        }
-                                      },
-                                      "content": 470
-                                    },
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 22
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 17
-                                        }
-                                      },
-                                      "content": 4
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "content": "skip"
                     }
                   }
@@ -291,51 +66,6 @@
                   "meta": {
                     "description": {
                       "element": "string",
-                      "attributes": {
-                        "sourceMap": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "sourceMap",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "content": [
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 29
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 20
-                                        }
-                                      },
-                                      "content": 624
-                                    },
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 29
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 41
-                                        }
-                                      },
-                                      "content": 21
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "content": "max records to return"
                     }
                   },
@@ -353,51 +83,6 @@
                   "content": {
                     "key": {
                       "element": "string",
-                      "attributes": {
-                        "sourceMap": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "sourceMap",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "content": [
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 27
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 13
-                                        }
-                                      },
-                                      "content": 583
-                                    },
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 27
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 18
-                                        }
-                                      },
-                                      "content": 5
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "content": "limit"
                     }
                   }
@@ -411,51 +96,6 @@
               "meta": {
                 "title": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 11
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 16
-                                    }
-                                  },
-                                  "content": 227
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 11
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 29
-                                    }
-                                  },
-                                  "content": 13
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "List all pets"
                 }
               },
@@ -468,51 +108,6 @@
                       "attributes": {
                         "method": {
                           "element": "string",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 10
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 5
-                                            }
-                                          },
-                                          "content": 207
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 10
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 8
-                                            }
-                                          },
-                                          "content": 3
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "GET"
                         }
                       }
@@ -552,51 +147,6 @@
                         },
                         {
                           "element": "copy",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 14
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 24
-                                            }
-                                          },
-                                          "content": 296
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 14
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 45
-                                            }
-                                          },
-                                          "content": 21
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "A paged array of pets"
                         }
                       ]

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
@@ -15,102 +15,12 @@
         },
         "title": {
           "element": "string",
-          "attributes": {
-            "sourceMap": {
-              "element": "array",
-              "content": [
-                {
-                  "element": "sourceMap",
-                  "content": [
-                    {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 4
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 10
-                            }
-                          },
-                          "content": 49
-                        },
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 4
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 26
-                            }
-                          },
-                          "content": 16
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          },
           "content": "Swagger Petstore"
         }
       },
       "attributes": {
         "version": {
           "element": "string",
-          "attributes": {
-            "sourceMap": {
-              "element": "array",
-              "content": [
-                {
-                  "element": "sourceMap",
-                  "content": [
-                    {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 3
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 12
-                            }
-                          },
-                          "content": 34
-                        },
-                        {
-                          "element": "number",
-                          "attributes": {
-                            "line": {
-                              "element": "number",
-                              "content": 3
-                            },
-                            "column": {
-                              "element": "number",
-                              "content": 17
-                            }
-                          },
-                          "content": 5
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          },
           "content": "1.0.0"
         }
       },
@@ -120,51 +30,6 @@
           "attributes": {
             "href": {
               "element": "string",
-              "attributes": {
-                "sourceMap": {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "sourceMap",
-                      "content": [
-                        {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "number",
-                              "attributes": {
-                                "line": {
-                                  "element": "number",
-                                  "content": 10
-                                },
-                                "column": {
-                                  "element": "number",
-                                  "content": 3
-                                }
-                              },
-                              "content": 148
-                            },
-                            {
-                              "element": "number",
-                              "attributes": {
-                                "line": {
-                                  "element": "number",
-                                  "content": 10
-                                },
-                                "column": {
-                                  "element": "number",
-                                  "content": 8
-                                }
-                              },
-                              "content": 5
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
               "content": "/pets"
             }
           },
@@ -174,100 +39,10 @@
               "meta": {
                 "title": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 12
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 16
-                                    }
-                                  },
-                                  "content": 179
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 12
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 29
-                                    }
-                                  },
-                                  "content": 13
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "List all pets"
                 },
                 "id": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 13
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 20
-                                    }
-                                  },
-                                  "content": 212
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 13
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 28
-                                    }
-                                  },
-                                  "content": 8
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "listPets"
                 }
               },
@@ -280,51 +55,6 @@
                       "attributes": {
                         "method": {
                           "element": "string",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 11
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 5
-                                            }
-                                          },
-                                          "content": 159
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 11
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 8
-                                            }
-                                          },
-                                          "content": 3
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "GET"
                         }
                       }
@@ -364,51 +94,6 @@
                         },
                         {
                           "element": "copy",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 26
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 24
-                                            }
-                                          },
-                                          "content": 529
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 26
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 45
-                                            }
-                                          },
-                                          "content": 21
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "A paged array of pets"
                         }
                       ]
@@ -422,100 +107,10 @@
               "meta": {
                 "title": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 43
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 16
-                                    }
-                                  },
-                                  "content": 1034
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 43
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 28
-                                    }
-                                  },
-                                  "content": 12
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "Create a pet"
                 },
                 "id": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 44
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 20
-                                    }
-                                  },
-                                  "content": 1066
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 44
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 30
-                                    }
-                                  },
-                                  "content": 10
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "createPets"
                 }
               },
@@ -528,51 +123,6 @@
                       "attributes": {
                         "method": {
                           "element": "string",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 42
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 5
-                                            }
-                                          },
-                                          "content": 1013
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 42
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 9
-                                            }
-                                          },
-                                          "content": 4
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "POST"
                         }
                       }
@@ -588,51 +138,6 @@
                       "content": [
                         {
                           "element": "copy",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 49
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 24
-                                            }
-                                          },
-                                          "content": 1159
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 49
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 37
-                                            }
-                                          },
-                                          "content": 13
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "Null response"
                         }
                       ]
@@ -648,51 +153,6 @@
           "attributes": {
             "href": {
               "element": "string",
-              "attributes": {
-                "sourceMap": {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "sourceMap",
-                      "content": [
-                        {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "number",
-                              "attributes": {
-                                "line": {
-                                  "element": "number",
-                                  "content": 56
-                                },
-                                "column": {
-                                  "element": "number",
-                                  "content": 3
-                                }
-                              },
-                              "content": 1354
-                            },
-                            {
-                              "element": "number",
-                              "attributes": {
-                                "line": {
-                                  "element": "number",
-                                  "content": 56
-                                },
-                                "column": {
-                                  "element": "number",
-                                  "content": 16
-                                }
-                              },
-                              "content": 13
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              },
               "content": "/pets/{petId}"
             },
             "hrefVariables": {
@@ -703,51 +163,6 @@
                   "meta": {
                     "description": {
                       "element": "string",
-                      "attributes": {
-                        "sourceMap": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "sourceMap",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "content": [
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 61
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 22
-                                        }
-                                      },
-                                      "content": 1466
-                                    },
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 61
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 51
-                                        }
-                                      },
-                                      "content": 29
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "content": "The id of the pet to retrieve"
                     }
                   },
@@ -765,51 +180,6 @@
                   "content": {
                     "key": {
                       "element": "string",
-                      "attributes": {
-                        "sourceMap": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "sourceMap",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "content": [
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 58
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 15
-                                        }
-                                      },
-                                      "content": 1399
-                                    },
-                                    {
-                                      "element": "number",
-                                      "attributes": {
-                                        "line": {
-                                          "element": "number",
-                                          "content": 58
-                                        },
-                                        "column": {
-                                          "element": "number",
-                                          "content": 20
-                                        }
-                                      },
-                                      "content": 5
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "content": "petId"
                     }
                   }
@@ -823,100 +193,10 @@
               "meta": {
                 "title": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 65
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 16
-                                    }
-                                  },
-                                  "content": 1559
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 65
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 39
-                                    }
-                                  },
-                                  "content": 23
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "Info for a specific pet"
                 },
                 "id": {
                   "element": "string",
-                  "attributes": {
-                    "sourceMap": {
-                      "element": "array",
-                      "content": [
-                        {
-                          "element": "sourceMap",
-                          "content": [
-                            {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 66
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 20
-                                    }
-                                  },
-                                  "content": 1602
-                                },
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "line": {
-                                      "element": "number",
-                                      "content": 66
-                                    },
-                                    "column": {
-                                      "element": "number",
-                                      "content": 31
-                                    }
-                                  },
-                                  "content": 11
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
                   "content": "showPetById"
                 }
               },
@@ -929,51 +209,6 @@
                       "attributes": {
                         "method": {
                           "element": "string",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 64
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 5
-                                            }
-                                          },
-                                          "content": 1539
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 64
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 8
-                                            }
-                                          },
-                                          "content": 3
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "GET"
                         }
                       }
@@ -1013,51 +248,6 @@
                         },
                         {
                           "element": "copy",
-                          "attributes": {
-                            "sourceMap": {
-                              "element": "array",
-                              "content": [
-                                {
-                                  "element": "sourceMap",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "content": [
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 71
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 24
-                                            }
-                                          },
-                                          "content": 1696
-                                        },
-                                        {
-                                          "element": "number",
-                                          "attributes": {
-                                            "line": {
-                                              "element": "number",
-                                              "content": 71
-                                            },
-                                            "column": {
-                                              "element": "number",
-                                              "content": 60
-                                            }
-                                          },
-                                          "content": 36
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
                           "content": "Expected response to a valid request"
                         }
                       ]
@@ -1089,51 +279,6 @@
                 "meta": {
                   "id": {
                     "element": "string",
-                    "attributes": {
-                      "sourceMap": {
-                        "element": "array",
-                        "content": [
-                          {
-                            "element": "sourceMap",
-                            "content": [
-                              {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "number",
-                                    "attributes": {
-                                      "line": {
-                                        "element": "number",
-                                        "content": 84
-                                      },
-                                      "column": {
-                                        "element": "number",
-                                        "content": 5
-                                      }
-                                    },
-                                    "content": 2060
-                                  },
-                                  {
-                                    "element": "number",
-                                    "attributes": {
-                                      "line": {
-                                        "element": "number",
-                                        "content": 84
-                                      },
-                                      "column": {
-                                        "element": "number",
-                                        "content": 8
-                                      }
-                                    },
-                                    "content": 3
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
                     "content": "Pet"
                   }
                 }
@@ -1146,51 +291,6 @@
                 "meta": {
                   "id": {
                     "element": "string",
-                    "attributes": {
-                      "sourceMap": {
-                        "element": "array",
-                        "content": [
-                          {
-                            "element": "sourceMap",
-                            "content": [
-                              {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "number",
-                                    "attributes": {
-                                      "line": {
-                                        "element": "number",
-                                        "content": 97
-                                      },
-                                      "column": {
-                                        "element": "number",
-                                        "content": 5
-                                      }
-                                    },
-                                    "content": 2283
-                                  },
-                                  {
-                                    "element": "number",
-                                    "attributes": {
-                                      "line": {
-                                        "element": "number",
-                                        "content": 97
-                                      },
-                                      "column": {
-                                        "element": "number",
-                                        "content": 9
-                                      }
-                                    },
-                                    "content": 4
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
                     "content": "Pets"
                   }
                 }
@@ -1203,51 +303,6 @@
                 "meta": {
                   "id": {
                     "element": "string",
-                    "attributes": {
-                      "sourceMap": {
-                        "element": "array",
-                        "content": [
-                          {
-                            "element": "sourceMap",
-                            "content": [
-                              {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "number",
-                                    "attributes": {
-                                      "line": {
-                                        "element": "number",
-                                        "content": 101
-                                      },
-                                      "column": {
-                                        "element": "number",
-                                        "content": 5
-                                      }
-                                    },
-                                    "content": 2365
-                                  },
-                                  {
-                                    "element": "number",
-                                    "attributes": {
-                                      "line": {
-                                        "element": "number",
-                                        "content": 101
-                                      },
-                                      "column": {
-                                        "element": "number",
-                                        "content": 10
-                                      }
-                                    },
-                                    "content": 5
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
                     "content": "Error"
                   }
                 }

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -1,0 +1,2089 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "attributes": {
+            "sourceMap": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "sourceMap",
+                  "content": [
+                    {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "number",
+                          "attributes": {
+                            "line": {
+                              "element": "number",
+                              "content": 4
+                            },
+                            "column": {
+                              "element": "number",
+                              "content": 10
+                            }
+                          },
+                          "content": 49
+                        },
+                        {
+                          "element": "number",
+                          "attributes": {
+                            "line": {
+                              "element": "number",
+                              "content": 4
+                            },
+                            "column": {
+                              "element": "number",
+                              "content": 26
+                            }
+                          },
+                          "content": 16
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "content": "Swagger Petstore"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "attributes": {
+            "sourceMap": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "sourceMap",
+                  "content": [
+                    {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "number",
+                          "attributes": {
+                            "line": {
+                              "element": "number",
+                              "content": 3
+                            },
+                            "column": {
+                              "element": "number",
+                              "content": 12
+                            }
+                          },
+                          "content": 34
+                        },
+                        {
+                          "element": "number",
+                          "attributes": {
+                            "line": {
+                              "element": "number",
+                              "content": 3
+                            },
+                            "column": {
+                              "element": "number",
+                              "content": 17
+                            }
+                          },
+                          "content": 5
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "attributes": {
+                "sourceMap": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "sourceMap",
+                      "content": [
+                        {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "number",
+                              "attributes": {
+                                "line": {
+                                  "element": "number",
+                                  "content": 10
+                                },
+                                "column": {
+                                  "element": "number",
+                                  "content": 3
+                                }
+                              },
+                              "content": 148
+                            },
+                            {
+                              "element": "number",
+                              "attributes": {
+                                "line": {
+                                  "element": "number",
+                                  "content": 10
+                                },
+                                "column": {
+                                  "element": "number",
+                                  "content": 8
+                                }
+                              },
+                              "content": 5
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "content": "/pets"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "sourceMap",
+                          "content": [
+                            {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 12
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 16
+                                    }
+                                  },
+                                  "content": 179
+                                },
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 12
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 29
+                                    }
+                                  },
+                                  "content": 13
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "content": "List all pets"
+                },
+                "id": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "sourceMap",
+                          "content": [
+                            {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 13
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 20
+                                    }
+                                  },
+                                  "content": 212
+                                },
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 13
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 28
+                                    }
+                                  },
+                                  "content": 8
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "content": "listPets"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 11
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 5
+                                            }
+                                          },
+                                          "content": 159
+                                        },
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 11
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 8
+                                            }
+                                          },
+                                          "content": 3
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Pets"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 26
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 24
+                                            }
+                                          },
+                                          "content": 529
+                                        },
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 26
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 45
+                                            }
+                                          },
+                                          "content": 21
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "A paged array of pets"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "sourceMap",
+                          "content": [
+                            {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 43
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 16
+                                    }
+                                  },
+                                  "content": 1034
+                                },
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 43
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 28
+                                    }
+                                  },
+                                  "content": 12
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "content": "Create a pet"
+                },
+                "id": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "sourceMap",
+                          "content": [
+                            {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 44
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 20
+                                    }
+                                  },
+                                  "content": 1066
+                                },
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 44
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 30
+                                    }
+                                  },
+                                  "content": 10
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "content": "createPets"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 42
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 5
+                                            }
+                                          },
+                                          "content": 1013
+                                        },
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 42
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 9
+                                            }
+                                          },
+                                          "content": 4
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "POST"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "201"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 49
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 24
+                                            }
+                                          },
+                                          "content": 1159
+                                        },
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 49
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 37
+                                            }
+                                          },
+                                          "content": 13
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "Null response"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "attributes": {
+                "sourceMap": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "sourceMap",
+                      "content": [
+                        {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "number",
+                              "attributes": {
+                                "line": {
+                                  "element": "number",
+                                  "content": 56
+                                },
+                                "column": {
+                                  "element": "number",
+                                  "content": 3
+                                }
+                              },
+                              "content": 1354
+                            },
+                            {
+                              "element": "number",
+                              "attributes": {
+                                "line": {
+                                  "element": "number",
+                                  "content": 56
+                                },
+                                "column": {
+                                  "element": "number",
+                                  "content": 16
+                                }
+                              },
+                              "content": 13
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "content": "/pets/{petId}"
+            },
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": {
+                      "element": "string",
+                      "attributes": {
+                        "sourceMap": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "sourceMap",
+                              "content": [
+                                {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "number",
+                                      "attributes": {
+                                        "line": {
+                                          "element": "number",
+                                          "content": 61
+                                        },
+                                        "column": {
+                                          "element": "number",
+                                          "content": 22
+                                        }
+                                      },
+                                      "content": 1466
+                                    },
+                                    {
+                                      "element": "number",
+                                      "attributes": {
+                                        "line": {
+                                          "element": "number",
+                                          "content": 61
+                                        },
+                                        "column": {
+                                          "element": "number",
+                                          "content": 51
+                                        }
+                                      },
+                                      "content": 29
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "content": "The id of the pet to retrieve"
+                    }
+                  },
+                  "attributes": {
+                    "typeAttributes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "required"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "attributes": {
+                        "sourceMap": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "sourceMap",
+                              "content": [
+                                {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "number",
+                                      "attributes": {
+                                        "line": {
+                                          "element": "number",
+                                          "content": 58
+                                        },
+                                        "column": {
+                                          "element": "number",
+                                          "content": 15
+                                        }
+                                      },
+                                      "content": 1399
+                                    },
+                                    {
+                                      "element": "number",
+                                      "attributes": {
+                                        "line": {
+                                          "element": "number",
+                                          "content": 58
+                                        },
+                                        "column": {
+                                          "element": "number",
+                                          "content": 20
+                                        }
+                                      },
+                                      "content": 5
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "content": "petId"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "sourceMap",
+                          "content": [
+                            {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 65
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 16
+                                    }
+                                  },
+                                  "content": 1559
+                                },
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 65
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 39
+                                    }
+                                  },
+                                  "content": 23
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "content": "Info for a specific pet"
+                },
+                "id": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "sourceMap",
+                          "content": [
+                            {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 66
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 20
+                                    }
+                                  },
+                                  "content": 1602
+                                },
+                                {
+                                  "element": "number",
+                                  "attributes": {
+                                    "line": {
+                                      "element": "number",
+                                      "content": 66
+                                    },
+                                    "column": {
+                                      "element": "number",
+                                      "content": 31
+                                    }
+                                  },
+                                  "content": 11
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "content": "showPetById"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 64
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 5
+                                            }
+                                          },
+                                          "content": 1539
+                                        },
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 64
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 8
+                                            }
+                                          },
+                                          "content": 3
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Pets"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 71
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 24
+                                            }
+                                          },
+                                          "content": 1696
+                                        },
+                                        {
+                                          "element": "number",
+                                          "attributes": {
+                                            "line": {
+                                              "element": "number",
+                                              "content": 71
+                                            },
+                                            "column": {
+                                              "element": "number",
+                                              "content": 60
+                                            }
+                                          },
+                                          "content": 36
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "Expected response to a valid request"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "attributes": {
+                      "sourceMap": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "sourceMap",
+                            "content": [
+                              {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "number",
+                                    "attributes": {
+                                      "line": {
+                                        "element": "number",
+                                        "content": 84
+                                      },
+                                      "column": {
+                                        "element": "number",
+                                        "content": 5
+                                      }
+                                    },
+                                    "content": 2060
+                                  },
+                                  {
+                                    "element": "number",
+                                    "attributes": {
+                                      "line": {
+                                        "element": "number",
+                                        "content": 84
+                                      },
+                                      "column": {
+                                        "element": "number",
+                                        "content": 8
+                                      }
+                                    },
+                                    "content": 3
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "content": "Pet"
+                  }
+                }
+              }
+            },
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "array",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "attributes": {
+                      "sourceMap": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "sourceMap",
+                            "content": [
+                              {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "number",
+                                    "attributes": {
+                                      "line": {
+                                        "element": "number",
+                                        "content": 97
+                                      },
+                                      "column": {
+                                        "element": "number",
+                                        "content": 5
+                                      }
+                                    },
+                                    "content": 2283
+                                  },
+                                  {
+                                    "element": "number",
+                                    "attributes": {
+                                      "line": {
+                                        "element": "number",
+                                        "content": 97
+                                      },
+                                      "column": {
+                                        "element": "number",
+                                        "content": 9
+                                      }
+                                    },
+                                    "content": 4
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "content": "Pets"
+                  }
+                }
+              }
+            },
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "attributes": {
+                      "sourceMap": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "sourceMap",
+                            "content": [
+                              {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "number",
+                                    "attributes": {
+                                      "line": {
+                                        "element": "number",
+                                        "content": 101
+                                      },
+                                      "column": {
+                                        "element": "number",
+                                        "content": 5
+                                      }
+                                    },
+                                    "content": 2365
+                                  },
+                                  {
+                                    "element": "number",
+                                    "attributes": {
+                                      "line": {
+                                        "element": "number",
+                                        "content": 101
+                                      },
+                                      "column": {
+                                        "element": "number",
+                                        "content": 10
+                                      }
+                                    },
+                                    "content": 5
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "content": "Error"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 3
+                        }
+                      },
+                      "content": 68
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 10
+                        }
+                      },
+                      "content": 7
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Info Object' contains unsupported key 'license'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 7
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 91
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 7
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 8
+                        }
+                      },
+                      "content": 7
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'OpenAPI Object' contains unsupported key 'servers'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 227
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 11
+                        }
+                      },
+                      "content": 4
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Operation Object' contains unsupported key 'tags'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 16
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 254
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 16
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 17
+                        }
+                      },
+                      "content": 10
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Operation Object' contains unsupported key 'parameters'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 27
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 11
+                        }
+                      },
+                      "content": 561
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 27
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 18
+                        }
+                      },
+                      "content": 7
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Response Object' contains unsupported key 'headers'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {},
+      "content": "'Response Object' default responses unsupported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 45
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 1083
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 45
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 11
+                        }
+                      },
+                      "content": 4
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Operation Object' contains unsupported key 'tags'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {},
+      "content": "'Response Object' default responses unsupported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 62
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
+                      "content": 1504
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 62
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 15
+                        }
+                      },
+                      "content": 6
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Parameter Object' contains invalid key 'schema'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 67
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 1620
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 67
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 11
+                        }
+                      },
+                      "content": 4
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Operation Object' contains unsupported key 'tags'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {},
+      "content": "'Response Object' default responses unsupported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 86
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 2090
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 86
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 15
+                        }
+                      },
+                      "content": 8
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Schema Object' contains unsupported key 'required'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 89
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 2134
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 89
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 17
+                        }
+                      },
+                      "content": 10
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Schema Object' contains unsupported key 'properties'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 99
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 2313
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 99
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 12
+                        }
+                      },
+                      "content": 5
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Schema Object' contains unsupported key 'items'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 103
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 2397
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 103
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 15
+                        }
+                      },
+                      "content": 8
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Schema Object' contains unsupported key 'required'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 106
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 2446
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 106
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 17
+                        }
+                      },
+                      "content": 10
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Schema Object' contains unsupported key 'properties'"
+    }
+  ]
+}

--- a/packages/fury-adapter-oas3-parser/test/integration/parse-test.js
+++ b/packages/fury-adapter-oas3-parser/test/integration/parse-test.js
@@ -6,4 +6,9 @@ describe('#parse', () => {
     const file = path.join(__dirname, 'fixtures', 'petstore');
     return testParseFixture(file);
   });
+
+  it('can parse petstore example generating source maps', () => {
+    const file = path.join(__dirname, 'fixtures', 'petstore');
+    return testParseFixture(file, true);
+  });
 });

--- a/packages/fury-adapter-oas3-parser/test/integration/testParseFixture.js
+++ b/packages/fury-adapter-oas3-parser/test/integration/testParseFixture.js
@@ -22,10 +22,10 @@ fury.use(adapter);
 const { minim: namespace } = fury;
 const parse = promisify(fury.parse.bind(fury));
 
-function testParseFixture(file) {
+function testParseFixture(file, generateSourceMap = false) {
   const source = fs.readFileSync(`${file}.yaml`, 'utf-8');
 
-  return parse({ source }).then((parseResult) => {
+  return parse({ source, generateSourceMap }).then((parseResult) => {
     expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
 
     // freeze elements to ensure there is no duplicate elements in tree,
@@ -34,7 +34,7 @@ function testParseFixture(file) {
 
     const result = JSON.stringify(namespace.serialiser.serialise(parseResult), null, 2);
 
-    const expectedPath = `${file}.json`;
+    const expectedPath = `${file + (generateSourceMap ? '.sourcemap' : '')}.json`;
 
     if (process.env.GENERATE) {
       fs.writeFileSync(expectedPath, result);


### PR DESCRIPTION
Filters out sourceMap attributes from non-annotation elements at the end of parsing.
Filtering at the end is suboptimal, but currently we are creating annotation source maps from their elements during parsing, so changing this might be a mess.