### PR TITLE
Don't expose error that reference param wasn't defined when it was

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Parameter names containing unreserved URI Template characters (`-`, `.`, `_`,
   and `~`) are now supported.
 
+- Referencing (`$ref`) a parameter that couldn't be parsed (due to the
+  parameter failing validation) will no longer cause a cryptic error that the
+  referenced object was not defined.
+
 ## 0.4.0 (25-01-19)
 
 ### Enhancements

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -16,6 +16,53 @@ const name = 'Components Object';
 const unsupportedKeys = ['responses', 'examples', 'requestBodies', 'headers', 'securitySchemes', 'links', 'callbacks'];
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 
+const valueIsObject = R.compose(isObject, getValue);
+
+/**
+ * Is the given parse result empty (i.e, contains no elements other than annotations)
+ *
+ * @param parseResult {ParseResult}
+ * @returns boolean
+ */
+const isParseResultEmpty = parseResult => R.reject(isAnnotation, parseResult).isEmpty;
+
+/**
+ * Parse a component member
+ *
+ * This function takes another parser that is capable of parsing the specific
+ * component type (schema parser, parameter parser etc) and parses a
+ * component using the given parser. It will return a parse result of member.
+ *
+ * In the cases that the given member cannot be parsed, it will result in
+ * returning a member element to represent the key without a value.
+ *
+ * @param context
+ * @param parser {function}
+ * @param member {Member} - Member element to represent the component,
+ *   member key contains the reusable component name, value represents
+ *   the reusable component
+ *
+ * @returns ParseResult
+ */
+const parseComponentMember = R.curry((context, parser, member) => {
+  // Create a Member Element with `member.key` as the key
+  const Member = R.constructN(2, context.namespace.elements.Member)(member.key);
+
+  const parseResult = pipeParseResult(context.namespace,
+    parser(context),
+    Member)(member.value);
+
+  if (isParseResultEmpty(parseResult)) {
+    // parse result does not contain a member, that's because parsing a
+    // component has failed. We want to store the member without value in
+    // this case so that we can correctly know if a component with the name
+    // existed during dereferencing.
+    parseResult.unshift(Member(undefined));
+  }
+
+  return parseResult;
+});
+
 /**
  * Parse Components Object
  *
@@ -28,45 +75,39 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 function parseComponentsObject(context, element) {
   const { namespace } = context;
 
-  const validateIsObject = key => R.unless(isObject,
-    createWarning(namespace, `'${name}' '${key}' is not an object`));
+  const createMemberValueNotObjectWarning = member => createWarning(namespace,
+    `'${name}' '${member.key.toValue()}' is not an object`, member.value);
+  const validateIsObject = R.unless(valueIsObject, createMemberValueNotObjectWarning);
 
-  const parseSchemaMember = member => pipeParseResult(namespace,
-    R.compose(parseSchemaObject(context), getValue),
-    (dataStructure) => {
-      // eslint-disable-next-line no-param-reassign
-      dataStructure.content.id = member.key.clone();
-      return dataStructure;
-    })(member);
+  /**
+   * Parses a member representing a component object (such as an object
+   * representing the parameter components)
+   *
+   * @param parser {function}
+   * @param member {Member}
+   *
+   * @returns ParseResult
+   */
+  const parseComponentObjectMember = (parser) => {
+    const parseMember = parseComponentMember(context, parser);
 
-  const parseSchemasObject = pipeParseResult(namespace,
-    validateIsObject('schemas'),
-    parseObject(context, name, parseSchemaMember));
-
-  const parseParametersObjectMember = (member) => {
-    // Create a Member Element with `member.key` as the key
-    const Member = R.constructN(2, namespace.elements.Member)(member.key);
-    const parseResult = parseParameterObject(context, member.value);
-    // Wrap non-annotation elements in member element
-    const result = R.map(R.unless(isAnnotation, Member), parseResult);
-
-    if (result.annotations.length === result.length) {
-      // failed to parse parameter, let's store a member without a value
-      // in parameters components section so dereferencing can know if the
-      // parameter existing under the key name
-      result.unshift(new namespace.elements.Member(member.key));
-    }
-
-    return result;
+    return pipeParseResult(context.namespace,
+      validateIsObject,
+      R.compose(parseObject(context, name, parseMember), getValue));
   };
 
-  const parseParametersObject = pipeParseResult(namespace,
-    validateIsObject('parameters'),
-    parseObject(context, name, parseParametersObjectMember));
+  // eslint-disable-next-line no-param-reassign
+  const setDataStructureId = (dataStructure, key) => { dataStructure.content.id = key.clone(); };
+  const parseSchemas = pipeParseResult(namespace,
+    parseComponentObjectMember(parseSchemaObject),
+    (object) => {
+      object.forEach(setDataStructureId);
+      return object;
+    });
 
   const parseMember = R.cond([
-    [hasKey('schemas'), R.compose(parseSchemasObject, getValue)],
-    [hasKey('parameters'), R.compose(parseParametersObject, getValue)],
+    [hasKey('schemas'), parseSchemas],
+    [hasKey('parameters'), parseComponentObjectMember(parseParameterObject)],
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],
 
     // FIXME Support exposing extensions into parse result

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -48,7 +48,16 @@ function parseComponentsObject(context, element) {
     const Member = R.constructN(2, namespace.elements.Member)(member.key);
     const parseResult = parseParameterObject(context, member.value);
     // Wrap non-annotation elements in member element
-    return R.map(R.unless(isAnnotation, Member), parseResult);
+    const result = R.map(R.unless(isAnnotation, Member), parseResult);
+
+    if (result.annotations.length === result.length) {
+      // failed to parse parameter, let's store a member without a value
+      // in parameters components section so dereferencing can know if the
+      // parameter existing under the key name
+      result.unshift(new namespace.elements.Member(member.key));
+    }
+
+    return result;
   };
 
   const parseParametersObject = pipeParseResult(namespace,

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
@@ -18,7 +18,9 @@ const requiredKeys = ['$ref'];
  * @param namespace {Namespace}
  * @param componentName {string}
  * @param element {Element}
- * @returns ParseResult
+ * @returns ParseResult - A parse result containing error if the referenced
+ * object was not found, the referenced element, or if the referenced
+ * element was not successfully parsed, an empty parse result.
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#referenceObject
  */
@@ -50,12 +52,16 @@ function parseReferenceObject(context, componentName, element) {
       return createError(namespace, `'#/components/${componentName}' is not defined`, ref);
     }
 
-    const element = component.get(referenceParts[3]);
+    const element = component.getMember(referenceParts[3]);
     if (!element) {
       return createError(namespace, `'${ref.toValue()}' is not defined`, ref);
     }
 
-    return element;
+    if (element.value) {
+      return element.value;
+    }
+
+    return new namespace.elements.ParseResult([]);
   };
 
   const parseMember = R.cond([

--- a/packages/fury-adapter-oas3-parser/test/integration/components-test.js
+++ b/packages/fury-adapter-oas3-parser/test/integration/components-test.js
@@ -8,4 +8,9 @@ describe('components', () => {
     const file = path.join(fixtures, 'path-item-object-parameters');
     return testParseFixture(file);
   });
+
+  it("'Path Item Object' parameter referencing unsupported parameter", () => {
+    const file = path.join(fixtures, 'path-item-object-parameters-unsupported-parameter');
+    return testParseFixture(file);
+  });
 });

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/path-item-object-parameters-unsupported-parameter.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/path-item-object-parameters-unsupported-parameter.json
@@ -1,0 +1,166 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Unsupported Parameter Components"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/pets"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "List all pets"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "array"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "content": "A paged array of pets"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 22
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 11
+                        }
+                      },
+                      "content": 455
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 22
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 17
+                        }
+                      },
+                      "content": 6
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Parameter Object' 'in' header is unsupported"
+    }
+  ]
+}

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/path-item-object-parameters-unsupported-parameter.yaml
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/path-item-object-parameters-unsupported-parameter.yaml
@@ -1,0 +1,22 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Unsupported Parameter Components
+paths:
+  /pets:
+    parameters:
+      - $ref: '#/components/parameters/authParam'
+    get:
+      summary: List all pets
+      responses:
+        '200':
+          description: A paged array of pets
+          content:
+            application/json:
+              schema:
+                type: array
+components:
+  parameters:
+    authParam:
+      name: Authorization
+      in: header

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -83,6 +83,32 @@ describe('Components Object', () => {
       expect(parameters.get('limitParam')).to.be.instanceof(namespace.elements.Member);
       expect(parameters.get('limitParam').key.toValue()).to.equal('limit');
     });
+
+    it('parses unsupported parameters', () => {
+      const components = new namespace.elements.Object({
+        parameters: {
+          limitParam: {
+            name: 'limit',
+            in: 'cookie',
+          },
+        },
+      });
+
+      const result = parse(context, components);
+
+      expect(result).to.contain.warning("'Parameter Object' 'in' cookie is unsupported");
+
+      const parsedComponents = result.get(0);
+      expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
+
+      const parameters = parsedComponents.get('parameters');
+      expect(parameters).to.be.instanceof(namespace.elements.Object);
+      expect(result.length).to.equal(2);
+
+      const parameter = parameters.getMember('limitParam');
+      expect(parameter).to.be.instanceof(namespace.elements.Member);
+      expect(parameter.value).to.be.undefined;
+    });
   });
 
   describe('warnings for unsupported properties', () => {

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseReferenceObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseReferenceObject-test.js
@@ -43,6 +43,21 @@ describe('Reference Object', () => {
     expect(structure).to.equal(dataStructure);
   });
 
+  it('can parse a reference to a component that could not be parsed', () => {
+    context.state.components = new namespace.elements.Object({
+      schemas: {
+        Node: undefined,
+      },
+    });
+
+    const reference = new namespace.elements.Object({
+      $ref: '#/components/schemas/Node',
+    });
+    const result = parse(context, 'schemas', reference);
+
+    expect(result.length).to.equal(0);
+  });
+
   describe('invalid references', () => {
     it('errors when parsing a non-components reference', () => {
       const reference = new namespace.elements.Object({


### PR DESCRIPTION
In some cases you can reference a parameter that couldn't be parsed (such as if it was an unsupported cookie parameter). This would cause the dereferencing to fail.