### PR TITLE
Refactor parseObject to handle required keys validations

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -12,6 +12,9 @@
   warning, previously using unsupported properties was emitting a warning that
   the properties were invalid.
 
+- The parser will no longer error out for unsupported parameter 'in' values,
+  instead an unsupported warning will be emitted.
+
 ## 0.4.0 (25-01-19)
 
 ### Enhancements

--- a/packages/fury-adapter-oas3-parser/lib/parser/annotations.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/annotations.js
@@ -1,5 +1,4 @@
 const R = require('ramda');
-const { isMember, isObject } = require('../predicates');
 
 function createAnnotation(annotationClass, namespace, message, element) {
   const annotation = new namespace.elements.Annotation(message);
@@ -41,30 +40,6 @@ function createMemberValueNotBooleanError(namespace, path, member) {
   return createError(namespace, `'${path}' '${member.key.toValue()}' is not a boolean`, member.value);
 }
 
-function validateObjectContainsRequiredKeys(namespace, path, requiredKeys, object) {
-  if (!isObject(object)) {
-    return new namespace.elements.ParseResult([object]);
-  }
-
-  // FIXME Can be simplified once https://github.com/refractproject/minim/issues/201 is completed
-  const hasMember = (key) => {
-    const findKey = R.allPass([isMember, member => member.key.toValue() === key]);
-    const matchingMembers = object.content.filter(findKey);
-    return matchingMembers.length > 0;
-  };
-
-  const missingKeys = R.reject(hasMember, requiredKeys);
-  const errorFromKey = key => createError(namespace, `'${path}' is missing required property '${key}'`, object);
-
-  if (missingKeys.length > 0) {
-    return new namespace.elements.ParseResult(
-      R.map(errorFromKey, missingKeys)
-    );
-  }
-
-  return new namespace.elements.ParseResult([object]);
-}
-
 module.exports = {
   createError,
   createWarning,
@@ -75,5 +50,4 @@ module.exports = {
   createMemberValueNotStringError: R.curry(createMemberValueNotStringError),
   createMemberValueNotBooleanWarning: R.curry(createMemberValueNotBooleanWarning),
   createMemberValueNotBooleanError: R.curry(createMemberValueNotBooleanError),
-  validateObjectContainsRequiredKeys: R.curry(validateObjectContainsRequiredKeys),
 };

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -67,7 +67,7 @@ function parseComponentsObject(context, element) {
     [R.T, createInvalidMemberWarning(namespace, name)],
   ]);
 
-  return parseObject(context, name, parseMember, element);
+  return parseObject(context, name, parseMember)(element);
 }
 
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseInfoObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseInfoObject.js
@@ -3,7 +3,6 @@ const { createError } = require('../../elements');
 const {
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
-  validateObjectContainsRequiredKeys,
 } = require('../annotations');
 const {
   isObject, hasKey, isExtension,
@@ -48,8 +47,7 @@ function parseInfo(context, info) {
 
   const parseInfo = pipeParseResult(namespace,
     R.unless(isObject, createError(namespace, `'${name}' is not an object`)),
-    validateObjectContainsRequiredKeys(namespace, name, requiredKeys),
-    parseObject(context, name, parseMember),
+    parseObject(context, name, parseMember, requiredKeys),
     (info) => {
       const api = new namespace.elements.Category();
       api.classes = ['api'];

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -8,7 +8,6 @@ const {
 const {
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
-  validateObjectContainsRequiredKeys,
 } = require('../annotations');
 const pipeParseResult = require('../../pipeParseResult');
 const parseObject = require('../parseObject');
@@ -104,8 +103,7 @@ function parseOASObject(context, object) {
   ]);
 
   const parseOASObject = pipeParseResult(namespace,
-    validateObjectContainsRequiredKeys(namespace, name, requiredKeys),
-    parseObject(context, name, parseMember),
+    parseObject(context, name, parseMember, requiredKeys),
     (object) => {
       const api = object.get('info');
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOperationObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOperationObject.js
@@ -3,7 +3,6 @@ const { isExtension, hasKey, getValue } = require('../../predicates');
 const {
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
-  validateObjectContainsRequiredKeys,
   createIdentifierNotUniqueWarning,
 } = require('../annotations');
 const parseCopy = require('../parseCopy');
@@ -96,8 +95,7 @@ function parseOperationObject(context, path, member) {
   ]);
 
   const parseOperation = pipeParseResult(namespace,
-    validateObjectContainsRequiredKeys(namespace, name, requiredKeys),
-    parseObject(context, name, parseMember),
+    parseObject(context, name, parseMember, requiredKeys),
     (operation) => {
       const transition = new namespace.elements.Transition();
       transition.title = operation.get('summary');

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
@@ -2,6 +2,7 @@ const R = require('ramda');
 const { isExtension, hasKey } = require('../../predicates');
 const {
   createError,
+  createWarning,
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
 } = require('../annotations');
@@ -46,9 +47,8 @@ function parseParameterObject(context, object) {
   const validateIn = R.unless(isValidInValue, createError(namespace,
     "'Parameter Object' 'in' must be either 'query, 'header', 'path' or 'cookie'"));
 
-  // FIXME: The following should not be an error
   const isSupportedIn = R.anyPass([hasValue('path'), hasValue('query')]);
-  const ensureSupportedIn = R.unless(isSupportedIn, createError(namespace,
+  const ensureSupportedIn = R.unless(isSupportedIn, createWarning(namespace,
     "Only 'in' values of 'path' and 'query' are supported at the moment"));
 
   const parseIn = pipeParseResult(namespace,

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
@@ -4,7 +4,6 @@ const {
   createError,
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
-  validateObjectContainsRequiredKeys,
 } = require('../annotations');
 const pipeParseResult = require('../../pipeParseResult');
 const parseObject = require('../parseObject');
@@ -80,8 +79,7 @@ function parseParameterObject(context, object) {
   ]);
 
   const parseParameter = pipeParseResult(namespace,
-    validateObjectContainsRequiredKeys(namespace, name, requiredKeys),
-    parseObject(context, name, parseMember),
+    parseObject(context, name, parseMember, requiredKeys),
     (parameter) => {
       const member = new namespace.elements.Member(parameter.get('name'));
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
@@ -3,7 +3,6 @@ const {
   createError,
   createWarning,
   createInvalidMemberWarning,
-  validateObjectContainsRequiredKeys,
 } = require('../annotations');
 const { isExtension, hasKey } = require('../../predicates');
 const pipeParseResult = require('../../pipeParseResult');
@@ -66,8 +65,7 @@ function parseReferenceObject(context, componentName, element) {
   ]);
 
   const parseReference = pipeParseResult(namespace,
-    validateObjectContainsRequiredKeys(namespace, name, requiredKeys),
-    parseObject(context, name, parseMember),
+    parseObject(context, name, parseMember, requiredKeys),
     object => object.get('$ref'),
     parseRef);
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponseObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponseObject.js
@@ -7,7 +7,6 @@ const {
   createWarning,
   createUnsupportedMemberWarning,
   createInvalidMemberWarning,
-  validateObjectContainsRequiredKeys,
 } = require('../annotations');
 const parseObject = require('../parseObject');
 const parseMediaTypeObject = require('./parseMediaTypeObject');
@@ -76,8 +75,7 @@ function parseResponseObject(context, element) {
   ]);
 
   const parseResponse = pipeParseResult(namespace,
-    validateObjectContainsRequiredKeys(namespace, name, requiredKeys),
-    parseObject(context, name, parseMember),
+    parseObject(context, name, parseMember, requiredKeys),
     (responseObject) => {
       // Try to fecth responses from the media type parsing
       // if not, create empty HttpResponse

--- a/packages/fury-adapter-oas3-parser/lib/parser/openapi.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/openapi.js
@@ -30,7 +30,7 @@ function parseOpenAPI(context, openapi) {
   }
 
 
-  return new namespace.elements.ParseResult([]);
+  return new namespace.elements.ParseResult([openapi]);
 }
 
 module.exports = R.curry(parseOpenAPI);

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -80,7 +80,7 @@ describe('Parameter Object', () => {
       const result = parse(context, parameter);
 
       expect(result.length).to.equal(1);
-      expect(result).to.contain.error("Only 'in' values of 'path' and 'query' are supported at the moment");
+      expect(result).to.contain.warning("Only 'in' values of 'path' and 'query' are supported at the moment");
     });
 
     it('provides an unsupported error for cookie parameters', () => {
@@ -92,7 +92,7 @@ describe('Parameter Object', () => {
       const result = parse(context, parameter);
 
       expect(result.length).to.equal(1);
-      expect(result).to.contain.error("Only 'in' values of 'path' and 'query' are supported at the moment");
+      expect(result).to.contain.warning("Only 'in' values of 'path' and 'query' are supported at the moment");
     });
   });
 

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/parseObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/parseObject-test.js
@@ -142,5 +142,29 @@ describe('#parseObject', () => {
         "'Example Object' is missing required property 'required2'",
       ]);
     });
+
+    it('fails object parsing when member parse cannot parse required key', () => {
+      const parseMember = (member) => {
+        const warning = new namespace.elements.Annotation(
+          `${member.key.toValue()} warning`,
+          { classes: ['warning'] }
+        );
+        return new namespace.elements.ParseResult([warning]);
+      };
+      const parseResult = parseObject(context, name, parseMember, ['name'])(object);
+
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.annotations.toValue()).to.deep.equal([
+        'name warning',
+        'message warning',
+      ]);
+    });
+
+    it('can parse object with required keys', () => {
+      const parseResult = parseObject(context, name, R.T, ['name'])(object);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);
+    });
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/parseObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/parseObject-test.js
@@ -1,3 +1,4 @@
+const R = require('ramda');
 const { Fury } = require('fury');
 const { expect } = require('../chai');
 const parseObject = require('../../../lib/parser/parseObject');
@@ -129,5 +130,17 @@ describe('#parseObject', () => {
 
     expect(parseResult.warnings.get(0).toValue()).to.equal('name warning');
     expect(parseResult.warnings.get(1).toValue()).to.equal('message warning');
+  });
+
+  describe('required keys', () => {
+    it('validates that the object contains any required keys', () => {
+      const parseResult = parseObject(context, name, R.T, ['name', 'required1', 'required2'])(object);
+
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.errors.toValue()).to.deep.equal([
+        "'Example Object' is missing required property 'required1'",
+        "'Example Object' is missing required property 'required2'",
+      ]);
+    });
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/parseObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/parseObject-test.js
@@ -23,14 +23,14 @@ describe('#parseObject', () => {
     const element = new namespace.elements.String();
 
     const parseMember = member => member;
-    const parseResult = parseObject(context, name, parseMember, element);
+    const parseResult = parseObject(context, name, parseMember)(element);
 
     expect(parseResult).to.contain.warning("'Example Object' is not an object");
   });
 
   it('can parse an object when the transform returns a member element', () => {
     const parseMember = member => member;
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(1);
     expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);
@@ -42,7 +42,7 @@ describe('#parseObject', () => {
 
   it('can parse an object when the transform returns a value to be wrapped in a member', () => {
     const parseMember = member => member.value;
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(1);
     expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);
@@ -54,7 +54,7 @@ describe('#parseObject', () => {
 
   it('can parse an object when the transform returns a parse result', () => {
     const parseMember = member => new namespace.elements.ParseResult([member]);
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(1);
     expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);
@@ -66,7 +66,7 @@ describe('#parseObject', () => {
 
   it('can parse an object when the transform returns a parse result containing a value to be wrapped in a member', () => {
     const parseMember = member => new namespace.elements.ParseResult([member.value]);
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(1);
     expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);
@@ -84,7 +84,7 @@ describe('#parseObject', () => {
       );
       return new namespace.elements.ParseResult([member, warning]);
     };
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(3);
     expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);
@@ -106,7 +106,7 @@ describe('#parseObject', () => {
       );
       return new namespace.elements.ParseResult([member, warning]);
     };
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(2);
     expect(parseResult.errors.get(0).toValue()).to.equal('name error');
@@ -121,7 +121,7 @@ describe('#parseObject', () => {
       );
       return new namespace.elements.ParseResult([warning]);
     };
-    const parseResult = parseObject(context, name, parseMember, object);
+    const parseResult = parseObject(context, name, parseMember)(object);
 
     expect(parseResult.length).to.equal(3);
     expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Object);


### PR DESCRIPTION
This PR makes `parseObject` responsible for validating required keys, and it can do it both before and "after" each member has been parsed. This means if a required property (required member) cannot be parsed it can return a warning and `parseObject` can fail parsing the entire object.

Here's an example:

```js
const requiredKeys = ['in'];
const parseMember = R.cond([
  ['in', parseIn],
  ['required', parseRequired],
]);
const parser = parseObject(context, 'Parameter Object', parseMember, requiredKeys);
```

Now, if the require property `in` is missing, parseObject will create a warning upfront and prevent continuing parsing the object. If there is an `in` property, but it is invalid, then the "in" parser (`parseIn`) can fail (not return an element, returning a warning etc) then `parseObject` will fail parsing the object and return out. This makes it much simpler for us to create warnings that exit out certain object parsers for required properties.

This PR also makes use of this functionality to make the parameter 'in' property cause a warning for unsupported values.

I though about making some kind of composable "required" middleware function, but I cannot see any use of making it separate at the moment. We could change this in the future though.