### PR TITLE
Release fury-adapter-oas3-parser 0.4.1

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.4.1 (28-01-19)
 
 ### Enhancements
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
### Enhancements

- Path and query parameters are not supported in 'Operation Object'

### Bug Fixes

- Unsupported properties in 'Parameter Object' will now emit an unsupported warning, previously using unsupported properties was emitting a warning that the properties were invalid.

- The parser will no longer error out for unsupported parameter 'in' values, instead an unsupported warning will be emitted.

- Parameter names containing unreserved URI Template characters (`-`, `.`, `_`, and `~`) are now supported.

- Referencing (`$ref`) a parameter that couldn't be parsed (due to the parameter failing validation) will no longer cause a cryptic error that the referenced object was not defined.