### PR TITLE
Don't emit errors for missing path parameters

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathItemObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathItemObject.js
@@ -35,44 +35,8 @@ function extractPathVariables(path) {
   return [];
 }
 
-function createErrorForMissingPathParameter(namespace, path, variable) {
-  // FIXME: This shouldn't be an error
-  const message = `Path '${path.toValue()}' contains variable '${variable}' which is not declared in the parameters section of the '${name}'`;
-  return createError(namespace, message, path);
-}
-
 function createErrorForMissingPathVariable(namespace, path, variable) {
   return createError(namespace, `Path '${path.toValue()}' is missing path variable '${variable}'. Add '{${variable}}' to the path`, path);
-}
-
-/**
- * Validates that there is a href variable for each path variable in the given path
- * @param namespace
- * @param path {StringElement}
- * @param pathItem {ObjectElement}
- * @retuns ParseResult<ObjectElement>
- */
-function validatePathForMissingHrefVariables(namespace, path, pathItem) {
-  const pathVariables = extractPathVariables(path.toValue());
-
-  const parameters = pathItem.get('parameters')
-    ? pathItem.get('parameters')
-    : new namespace.elements.Object();
-
-  const hrefVariables = parameters.get('path')
-    ? parameters.get('path')
-    : new namespace.elements.HrefVariables();
-
-  const missingParameters = hrefVariables
-    ? pathVariables.filter(name => !hrefVariables.getMember(name))
-    : pathVariables;
-
-  if (missingParameters.length > 0) {
-    const toError = R.curry(createErrorForMissingPathParameter)(namespace, path);
-    return new namespace.elements.ParseResult(missingParameters.map(toError));
-  }
-
-  return new namespace.elements.ParseResult([pathItem]);
 }
 
 /**
@@ -174,7 +138,6 @@ function parsePathItemObject(context, member) {
 
   const parsePathItem = pipeParseResult(namespace,
     parseObject(context, name, parseMember),
-    R.curry(validatePathForMissingHrefVariables)(namespace, member.key),
     (pathItem) => {
       const resource = new namespace.elements.Resource();
 

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parsePathItemObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parsePathItemObject-test.js
@@ -216,15 +216,6 @@ describe('#parsePathItemObject', () => {
         expect(result.length).to.equal(1);
         expect(result).to.contain.error("Path '/' is missing path variable 'resource'. Add '{resource}' to the path");
       });
-
-      it('errors when path variable not defined in parameters', () => {
-        const path = new namespace.elements.Member('/{resource}', {});
-
-        const result = parse(context, path);
-
-        expect(result.length).to.equal(1);
-        expect(result).to.contain.error("Path '/{resource}' contains variable 'resource' which is not declared in the parameters section of the 'Path Item Object'");
-      });
     });
 
     describe('query parameters', () => {


### PR DESCRIPTION
Since this error doesn't count for both path item and operation parameters it can produce false positives causing a document to be unparsable (as it incorrectly causes an error).

We should validate that the parameters contain all the path variables. For now I am going to remove the validation logic as it is currently doing more harm than good to OAS 3 user experiance. Upon merge I'll create an issue to track restoring this behaviour.