### PR TITLE
Prefer example values when generating body in OAS 2

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury Swagger Parser Changelog
 
+## 0.23.2 (2019-01-25)
+
+### Bug Fixes
+
+- Fix cases where example values in schema definitions are not used in request
+  or response bodies.
+
 ## 0.23.1 (2019-01-10)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
In some cases, it seems like the logic to compute intermediary “JSON Schema” (from Swagger Schema) is failing to copy some of the definitions over thus causing a ref to fail and expand to `null` causing failure to render body.

I've had these changes stashed locally for a while as I've been unable to write a test that can actually test this behaviour. without disclosing private API Description Documents from a user's report.