### PR TITLE
Release fury-adapter-oas3-parser 0.5.0

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.5.0 (30-01-19)
 
 ### Enhancements
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
### Enhancements

- Object properties in a Schema Object are now supported.
- Referencing (`$ref`) a response object is now supported.
- Array items in a Schema Object are now supported.
- Object required properties in a Schema Object are now supported.
- Request bodies and request body references are now supported in operations.

### Bug Fixes

- Fixed detection of YAML OpenAPI 3 documents where the OpenAPI version was not wrapped in quotes.