### PR TITLE
Rename result variable to parseResult

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/parseReference.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseReference.js
@@ -8,17 +8,17 @@ function isReferenceObject(element) {
 
 function parseReference(component, parser, context, element, isInsideSchema) {
   if (isReferenceObject(element)) {
-    const result = parseReferenceObject(context, component, element, component === 'schemas');
+    const parseResult = parseReferenceObject(context, component, element, component === 'schemas');
 
     // If we're referencing a schema object and we're not inside a schema
     // parser (subschema), then we want to wrap the object in a data structure element
     if (!isInsideSchema && component === 'schemas') {
       const DataStructure = R.constructN(1, context.namespace.elements.DataStructure);
       const wrapInDataStructure = R.unless(isAnnotation, DataStructure);
-      return R.map(wrapInDataStructure, result);
+      return R.map(wrapInDataStructure, parseResult);
     }
 
-    return result;
+    return parseResult;
   }
 
   return parser(context, element);

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -14,10 +14,10 @@ describe('Components Object', () => {
   it('provides a warning when components is non-object', () => {
     const components = new namespace.elements.String();
 
-    const result = parse(context, components);
+    const parseResult = parse(context, components);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Components Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Components Object' is not an object");
   });
 
   describe('#schemas', () => {
@@ -26,9 +26,9 @@ describe('Components Object', () => {
         schemas: '',
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' 'schemas' is not an object");
+      expect(parseResult).to.contain.warning("'Components Object' 'schemas' is not an object");
     });
 
     it('parses valid schemas into data structures', () => {
@@ -40,10 +40,10 @@ describe('Components Object', () => {
         },
       });
 
-      const result = parse(context, components);
-      expect(result.length).to.equal(1);
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(1);
 
-      const parsedComponents = result.get(0);
+      const parsedComponents = parseResult.get(0);
       expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
 
       const schemas = parsedComponents.get('schemas');
@@ -58,8 +58,8 @@ describe('Components Object', () => {
         parameters: '',
       });
 
-      const result = parse(context, components);
-      expect(result).to.contain.warning("'Components Object' 'parameters' is not an object");
+      const parseResult = parse(context, components);
+      expect(parseResult).to.contain.warning("'Components Object' 'parameters' is not an object");
     });
 
     it('parses valid parameters', () => {
@@ -72,10 +72,10 @@ describe('Components Object', () => {
         },
       });
 
-      const result = parse(context, components);
-      expect(result.length).to.equal(1);
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(1);
 
-      const parsedComponents = result.get(0);
+      const parsedComponents = parseResult.get(0);
       expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
 
       const parameters = parsedComponents.get('parameters');
@@ -94,16 +94,16 @@ describe('Components Object', () => {
         },
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Parameter Object' 'in' cookie is unsupported");
+      expect(parseResult).to.contain.warning("'Parameter Object' 'in' cookie is unsupported");
 
-      const parsedComponents = result.get(0);
+      const parsedComponents = parseResult.get(0);
       expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
 
       const parameters = parsedComponents.get('parameters');
       expect(parameters).to.be.instanceof(namespace.elements.Object);
-      expect(result.length).to.equal(2);
+      expect(parseResult.length).to.equal(2);
 
       const parameter = parameters.getMember('limitParam');
       expect(parameter).to.be.instanceof(namespace.elements.Member);
@@ -117,8 +117,8 @@ describe('Components Object', () => {
         responses: '',
       });
 
-      const result = parse(context, components);
-      expect(result).to.contain.warning("'Components Object' 'responses' is not an object");
+      const parseResult = parse(context, components);
+      expect(parseResult).to.contain.warning("'Components Object' 'responses' is not an object");
     });
 
     it('parses valid responses', () => {
@@ -134,10 +134,10 @@ describe('Components Object', () => {
         },
       });
 
-      const result = parse(context, components);
-      expect(result.length).to.equal(1);
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(1);
 
-      const parsedComponents = result.get(0);
+      const parsedComponents = parseResult.get(0);
       expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
 
       const responses = parsedComponents.get('responses');
@@ -162,8 +162,8 @@ describe('Components Object', () => {
         requestBodies: '',
       });
 
-      const result = parse(context, components);
-      expect(result).to.contain.warning("'Components Object' 'requestBodies' is not an object");
+      const parseResult = parse(context, components);
+      expect(parseResult).to.contain.warning("'Components Object' 'requestBodies' is not an object");
     });
 
     it('parses valid requestBodies', () => {
@@ -178,10 +178,10 @@ describe('Components Object', () => {
         },
       });
 
-      const result = parse(context, components);
-      expect(result.length).to.equal(1);
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(1);
 
-      const parsedComponents = result.get(0);
+      const parsedComponents = parseResult.get(0);
       expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
 
       const requests = parsedComponents.get('requestBodies');
@@ -208,9 +208,9 @@ describe('Components Object', () => {
         examples: {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' contains unsupported key 'examples'");
+      expect(parseResult).to.contain.warning("'Components Object' contains unsupported key 'examples'");
     });
 
     it('provides warning for unsupported headers key', () => {
@@ -218,9 +218,9 @@ describe('Components Object', () => {
         headers: {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' contains unsupported key 'headers'");
+      expect(parseResult).to.contain.warning("'Components Object' contains unsupported key 'headers'");
     });
 
     it('provides warning for unsupported securitySchemes key', () => {
@@ -228,9 +228,9 @@ describe('Components Object', () => {
         securitySchemes: {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' contains unsupported key 'securitySchemes'");
+      expect(parseResult).to.contain.warning("'Components Object' contains unsupported key 'securitySchemes'");
     });
 
     it('provides warning for unsupported links key', () => {
@@ -238,9 +238,9 @@ describe('Components Object', () => {
         links: {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' contains unsupported key 'links'");
+      expect(parseResult).to.contain.warning("'Components Object' contains unsupported key 'links'");
     });
 
     it('provides warning for unsupported callbacks key', () => {
@@ -248,9 +248,9 @@ describe('Components Object', () => {
         callbacks: {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' contains unsupported key 'callbacks'");
+      expect(parseResult).to.contain.warning("'Components Object' contains unsupported key 'callbacks'");
     });
 
     it('does not provide warning for Info Object extensions', () => {
@@ -258,9 +258,9 @@ describe('Components Object', () => {
         'x-extension': {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
     });
 
     it('provides warning for invalid keys', () => {
@@ -268,9 +268,9 @@ describe('Components Object', () => {
         invalid: {},
       });
 
-      const result = parse(context, components);
+      const parseResult = parse(context, components);
 
-      expect(result).to.contain.warning("'Components Object' contains invalid key 'invalid'");
+      expect(parseResult).to.contain.warning("'Components Object' contains invalid key 'invalid'");
     });
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseInfoObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseInfoObject-test.js
@@ -15,10 +15,10 @@ describe('#parseInfoObject', () => {
   it('provides error when info is non-object', () => {
     const info = new namespace.elements.String();
 
-    const result = parse(context, info);
+    const parseResult = parse(context, info);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.error("'Info Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.error("'Info Object' is not an object");
   });
 
   describe('missing required properties', () => {
@@ -27,10 +27,10 @@ describe('#parseInfoObject', () => {
         version: '1.0.0',
       });
 
-      const result = parse(context, info);
+      const parseResult = parse(context, info);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Info Object' is missing required property 'title'");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Info Object' is missing required property 'title'");
     });
 
     it('provides error for missing version', () => {
@@ -38,10 +38,10 @@ describe('#parseInfoObject', () => {
         title: 'My API',
       });
 
-      const result = parse(context, info);
+      const parseResult = parse(context, info);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Info Object' is missing required property 'version'");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Info Object' is missing required property 'version'");
     });
   });
 
@@ -52,10 +52,10 @@ describe('#parseInfoObject', () => {
         version: '1.0.0',
       });
 
-      const result = parse(context, info);
+      const parseResult = parse(context, info);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Info Object' 'title' is not a string");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Info Object' 'title' is not a string");
     });
 
     it('provides error when version is non-string', () => {
@@ -64,10 +64,10 @@ describe('#parseInfoObject', () => {
         version: 1,
       });
 
-      const result = parse(context, info);
+      const parseResult = parse(context, info);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Info Object' 'version' is not a string");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Info Object' 'version' is not a string");
     });
   });
 
@@ -79,8 +79,8 @@ describe('#parseInfoObject', () => {
         description: 1,
       });
 
-      const result = parse(context, info);
-      expect(result).to.contain.warning("'Info Object' 'description' is not a string");
+      const parseResult = parse(context, info);
+      expect(parseResult).to.contain.warning("'Info Object' 'description' is not a string");
     });
   });
 
@@ -92,10 +92,10 @@ describe('#parseInfoObject', () => {
         termsOfService: '',
       });
 
-      const result = parse(context, object);
+      const parseResult = parse(context, object);
 
-      expect(result.warnings.length).to.equal(1);
-      expect(result).to.contain.warning("'Info Object' contains unsupported key 'termsOfService'");
+      expect(parseResult.warnings.length).to.equal(1);
+      expect(parseResult).to.contain.warning("'Info Object' contains unsupported key 'termsOfService'");
     });
 
     it('provides warning for unsupported contact key', () => {
@@ -105,10 +105,10 @@ describe('#parseInfoObject', () => {
         contact: {},
       });
 
-      const result = parse(context, object);
+      const parseResult = parse(context, object);
 
-      expect(result.warnings.length).to.equal(1);
-      expect(result).to.contain.warning("'Info Object' contains unsupported key 'contact'");
+      expect(parseResult.warnings.length).to.equal(1);
+      expect(parseResult).to.contain.warning("'Info Object' contains unsupported key 'contact'");
     });
 
     it('provides warning for unsupported license key', () => {
@@ -118,9 +118,9 @@ describe('#parseInfoObject', () => {
         license: {},
       });
 
-      const result = parse(context, object);
+      const parseResult = parse(context, object);
 
-      expect(result).to.contain.warning("'Info Object' contains unsupported key 'license'");
+      expect(parseResult).to.contain.warning("'Info Object' contains unsupported key 'license'");
     });
 
     it('does not provide warning for Info Object extensions', () => {
@@ -130,9 +130,9 @@ describe('#parseInfoObject', () => {
         'x-extension': {},
       });
 
-      const result = parse(context, object);
+      const parseResult = parse(context, object);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
     });
 
     it('provides warning for invalid keys', () => {
@@ -142,9 +142,9 @@ describe('#parseInfoObject', () => {
         invalid: {},
       });
 
-      const result = parse(context, object);
+      const parseResult = parse(context, object);
 
-      expect(result).to.contain.warning("'Info Object' contains invalid key 'invalid'");
+      expect(parseResult).to.contain.warning("'Info Object' contains invalid key 'invalid'");
     });
   });
 
@@ -154,11 +154,11 @@ describe('#parseInfoObject', () => {
       version: '1.0.0',
     });
 
-    const result = parse(context, info);
-    expect(result.length).to.equal(1);
-    expect(result.api.classes.toValue()).to.deep.equal(['api']);
-    expect(result.api.title.toValue()).to.equal('My API');
-    expect(result.api.attributes.get('version').toValue()).to.equal('1.0.0');
+    const parseResult = parse(context, info);
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult.api.classes.toValue()).to.deep.equal(['api']);
+    expect(parseResult.api.title.toValue()).to.equal('My API');
+    expect(parseResult.api.attributes.get('version').toValue()).to.equal('1.0.0');
   });
 
   it('provides api category with description', () => {
@@ -168,8 +168,8 @@ describe('#parseInfoObject', () => {
       description: 'My API Description',
     });
 
-    const result = parse(context, info);
-    expect(result.length).to.equal(1);
-    expect(result.api.copy.toValue()).to.deep.equal(['My API Description']);
+    const parseResult = parse(context, info);
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult.api.copy.toValue()).to.deep.equal(['My API Description']);
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
@@ -16,17 +16,17 @@ describe('Media Type Object', () => {
   it('provides warning when media type is non-object', () => {
     const mediaType = new namespace.elements.Member('application/json', null);
 
-    const result = parse(context, messageBodyClass, mediaType);
+    const parseResult = parse(context, messageBodyClass, mediaType);
 
-    expect(result).to.contain.warning("'Media Type Object' is not an object");
+    expect(parseResult).to.contain.warning("'Media Type Object' is not an object");
   });
 
   it('returns a HTTP message body', () => {
     const mediaType = new namespace.elements.Member('application/json', {});
 
-    const result = parse(context, messageBodyClass, mediaType);
+    const parseResult = parse(context, messageBodyClass, mediaType);
 
-    const message = result.get(0);
+    const message = parseResult.get(0);
     expect(message).to.be.instanceof(messageBodyClass);
     expect(message.contentType.toValue()).to.equal('application/json');
   });
@@ -37,9 +37,9 @@ describe('Media Type Object', () => {
         examples: {},
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      expect(result).to.contain.warning("'Media Type Object' contains unsupported key 'examples'");
+      expect(parseResult).to.contain.warning("'Media Type Object' contains unsupported key 'examples'");
     });
 
     it('provides warning for unsupported encoding key', () => {
@@ -47,9 +47,9 @@ describe('Media Type Object', () => {
         encoding: {},
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      expect(result).to.contain.warning("'Media Type Object' contains unsupported key 'encoding'");
+      expect(parseResult).to.contain.warning("'Media Type Object' contains unsupported key 'encoding'");
     });
   });
 
@@ -61,9 +61,9 @@ describe('Media Type Object', () => {
         },
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      const message = result.get(0);
+      const message = parseResult.get(0);
       expect(message).to.be.instanceof(messageBodyClass);
       expect(message.messageBody.toValue()).to.equal('{"message":"Hello World"}');
       expect(message.messageBody.contentType.toValue()).to.equal('application/json');
@@ -76,9 +76,9 @@ describe('Media Type Object', () => {
         },
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      const message = result.get(0);
+      const message = parseResult.get(0);
       expect(message).to.be.instanceof(messageBodyClass);
       expect(message.messageBody.toValue()).to.equal('{"message":"Hello World"}');
       expect(message.messageBody.contentType.toValue()).to.equal('application/hal+json');
@@ -91,13 +91,13 @@ describe('Media Type Object', () => {
         },
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      const message = result.get(0);
+      const message = parseResult.get(0);
       expect(message).to.be.instanceof(messageBodyClass);
       expect(message.messageBody).to.be.undefined;
 
-      expect(result).to.contain.warning(
+      expect(parseResult).to.contain.warning(
         "'Media Type Object' 'example' is only supported for JSON media types"
       );
     });
@@ -111,9 +111,9 @@ describe('Media Type Object', () => {
         },
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      const message = result.get(0);
+      const message = parseResult.get(0);
       expect(message).to.be.instanceof(messageBodyClass);
       expect(message.dataStructure).to.be.instanceof(namespace.elements.DataStructure);
       expect(message.dataStructure.content).to.be.instanceof(namespace.elements.Object);
@@ -137,9 +137,9 @@ describe('Media Type Object', () => {
         },
       });
 
-      const result = parse(context, messageBodyClass, mediaType);
+      const parseResult = parse(context, messageBodyClass, mediaType);
 
-      const message = result.get(0);
+      const message = parseResult.get(0);
       expect(message).to.be.instanceof(messageBodyClass);
       expect(message.dataStructure).to.be.instanceof(namespace.elements.DataStructure);
       expect(message.dataStructure.content.element).to.equal('User');

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
@@ -22,9 +22,9 @@ describe('#parseOpenAPIObject', () => {
       paths: {},
     });
 
-    const result = parse(context, object);
-    expect(result.length).to.equal(1);
-    expect(result.api.title.toValue()).to.equal('My API');
+    const parseResult = parse(context, object);
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult.api.title.toValue()).to.equal('My API');
   });
 
   it('can parse a document with Path Item Objects', () => {
@@ -39,12 +39,12 @@ describe('#parseOpenAPIObject', () => {
       },
     });
 
-    const result = parse(context, object);
-    expect(result.length).to.equal(1);
-    expect(result.api.title.toValue()).to.equal('My API');
-    expect(result.api.length).to.equal(1);
-    expect(result.api.get(0)).to.be.instanceof(namespace.elements.Resource);
-    expect(result.api.get(0).href.toValue()).to.equal('/');
+    const parseResult = parse(context, object);
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult.api.title.toValue()).to.equal('My API');
+    expect(parseResult.api.length).to.equal(1);
+    expect(parseResult.api.get(0)).to.be.instanceof(namespace.elements.Resource);
+    expect(parseResult.api.get(0).href.toValue()).to.equal('/');
   });
 
   it('can parse a document with schema components into data structures', () => {
@@ -64,12 +64,12 @@ describe('#parseOpenAPIObject', () => {
       },
     });
 
-    const result = parse(context, object);
-    expect(result.length).to.equal(1);
-    expect(result.api.title.toValue()).to.equal('My API');
-    expect(result.api.length).to.equal(1);
+    const parseResult = parse(context, object);
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult.api.title.toValue()).to.equal('My API');
+    expect(parseResult.api.length).to.equal(1);
 
-    const dataStructures = result.api.get(0);
+    const dataStructures = parseResult.api.get(0);
     expect(dataStructures).to.be.instanceof(namespace.elements.Category);
     expect(dataStructures.classes.toValue()).to.deep.equal(['dataStructures']);
     expect(dataStructures.length).to.equal(1);
@@ -85,9 +85,9 @@ describe('#parseOpenAPIObject', () => {
       paths: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.error("'OpenAPI Object' is missing required property 'openapi'");
+    expect(parseResult).to.contain.error("'OpenAPI Object' is missing required property 'openapi'");
   });
 
   it('provides error for missing info', () => {
@@ -96,10 +96,10 @@ describe('#parseOpenAPIObject', () => {
       paths: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.error("'OpenAPI Object' is missing required property 'info'");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.error("'OpenAPI Object' is missing required property 'info'");
   });
 
   it('provides error for missing paths', () => {
@@ -108,9 +108,9 @@ describe('#parseOpenAPIObject', () => {
       info: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.error("'OpenAPI Object' is missing required property 'paths'");
+    expect(parseResult).to.contain.error("'OpenAPI Object' is missing required property 'paths'");
   });
 
   it('provides warning for unsupported keys', () => {
@@ -124,9 +124,9 @@ describe('#parseOpenAPIObject', () => {
       invalid: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.warning("'OpenAPI Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains invalid key 'invalid'");
   });
 
   it('provides warning for unsupported security key', () => {
@@ -140,9 +140,9 @@ describe('#parseOpenAPIObject', () => {
       security: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.warning("'OpenAPI Object' contains unsupported key 'security'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'security'");
   });
 
   it('provides warning for unsupported tags key', () => {
@@ -156,9 +156,9 @@ describe('#parseOpenAPIObject', () => {
       tags: [],
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.warning("'OpenAPI Object' contains unsupported key 'tags'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'tags'");
   });
 
   it('provides warning for unsupported externalDocs key', () => {
@@ -172,9 +172,9 @@ describe('#parseOpenAPIObject', () => {
       externalDocs: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.warning("'OpenAPI Object' contains unsupported key 'externalDocs'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'externalDocs'");
   });
 
   it('provides warning for unsupported servers key', () => {
@@ -188,9 +188,9 @@ describe('#parseOpenAPIObject', () => {
       servers: [],
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.warning("'OpenAPI Object' contains unsupported key 'servers'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'servers'");
   });
 
   it('provides warning for invalid keys', () => {
@@ -204,9 +204,9 @@ describe('#parseOpenAPIObject', () => {
       invalid: {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result).to.contain.warning("'OpenAPI Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains invalid key 'invalid'");
   });
 
   it("doesn't provide warning for OpenAPI Object extensions", () => {
@@ -217,8 +217,8 @@ describe('#parseOpenAPIObject', () => {
       'x-extension': {},
     });
 
-    const result = parse(context, object);
+    const parseResult = parse(context, object);
 
-    expect(result.warnings.isEmpty).to.be.true;
+    expect(parseResult.warnings.isEmpty).to.be.true;
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOperationObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOperationObject-test.js
@@ -18,10 +18,10 @@ describe('Operation Object', () => {
       responses: {},
     });
 
-    const result = parse(context, path, operation);
+    const parseResult = parse(context, path, operation);
 
-    expect(result.length).to.equal(1);
-    const transition = result.get(0);
+    expect(parseResult.length).to.equal(1);
+    const transition = parseResult.get(0);
     expect(transition).to.be.instanceof(namespace.elements.Transition);
   });
 
@@ -34,11 +34,11 @@ describe('Operation Object', () => {
       },
     });
 
-    const result = parse(context, path, operation);
+    const parseResult = parse(context, path, operation);
 
-    expect(result.length).to.equal(1);
+    expect(parseResult.length).to.equal(1);
 
-    const transition = result.get(0);
+    const transition = parseResult.get(0);
     expect(transition).to.be.instanceof(namespace.elements.Transition);
     expect(transition.length).to.equal(1);
 
@@ -54,10 +54,10 @@ describe('Operation Object', () => {
   it('provides warning when operation is non-object', () => {
     const operation = new namespace.elements.Member('get', null);
 
-    const result = parse(context, path, operation);
+    const parseResult = parse(context, path, operation);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Operation Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Operation Object' is not an object");
   });
 
   describe('warnings for unsupported properties', () => {
@@ -67,9 +67,9 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result).to.contain.warning("'Operation Object' contains unsupported key 'tags'");
+      expect(parseResult).to.contain.warning("'Operation Object' contains unsupported key 'tags'");
     });
 
     it('provides warning for unsupported externalDocs key', () => {
@@ -78,9 +78,9 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result).to.contain.warning("'Operation Object' contains unsupported key 'externalDocs'");
+      expect(parseResult).to.contain.warning("'Operation Object' contains unsupported key 'externalDocs'");
     });
 
     it('provides warning for unsupported callbacks key', () => {
@@ -89,9 +89,9 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result).to.contain.warning("'Operation Object' contains unsupported key 'callbacks'");
+      expect(parseResult).to.contain.warning("'Operation Object' contains unsupported key 'callbacks'");
     });
 
     it('provides warning for unsupported deprecated key', () => {
@@ -100,9 +100,9 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result).to.contain.warning("'Operation Object' contains unsupported key 'deprecated'");
+      expect(parseResult).to.contain.warning("'Operation Object' contains unsupported key 'deprecated'");
     });
 
     it('provides warning for unsupported security key', () => {
@@ -111,9 +111,9 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result).to.contain.warning("'Operation Object' contains unsupported key 'security'");
+      expect(parseResult).to.contain.warning("'Operation Object' contains unsupported key 'security'");
     });
 
     it('does not provide warning/errors for extensions', () => {
@@ -122,9 +122,9 @@ describe('Operation Object', () => {
         'x-extension': '',
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
     });
   });
 
@@ -134,19 +134,19 @@ describe('Operation Object', () => {
       invalid: '',
     });
 
-    const result = parse(context, path, operation);
+    const parseResult = parse(context, path, operation);
 
-    expect(result).to.contain.warning("'Operation Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'Operation Object' contains invalid key 'invalid'");
   });
 
   describe('missing required properties', () => {
     it('provides error for missing responses', () => {
       const operation = new namespace.elements.Member('get', {});
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Operation Object' is missing required property 'responses'");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Operation Object' is missing required property 'responses'");
     });
   });
 
@@ -158,12 +158,12 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-      expect(result).to.contain.warning("'Operation Object' 'summary' is not a string");
+      expect(parseResult).to.contain.warning("'Operation Object' 'summary' is not a string");
     });
 
     it('returns a transition with a summary', () => {
@@ -172,11 +172,11 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(1);
+      expect(parseResult.length).to.equal(1);
 
-      const transition = result.get(0);
+      const transition = parseResult.get(0);
       expect(transition).to.be.instanceof(namespace.elements.Transition);
       expect(transition.title.toValue()).to.equal('Example Summary');
     });
@@ -189,11 +189,11 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
-      expect(result.get(0).copy.toValue()).to.deep.equal(['This is a transition']);
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
+      expect(parseResult.get(0).copy.toValue()).to.deep.equal(['This is a transition']);
     });
 
     it('warns when description is not a string', () => {
@@ -202,12 +202,12 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-      expect(result).to.contain.warning("'Operation Object' 'description' is not a string");
+      expect(parseResult).to.contain.warning("'Operation Object' 'description' is not a string");
     });
   });
 
@@ -218,12 +218,12 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-      expect(result).to.contain.warning("'Operation Object' 'operationId' is not a string");
+      expect(parseResult).to.contain.warning("'Operation Object' 'operationId' is not a string");
     });
 
     it('returns a transition with an id', () => {
@@ -232,11 +232,11 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(1);
+      expect(parseResult.length).to.equal(1);
 
-      const transition = result.get(0);
+      const transition = parseResult.get(0);
       expect(transition).to.be.instanceof(namespace.elements.Transition);
       expect(transition.id.toValue()).to.equal('exampleId');
     });
@@ -252,21 +252,21 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const resultA = parse(context, path, operationA);
+      const parseResultA = parse(context, path, operationA);
 
       {
-        expect(resultA.length).to.equal(1);
-        const transition = resultA.get(0);
+        expect(parseResultA.length).to.equal(1);
+        const transition = parseResultA.get(0);
         expect(transition).to.be.instanceof(namespace.elements.Transition);
         expect(transition.id.toValue()).to.equal('exampleId');
       }
 
-      const resultB = parse(context, path, operationB);
+      const parseResultB = parse(context, path, operationB);
       {
-        expect(resultB.length).to.equal(2);
-        const transition = resultB.get(0);
+        expect(parseResultB.length).to.equal(2);
+        const transition = parseResultB.get(0);
         expect(transition).to.be.instanceof(namespace.elements.Transition);
-        expect(resultB).to.contain.warning("'Operation Object' 'operationId' is not a unique identifier: 'exampleId'");
+        expect(parseResultB).to.contain.warning("'Operation Object' 'operationId' is not a unique identifier: 'exampleId'");
       }
     });
   });
@@ -278,12 +278,12 @@ describe('Operation Object', () => {
         responses: {},
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-      expect(result).to.contain.warning("'Operation Object' 'parameters' is not an array");
+      expect(parseResult).to.contain.warning("'Operation Object' 'parameters' is not an array");
     });
 
     describe('path parameters', () => {
@@ -298,12 +298,12 @@ describe('Operation Object', () => {
           responses: {},
         });
 
-        const result = parse(context, path, operation);
+        const parseResult = parse(context, path, operation);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-        const transition = result.get(0);
+        const transition = parseResult.get(0);
         expect(transition.hrefVariables).to.be.instanceof(namespace.elements.HrefVariables);
         expect(transition.hrefVariables.length).to.equal(1);
         expect(transition.hrefVariables.getMember('resource')).to.be.instanceof(namespace.elements.Member);
@@ -322,12 +322,12 @@ describe('Operation Object', () => {
           responses: {},
         });
 
-        const result = parse(context, path, operation);
+        const parseResult = parse(context, path, operation);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-        const transition = result.get(0);
+        const transition = parseResult.get(0);
         expect(transition.href.toValue()).to.equal('/{?categories}');
       });
 
@@ -346,12 +346,12 @@ describe('Operation Object', () => {
           responses: {},
         });
 
-        const result = parse(context, path, operation);
+        const parseResult = parse(context, path, operation);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-        const transition = result.get(0);
+        const transition = parseResult.get(0);
         expect(transition.href.toValue()).to.equal('/{?categories,tags}');
       });
 
@@ -366,12 +366,12 @@ describe('Operation Object', () => {
           responses: {},
         });
 
-        const result = parse(context, path, operation);
+        const parseResult = parse(context, path, operation);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Transition);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Transition);
 
-        const transition = result.get(0);
+        const transition = parseResult.get(0);
         expect(transition.hrefVariables).to.be.instanceof(namespace.elements.HrefVariables);
         expect(transition.hrefVariables.length).to.equal(1);
         expect(transition.hrefVariables.getMember('resource')).to.be.instanceof(namespace.elements.Member);
@@ -393,11 +393,11 @@ describe('Operation Object', () => {
         },
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(1);
+      expect(parseResult.length).to.equal(1);
 
-      const transition = result.get(0);
+      const transition = parseResult.get(0);
       expect(transition).to.be.instanceof(namespace.elements.Transition);
       expect(transition.length).to.equal(2);
 
@@ -435,11 +435,11 @@ describe('Operation Object', () => {
         },
       });
 
-      const result = parse(context, path, operation);
+      const parseResult = parse(context, path, operation);
 
-      expect(result.length).to.equal(1);
+      expect(parseResult.length).to.equal(1);
 
-      const transition = result.get(0);
+      const transition = parseResult.get(0);
       expect(transition).to.be.instanceof(namespace.elements.Transition);
       expect(transition.length).to.equal(2);
 

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -14,10 +14,10 @@ describe('Parameter Object', () => {
   it('provides warning when parameter is non-object', () => {
     const operation = new namespace.elements.String();
 
-    const result = parse(context, operation);
+    const parseResult = parse(context, operation);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Parameter Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Parameter Object' is not an object");
   });
 
   describe('#name', () => {
@@ -27,10 +27,10 @@ describe('Parameter Object', () => {
         in: 'path',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Parameter Object' 'name' is not a string");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Parameter Object' 'name' is not a string");
     });
 
     it('provides an error when name contains unsupported characters', () => {
@@ -39,10 +39,10 @@ describe('Parameter Object', () => {
         in: 'path',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Parameter Object' 'name' contains unsupported characters. Only alphanumeric characters are currently supported");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Parameter Object' 'name' contains unsupported characters. Only alphanumeric characters are currently supported");
     });
 
     it('allows name to contain unreserved URI Template characters', () => {
@@ -56,11 +56,11 @@ describe('Parameter Object', () => {
         in: 'path',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Member);
-      expect(result.get(0).key.toValue()).to.equal(unreserved);
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).key.toValue()).to.equal(unreserved);
     });
   });
 
@@ -71,10 +71,10 @@ describe('Parameter Object', () => {
         in: 1,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Parameter Object' 'in' is not a string");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Parameter Object' 'in' is not a string");
     });
 
     it('provides an error when value is not a permitted value', () => {
@@ -83,10 +83,10 @@ describe('Parameter Object', () => {
         in: 'space',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.error("'Parameter Object' 'in' must be either 'query, 'header', 'path' or 'cookie'");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Parameter Object' 'in' must be either 'query, 'header', 'path' or 'cookie'");
     });
 
     it('provides an unsupported error for header parameters', () => {
@@ -95,10 +95,10 @@ describe('Parameter Object', () => {
         in: 'header',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.warning("'Parameter Object' 'in' header is unsupported");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.warning("'Parameter Object' 'in' header is unsupported");
     });
 
     it('provides an unsupported error for cookie parameters', () => {
@@ -107,10 +107,10 @@ describe('Parameter Object', () => {
         in: 'cookie',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.contain.warning("'Parameter Object' 'in' cookie is unsupported");
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.warning("'Parameter Object' 'in' cookie is unsupported");
     });
   });
 
@@ -122,12 +122,12 @@ describe('Parameter Object', () => {
         description: 'an example parameter',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.not.contain.annotations;
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Member);
-      expect(result.get(0).description.toValue()).to.equal(
+      expect(parseResult).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).description.toValue()).to.equal(
         'an example parameter'
       );
     });
@@ -139,9 +139,9 @@ describe('Parameter Object', () => {
         description: true,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' 'description' is not a string");
+      expect(parseResult).to.contain.warning("'Parameter Object' 'description' is not a string");
     });
   });
 
@@ -153,14 +153,14 @@ describe('Parameter Object', () => {
         required: true,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
 
-      expect(result.length).to.be.equal(1);
+      expect(parseResult.length).to.be.equal(1);
 
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Member);
-      const typeAttributes = result.get(0).attributes.get('typeAttributes');
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      const typeAttributes = parseResult.get(0).attributes.get('typeAttributes');
 
       expect(typeAttributes).to.be.instanceof(namespace.elements.Array);
       expect(typeAttributes.length).to.be.equal(1);
@@ -174,14 +174,14 @@ describe('Parameter Object', () => {
         required: false,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.warnings.length).to.be.equal(0);
+      expect(parseResult.warnings.length).to.be.equal(0);
 
-      expect(result.length).to.be.equal(1);
+      expect(parseResult.length).to.be.equal(1);
 
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Member);
-      expect(result.get(0).attributes.get('typeAttributes')).to.be.undefined;
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).attributes.get('typeAttributes')).to.be.undefined;
     });
 
     it('provide warning if required is not bool', () => {
@@ -191,13 +191,13 @@ describe('Parameter Object', () => {
         required: 1,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result.length).to.be.equal(2); // parameter && warning
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Member);
-      expect(result.get(0).attributes.get('typeAttributes')).to.be.undefined;
+      expect(parseResult.length).to.be.equal(2); // parameter && warning
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).attributes.get('typeAttributes')).to.be.undefined;
 
-      expect(result).to.contain.warning("'Parameter Object' 'required' is not a boolean");
+      expect(parseResult).to.contain.warning("'Parameter Object' 'required' is not a boolean");
     });
   });
 
@@ -209,9 +209,9 @@ describe('Parameter Object', () => {
         deprecated: true,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'deprecated'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'deprecated'");
     });
 
     it('provides warning for unsupported allowEmptyValue property', () => {
@@ -221,9 +221,9 @@ describe('Parameter Object', () => {
         allowEmptyValue: true,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'allowEmptyValue'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'allowEmptyValue'");
     });
 
     it('provides warning for unsupported style property', () => {
@@ -233,9 +233,9 @@ describe('Parameter Object', () => {
         style: 'simple',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'style'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'style'");
     });
 
     it('provides warning for unsupported explode property', () => {
@@ -245,9 +245,9 @@ describe('Parameter Object', () => {
         explode: true,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'explode'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'explode'");
     });
 
     it('provides warning for unsupported allowReserved property', () => {
@@ -257,9 +257,9 @@ describe('Parameter Object', () => {
         allowReserved: true,
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'allowReserved'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'allowReserved'");
     });
 
     it('provides warning for unsupported schema property', () => {
@@ -269,9 +269,9 @@ describe('Parameter Object', () => {
         schema: { type: 'string' },
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'schema'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'schema'");
     });
 
     it('provides warning for unsupported example property', () => {
@@ -281,9 +281,9 @@ describe('Parameter Object', () => {
         example: 'east',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'example'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'example'");
     });
 
     it('provides warning for unsupported examples property', () => {
@@ -293,9 +293,9 @@ describe('Parameter Object', () => {
         examples: {},
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'examples'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'examples'");
     });
 
     it('provides warning for unsupported content property', () => {
@@ -305,9 +305,9 @@ describe('Parameter Object', () => {
         content: {},
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.contain.warning("'Parameter Object' contains unsupported key 'content'");
+      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'content'");
     });
 
     it('does not provide warning/errors for extensions', () => {
@@ -317,9 +317,9 @@ describe('Parameter Object', () => {
         'x-extension': '',
       });
 
-      const result = parse(context, parameter);
+      const parseResult = parse(context, parameter);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
     });
   });
 
@@ -330,8 +330,8 @@ describe('Parameter Object', () => {
       invalid: '',
     });
 
-    const result = parse(context, parameter);
+    const parseResult = parse(context, parameter);
 
-    expect(result).to.contain.warning("'Parameter Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'Parameter Object' contains invalid key 'invalid'");
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObjects-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObjects-test.js
@@ -14,9 +14,9 @@ describe('Parameter Objects', () => {
   it('provides warning when parameter is non-array', () => {
     const parameters = new namespace.elements.String();
 
-    const result = parse(context, 'Operation Object', parameters);
+    const parseResult = parse(context, 'Operation Object', parameters);
 
-    expect(result).to.contain.warning("'Operation Object' 'parameters' is not an array");
+    expect(parseResult).to.contain.warning("'Operation Object' 'parameters' is not an array");
   });
 
   it('can parse parameters into groups', () => {
@@ -35,10 +35,10 @@ describe('Parameter Objects', () => {
       },
     ]);
 
-    const result = parse(context, 'Operation Object', parameters);
+    const parseResult = parse(context, 'Operation Object', parameters);
 
-    expect(result.length).to.equal(1);
-    const parametersElement = result.get(0);
+    expect(parseResult.length).to.equal(1);
+    const parametersElement = parseResult.get(0);
     expect(parametersElement).to.be.instanceof(namespace.elements.Object);
 
     const pathParameters = parametersElement.get('path');
@@ -67,10 +67,10 @@ describe('Parameter Objects', () => {
       parameters: { tags },
     });
 
-    const result = parse(context, 'Operation Object', parameters);
+    const parseResult = parse(context, 'Operation Object', parameters);
 
-    expect(result.length).to.equal(1);
-    const parametersElement = result.get(0);
+    expect(parseResult.length).to.equal(1);
+    const parametersElement = parseResult.get(0);
     expect(parametersElement).to.be.instanceof(namespace.elements.Object);
 
     const queryParameters = parametersElement.get('query');

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parsePathItemObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parsePathItemObject-test.js
@@ -14,11 +14,11 @@ describe('#parsePathItemObject', () => {
 
   it('parses a path into a resource', () => {
     const path = new namespace.elements.Member('/', {});
-    const result = parse(context, path);
+    const parseResult = parse(context, path);
 
-    expect(result.length).to.equal(1);
-    expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-    expect(result.get(0).href.toValue()).to.equal('/');
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+    expect(parseResult.get(0).href.toValue()).to.equal('/');
   });
 
   it('parses a path methods into a resource and transactions', () => {
@@ -31,11 +31,11 @@ describe('#parsePathItemObject', () => {
         },
       },
     });
-    const result = parse(context, path);
+    const parseResult = parse(context, path);
 
-    expect(result.length).to.equal(1);
+    expect(parseResult.length).to.equal(1);
 
-    const resource = result.get(0);
+    const resource = parseResult.get(0);
     expect(resource).to.be.instanceof(namespace.elements.Resource);
     expect(resource.href.toValue()).to.equal('/');
     expect(resource.length).to.equal(1);
@@ -47,10 +47,10 @@ describe('#parsePathItemObject', () => {
 
   it('provides a warning when the path item object is non-object', () => {
     const path = new namespace.elements.Member('/', null);
-    const result = parse(context, path);
+    const parseResult = parse(context, path);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Path Item Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Path Item Object' is not an object");
   });
 
   describe('warnings for keys', () => {
@@ -59,13 +59,13 @@ describe('#parsePathItemObject', () => {
         $ref: '',
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).href.toValue()).to.equal('/');
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).href.toValue()).to.equal('/');
 
-      expect(result).to.contain.warning("'Path Item Object' contains unsupported key '$ref'");
+      expect(parseResult).to.contain.warning("'Path Item Object' contains unsupported key '$ref'");
     });
 
     it('warns for a servers', () => {
@@ -73,13 +73,13 @@ describe('#parsePathItemObject', () => {
         servers: '',
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).href.toValue()).to.equal('/');
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).href.toValue()).to.equal('/');
 
-      expect(result).to.contain.warning("'Path Item Object' contains unsupported key 'servers'");
+      expect(parseResult).to.contain.warning("'Path Item Object' contains unsupported key 'servers'");
     });
 
     it('does not provide warning for Info Object extensions', () => {
@@ -87,10 +87,10 @@ describe('#parsePathItemObject', () => {
         'x-extension': '',
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
     });
 
     it('provides warning for invalid keys', () => {
@@ -98,13 +98,13 @@ describe('#parsePathItemObject', () => {
         invalid: '',
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).href.toValue()).to.equal('/');
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).href.toValue()).to.equal('/');
 
-      expect(result).to.contain.warning("'Path Item Object' contains invalid key 'invalid'");
+      expect(parseResult).to.contain.warning("'Path Item Object' contains invalid key 'invalid'");
     });
   });
 
@@ -114,13 +114,13 @@ describe('#parsePathItemObject', () => {
         summary: 1,
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).href.toValue()).to.equal('/');
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).href.toValue()).to.equal('/');
 
-      expect(result).to.contain.warning("'Path Item Object' 'summary' is not a string");
+      expect(parseResult).to.contain.warning("'Path Item Object' 'summary' is not a string");
     });
 
     it('exposes summary as the title of the resource', () => {
@@ -128,11 +128,11 @@ describe('#parsePathItemObject', () => {
         summary: 'Root',
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).title.toValue()).to.equal('Root');
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).title.toValue()).to.equal('Root');
     });
   });
 
@@ -142,11 +142,11 @@ describe('#parsePathItemObject', () => {
         description: 'This is a resource',
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).copy.toValue()).to.deep.equal(['This is a resource']);
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).copy.toValue()).to.deep.equal(['This is a resource']);
     });
 
     it('warns when description is not a string', () => {
@@ -154,13 +154,13 @@ describe('#parsePathItemObject', () => {
         description: 1,
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).length).to.equal(0);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).length).to.equal(0);
 
-      expect(result).to.contain.warning("'Path Item Object' 'description' is not a string");
+      expect(parseResult).to.contain.warning("'Path Item Object' 'description' is not a string");
     });
   });
 
@@ -170,13 +170,13 @@ describe('#parsePathItemObject', () => {
         parameters: {},
       });
 
-      const result = parse(context, path);
+      const parseResult = parse(context, path);
 
-      expect(result.length).to.equal(2);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-      expect(result.get(0).href.toValue()).to.equal('/');
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+      expect(parseResult.get(0).href.toValue()).to.equal('/');
 
-      expect(result).to.contain.warning("'Path Item Object' 'parameters' is not an array");
+      expect(parseResult).to.contain.warning("'Path Item Object' 'parameters' is not an array");
     });
 
     describe('path parameters', () => {
@@ -190,12 +190,12 @@ describe('#parsePathItemObject', () => {
           ],
         });
 
-        const result = parse(context, path);
+        const parseResult = parse(context, path);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
 
-        const resource = result.get(0);
+        const resource = parseResult.get(0);
         expect(resource.hrefVariables).to.be.instanceof(namespace.elements.HrefVariables);
         expect(resource.hrefVariables.length).to.equal(1);
         expect(resource.hrefVariables.getMember('resource')).to.be.instanceof(namespace.elements.Member);
@@ -211,10 +211,10 @@ describe('#parsePathItemObject', () => {
           ],
         });
 
-        const result = parse(context, path);
+        const parseResult = parse(context, path);
 
-        expect(result.length).to.equal(1);
-        expect(result).to.contain.error("Path '/' is missing path variable 'resource'. Add '{resource}' to the path");
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult).to.contain.error("Path '/' is missing path variable 'resource'. Add '{resource}' to the path");
       });
     });
 
@@ -229,12 +229,12 @@ describe('#parsePathItemObject', () => {
           ],
         });
 
-        const result = parse(context, path);
+        const parseResult = parse(context, path);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
 
-        const resource = result.get(0);
+        const resource = parseResult.get(0);
         expect(resource.href.toValue()).to.equal('/{?categories}');
       });
 
@@ -252,12 +252,12 @@ describe('#parsePathItemObject', () => {
           ],
         });
 
-        const result = parse(context, path);
+        const parseResult = parse(context, path);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
 
-        const resource = result.get(0);
+        const resource = parseResult.get(0);
         expect(resource.href.toValue()).to.equal('/{?categories,tags}');
       });
 
@@ -271,12 +271,12 @@ describe('#parsePathItemObject', () => {
           ],
         });
 
-        const result = parse(context, path);
+        const parseResult = parse(context, path);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
 
-        const resource = result.get(0);
+        const resource = parseResult.get(0);
         expect(resource.hrefVariables).to.be.instanceof(namespace.elements.HrefVariables);
         expect(resource.hrefVariables.length).to.equal(1);
         expect(resource.hrefVariables.getMember('resource')).to.be.instanceof(namespace.elements.Member);

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parsePathsObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parsePathsObject-test.js
@@ -15,17 +15,17 @@ describe('#parsePathsObject', () => {
   it('provides error when paths is non-object', () => {
     const paths = new namespace.elements.String();
 
-    const result = parse(context, paths);
+    const parseResult = parse(context, paths);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.error("'Paths Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.error("'Paths Object' is not an object");
   });
 
-  it('returns empty parse result when paths is empty', () => {
+  it('returns empty parse parseResult when paths is empty', () => {
     const paths = new namespace.elements.Object();
-    const result = parse(context, paths);
+    const parseResult = parse(context, paths);
 
-    expect(result.isEmpty).to.be.true;
+    expect(parseResult.isEmpty).to.be.true;
   });
 
   it('provides a warning when paths contains non-path field pattern', () => {
@@ -33,10 +33,10 @@ describe('#parsePathsObject', () => {
       test: {},
     });
 
-    const result = parse(context, paths);
+    const parseResult = parse(context, paths);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Paths Object' contains invalid key 'test'");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Paths Object' contains invalid key 'test'");
   });
 
   it('ignores extension objects', () => {
@@ -44,9 +44,9 @@ describe('#parsePathsObject', () => {
       'x-extension': {},
     });
 
-    const result = parse(context, paths);
+    const parseResult = parse(context, paths);
 
-    expect(result.isEmpty).to.be.true;
+    expect(parseResult.isEmpty).to.be.true;
   });
 
   it('parses multiple path items into resources in defined order', () => {
@@ -56,16 +56,16 @@ describe('#parsePathsObject', () => {
       '/2': new namespace.elements.Object(),
     });
 
-    const result = parse(context, paths);
+    const parseResult = parse(context, paths);
 
-    expect(result.length).to.equal(3);
-    expect(result.get(0)).to.be.instanceof(namespace.elements.Resource);
-    expect(result.get(0).href.toValue()).to.equal('/3');
+    expect(parseResult.length).to.equal(3);
+    expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Resource);
+    expect(parseResult.get(0).href.toValue()).to.equal('/3');
 
-    expect(result.get(1)).to.be.instanceof(namespace.elements.Resource);
-    expect(result.get(1).href.toValue()).to.equal('/1');
+    expect(parseResult.get(1)).to.be.instanceof(namespace.elements.Resource);
+    expect(parseResult.get(1).href.toValue()).to.equal('/1');
 
-    expect(result.get(2)).to.be.instanceof(namespace.elements.Resource);
-    expect(result.get(2).href.toValue()).to.equal('/2');
+    expect(parseResult.get(2)).to.be.instanceof(namespace.elements.Resource);
+    expect(parseResult.get(2).href.toValue()).to.equal('/2');
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseReferenceObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseReferenceObject-test.js
@@ -27,19 +27,19 @@ describe('Reference Object', () => {
     const reference = new namespace.elements.Object({
       $ref: true,
     });
-    const result = parse(context, 'schemas', reference);
+    const parseResult = parse(context, 'schemas', reference);
 
-    expect(result).to.contain.error("'Reference Object' '$ref' is not a string");
+    expect(parseResult).to.contain.error("'Reference Object' '$ref' is not a string");
   });
 
   it('can parse a reference', () => {
     const reference = new namespace.elements.Object({
       $ref: '#/components/schemas/Node',
     });
-    const result = parse(context, 'schemas', reference);
+    const parseResult = parse(context, 'schemas', reference);
 
-    expect(result.length).to.equal(1);
-    const structure = result.get(0);
+    expect(parseResult.length).to.equal(1);
+    const structure = parseResult.get(0);
     expect(structure).to.equal(dataStructure);
   });
 
@@ -53,11 +53,11 @@ describe('Reference Object', () => {
       $ref: '#/components/requestBodies/Example',
     });
 
-    const result = parse(context, 'requestBodies', reference);
+    const parseResult = parse(context, 'requestBodies', reference);
 
-    expect(result.length).to.equal(2);
-    expect(result.get(0)).to.be.instanceof(namespace.elements.HttpRequest);
-    expect(result.get(1)).to.be.instanceof(namespace.elements.HttpRequest);
+    expect(parseResult.length).to.equal(2);
+    expect(parseResult.get(0)).to.be.instanceof(namespace.elements.HttpRequest);
+    expect(parseResult.get(1)).to.be.instanceof(namespace.elements.HttpRequest);
   });
 
   it('can parse a reference to a component that could not be parsed', () => {
@@ -70,9 +70,9 @@ describe('Reference Object', () => {
     const reference = new namespace.elements.Object({
       $ref: '#/components/schemas/Node',
     });
-    const result = parse(context, 'schemas', reference);
+    const parseResult = parse(context, 'schemas', reference);
 
-    expect(result.length).to.equal(0);
+    expect(parseResult.length).to.equal(0);
   });
 
   describe('invalid references', () => {
@@ -80,45 +80,45 @@ describe('Reference Object', () => {
       const reference = new namespace.elements.Object({
         $ref: '#/info/title',
       });
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.error("Only local references to '#/components' within the same file are supported");
+      expect(parseResult).to.contain.error("Only local references to '#/components' within the same file are supported");
     });
 
     it('errors when parsing reference to a nonexistent component', () => {
       const reference = new namespace.elements.Object({
         $ref: '#/components/parameters/Node',
       });
-      const result = parse(context, 'parameters', reference);
+      const parseResult = parse(context, 'parameters', reference);
 
-      expect(result).to.contain.error("'#/components/parameters' is not defined");
+      expect(parseResult).to.contain.error("'#/components/parameters' is not defined");
     });
 
     it('errors when parsing reference to incorrect component name', () => {
       const reference = new namespace.elements.Object({
         $ref: '#/components/parameters/Node',
       });
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.error("Only references to 'schemas' are permitted from this location");
+      expect(parseResult).to.contain.error("Only references to 'schemas' are permitted from this location");
     });
 
     it('errors when parsing reference to nonexistent property in component', () => {
       const reference = new namespace.elements.Object({
         $ref: '#/components/schemas/BaseNode',
       });
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.error("'#/components/schemas/BaseNode' is not defined");
+      expect(parseResult).to.contain.error("'#/components/schemas/BaseNode' is not defined");
     });
 
     it('errors when parsing reference thats too deep', () => {
       const reference = new namespace.elements.Object({
         $ref: '#/components/schemas/Node/inside',
       });
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.error(
+      expect(parseResult).to.contain.error(
         "Only references to a reusable component inside '#/components/schemas' are supported"
       );
     });
@@ -128,9 +128,9 @@ describe('Reference Object', () => {
       const reference = new namespace.elements.Object({
         $ref: '#/components/schemas/Node',
       });
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.error("'#/components' is not defined");
+      expect(parseResult).to.contain.error("'#/components' is not defined");
     });
   });
 
@@ -141,9 +141,9 @@ describe('Reference Object', () => {
         invalid: {},
       });
 
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.warning("'Reference Object' contains invalid key 'invalid'");
+      expect(parseResult).to.contain.warning("'Reference Object' contains invalid key 'invalid'");
     });
 
     it('provides warning for extensions', () => {
@@ -152,9 +152,9 @@ describe('Reference Object', () => {
         'x-extension': {},
       });
 
-      const result = parse(context, 'schemas', reference);
+      const parseResult = parse(context, 'schemas', reference);
 
-      expect(result).to.contain.warning("Extensions are not permitted in 'Reference Object'");
+      expect(parseResult).to.contain.warning("Extensions are not permitted in 'Reference Object'");
     });
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseRequestBodyObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseRequestBodyObject-test.js
@@ -13,20 +13,20 @@ describe('Request Body Object', () => {
 
   it('returns an HTTP request element', () => {
     const request = new namespace.elements.Object();
-    const result = parse(context, request);
+    const parseResult = parse(context, request);
 
-    expect(result.length).to.equal(1);
-    const httpRequest = result.get(0);
+    expect(parseResult.length).to.equal(1);
+    const httpRequest = parseResult.get(0);
     expect(httpRequest).to.be.instanceof(namespace.elements.HttpRequest);
   });
 
   it('provides warning when request body is non-object', () => {
     const request = new namespace.elements.String();
 
-    const result = parse(context, request);
+    const parseResult = parse(context, request);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Request Body Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Request Body Object' is not an object");
   });
 
   describe('#description', () => {
@@ -35,11 +35,11 @@ describe('Request Body Object', () => {
         description: 'Example Request Body',
       });
 
-      const result = parse(context, request);
+      const parseResult = parse(context, request);
 
-      expect(result).to.not.contain.annotations;
-      expect(result.length).to.be.equal(1);
-      expect(result.get(0).copy.toValue()).to.deep.equal(['Example Request Body']);
+      expect(parseResult).to.not.contain.annotations;
+      expect(parseResult.length).to.be.equal(1);
+      expect(parseResult.get(0).copy.toValue()).to.deep.equal(['Example Request Body']);
     });
   });
 
@@ -49,9 +49,9 @@ describe('Request Body Object', () => {
         required: true,
       });
 
-      const result = parse(context, request);
+      const parseResult = parse(context, request);
 
-      expect(result).to.contain.warning("'Request Body Object' contains unsupported key 'required'");
+      expect(parseResult).to.contain.warning("'Request Body Object' contains unsupported key 'required'");
     });
 
     it('does not provide warning/errors for extensions', () => {
@@ -59,9 +59,9 @@ describe('Request Body Object', () => {
         'x-extension': '',
       });
 
-      const result = parse(context, request);
+      const parseResult = parse(context, request);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
     });
   });
 
@@ -70,9 +70,9 @@ describe('Request Body Object', () => {
       invalid: '',
     });
 
-    const result = parse(context, request);
+    const parseResult = parse(context, request);
 
-    expect(result).to.contain.warning("'Request Body Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'Request Body Object' contains invalid key 'invalid'");
   });
 
   describe('#content', () => {
@@ -81,9 +81,9 @@ describe('Request Body Object', () => {
         content: '',
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.contain.warning("'Request Body Object' 'content' is not an object");
+      expect(parseResult).to.contain.warning("'Request Body Object' 'content' is not an object");
     });
 
     it('returns a HTTP request elements matching the media types', () => {
@@ -94,15 +94,15 @@ describe('Request Body Object', () => {
         },
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result.length).to.equal(2);
+      expect(parseResult.length).to.equal(2);
 
-      const jsonRequest = result.get(0);
+      const jsonRequest = parseResult.get(0);
       expect(jsonRequest).to.be.instanceof(namespace.elements.HttpRequest);
       expect(jsonRequest.contentType.toValue()).to.equal('application/json');
 
-      const textRequest = result.get(1);
+      const textRequest = parseResult.get(1);
       expect(textRequest).to.be.instanceof(namespace.elements.HttpRequest);
       expect(textRequest.contentType.toValue()).to.equal('text/plain');
     });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponseObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponseObject-test.js
@@ -15,10 +15,10 @@ describe('Response Object', () => {
     const response = new namespace.elements.Object({
       description: 'response',
     });
-    const result = parse(context, response);
+    const parseResult = parse(context, response);
 
-    expect(result.length).to.equal(1);
-    const httpResponse = result.get(0);
+    expect(parseResult.length).to.equal(1);
+    const httpResponse = parseResult.get(0);
     expect(httpResponse).to.be.instanceof(namespace.elements.HttpResponse);
   });
 
@@ -28,11 +28,11 @@ describe('Response Object', () => {
         description: 'Example Response',
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result.length).to.equal(1);
-      expect(result).to.not.contain.annotations;
-      expect(result.get(0).copy.toValue()).to.deep.equal(['Example Response']);
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.not.contain.annotations;
+      expect(parseResult.get(0).copy.toValue()).to.deep.equal(['Example Response']);
     });
 
     it('does not accept description if not string', () => {
@@ -40,28 +40,28 @@ describe('Response Object', () => {
         description: [],
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.contain.warning("'Response Object' 'description' is not a string");
+      expect(parseResult).to.contain.warning("'Response Object' 'description' is not a string");
     });
 
     it('provide warning if description is missing', () => {
       const response = new namespace.elements.Object({
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.contain.error("'Response Object' is missing required property 'description'");
+      expect(parseResult).to.contain.error("'Response Object' is missing required property 'description'");
     });
   });
 
   it('provides warning when response is non-object', () => {
     const response = new namespace.elements.Member('200', null);
 
-    const result = parse(context, response);
+    const parseResult = parse(context, response);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Response Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Response Object' is not an object");
   });
 
   describe('warnings for unsupported properties', () => {
@@ -71,9 +71,9 @@ describe('Response Object', () => {
         headers: 'dummy',
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.contain.warning("'Response Object' contains unsupported key 'headers'");
+      expect(parseResult).to.contain.warning("'Response Object' contains unsupported key 'headers'");
     });
 
     it('provides warning for unsupported links key', () => {
@@ -82,9 +82,9 @@ describe('Response Object', () => {
         links: 'dummy',
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.contain.warning("'Response Object' contains unsupported key 'links'");
+      expect(parseResult).to.contain.warning("'Response Object' contains unsupported key 'links'");
     });
 
     it('does not provide warning/errors for extensions', () => {
@@ -93,9 +93,9 @@ describe('Response Object', () => {
         'x-extension': '',
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.not.contain.annotations;
+      expect(parseResult).to.not.contain.annotations;
     });
   });
 
@@ -105,9 +105,9 @@ describe('Response Object', () => {
       invalid: '',
     });
 
-    const result = parse(context, response);
+    const parseResult = parse(context, response);
 
-    expect(result).to.contain.warning("'Response Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'Response Object' contains invalid key 'invalid'");
   });
 
   describe('#content', () => {
@@ -117,9 +117,9 @@ describe('Response Object', () => {
         content: '',
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result).to.contain.warning("'Response Object' 'content' is not an object");
+      expect(parseResult).to.contain.warning("'Response Object' 'content' is not an object");
     });
 
     it('returns a HTTP response elements matching the media types', () => {
@@ -131,15 +131,15 @@ describe('Response Object', () => {
         },
       });
 
-      const result = parse(context, response);
+      const parseResult = parse(context, response);
 
-      expect(result.length).to.equal(2);
+      expect(parseResult.length).to.equal(2);
 
-      const jsonResponse = result.get(0);
+      const jsonResponse = parseResult.get(0);
       expect(jsonResponse).to.be.instanceof(namespace.elements.HttpResponse);
       expect(jsonResponse.contentType.toValue()).to.equal('application/json');
 
-      const halResponse = result.get(1);
+      const halResponse = parseResult.get(1);
       expect(halResponse).to.be.instanceof(namespace.elements.HttpResponse);
       expect(halResponse.contentType.toValue()).to.equal('application/hal+json');
     });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
@@ -13,10 +13,10 @@ describe('Responses Object', () => {
 
   it('provides warning when responses is non-object', () => {
     const responses = new namespace.elements.String('');
-    const result = parse(context, responses);
+    const parseResult = parse(context, responses);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Responses Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Responses Object' is not an object");
   });
 
   it('does not provide warning/errors for extensions', () => {
@@ -24,9 +24,9 @@ describe('Responses Object', () => {
       'x-extension': '',
     });
 
-    const result = parse(context, responses);
+    const parseResult = parse(context, responses);
 
-    expect(result).to.not.contain.annotations;
+    expect(parseResult).to.not.contain.annotations;
   });
 
   it('provides warning for invalid keys', () => {
@@ -34,9 +34,9 @@ describe('Responses Object', () => {
       invalid: '',
     });
 
-    const result = parse(context, responses);
+    const parseResult = parse(context, responses);
 
-    expect(result).to.contain.warning("'Responses Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'Responses Object' contains invalid key 'invalid'");
   });
 
   it('provides warning for response range', () => {
@@ -44,9 +44,9 @@ describe('Responses Object', () => {
       invalid: '',
     });
 
-    const result = parse(context, responses);
+    const parseResult = parse(context, responses);
 
-    expect(result).to.contain.warning("'Responses Object' contains invalid key 'invalid'");
+    expect(parseResult).to.contain.warning("'Responses Object' contains invalid key 'invalid'");
   });
 
   it('can parse a numerical status code', () => {
@@ -56,10 +56,10 @@ describe('Responses Object', () => {
       },
     });
 
-    const result = parse(context, responses);
-    expect(result.length).to.equal(1);
+    const parseResult = parse(context, responses);
+    expect(parseResult.length).to.equal(1);
 
-    const array = result.get(0);
+    const array = parseResult.get(0);
     expect(array).to.be.instanceof(namespace.elements.Array);
     expect(array.length).to.equal(1);
 
@@ -73,8 +73,8 @@ describe('Responses Object', () => {
       default: {},
     });
 
-    const result = parse(context, responses);
-    expect(result).to.contain.warning("'Responses Object' default responses are unsupported");
+    const parseResult = parse(context, responses);
+    expect(parseResult).to.contain.warning("'Responses Object' default responses are unsupported");
   });
 
   it('parses a status code range as warning', () => {
@@ -82,7 +82,7 @@ describe('Responses Object', () => {
       '2XX': {},
     });
 
-    const result = parse(context, responses);
-    expect(result).to.contain.warning("'Responses Object' response status code ranges are unsupported");
+    const parseResult = parse(context, responses);
+    expect(parseResult).to.contain.warning("'Responses Object' response status code ranges are unsupported");
   });
 });

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseSchemaObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseSchemaObject-test.js
@@ -14,10 +14,10 @@ describe('Schema Object', () => {
 
   it('provides a warning when schema is non-object', () => {
     const schema = new namespace.elements.String('my schema');
-    const result = parse(context, schema);
+    const parseResult = parse(context, schema);
 
-    expect(result.length).to.equal(1);
-    expect(result).to.contain.warning("'Schema Object' is not an object");
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Schema Object' is not an object");
   });
 
   describe('#type', () => {
@@ -25,31 +25,31 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: ['null'],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result).to.contain.warning("'Schema Object' 'type' is not a string");
+      expect(parseResult).to.contain.warning("'Schema Object' 'type' is not a string");
     });
 
     it('warns when type is not a valid type', () => {
       const schema = new namespace.elements.Object({
         type: 'invalid',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result).to.contain.warning(
+      expect(parseResult).to.contain.warning(
         "'Schema Object' 'type' must be either null, boolean, object, array, number, string, integer"
       );
     });
 
     it('returns a data structure representing all types for no type limitations', () => {
       const schema = new namespace.elements.Object({});
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const element = result.get(0).content;
+      const element = parseResult.get(0).content;
       expect(element).to.be.instanceof(namespace.elements.Enum);
 
       expect(element.enumerations.length).to.equal(6);
@@ -65,13 +65,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'null',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const element = result.get(0).content;
+      const element = parseResult.get(0).content;
       expect(element).to.be.instanceof(namespace.elements.Null);
     });
 
@@ -79,13 +79,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'boolean',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const string = result.get(0).content;
+      const string = parseResult.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.Boolean);
     });
 
@@ -93,13 +93,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'object',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const object = result.get(0).content;
+      const object = parseResult.get(0).content;
       expect(object).to.be.instanceof(namespace.elements.Object);
     });
 
@@ -107,13 +107,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'array',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const array = result.get(0).content;
+      const array = parseResult.get(0).content;
       expect(array).to.be.instanceof(namespace.elements.Array);
     });
 
@@ -121,13 +121,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'number',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const string = result.get(0).content;
+      const string = parseResult.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.Number);
     });
 
@@ -135,13 +135,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'string',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const string = result.get(0).content;
+      const string = parseResult.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.String);
     });
 
@@ -149,13 +149,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         type: 'integer',
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const string = result.get(0).content;
+      const string = parseResult.get(0).content;
       expect(string).to.be.instanceof(namespace.elements.Number);
     });
   });
@@ -165,9 +165,9 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: 1,
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result).to.contain.warning(
+      expect(parseResult).to.contain.warning(
         "'Schema Object' 'enum' is not an array"
       );
     });
@@ -176,13 +176,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: [1],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = result.get(0).content;
+      const enumElement = parseResult.get(0).content;
       expect(enumElement).to.be.instanceof(namespace.elements.Enum);
       expect(enumElement.enumerations.length).to.equal(1);
 
@@ -197,13 +197,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: [true],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = result.get(0).content;
+      const enumElement = parseResult.get(0).content;
       expect(enumElement).to.be.instanceof(namespace.elements.Enum);
       expect(enumElement.enumerations.length).to.equal(1);
 
@@ -218,13 +218,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: [null],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = result.get(0).content;
+      const enumElement = parseResult.get(0).content;
       expect(enumElement).to.be.instanceof(namespace.elements.Enum);
       expect(enumElement.enumerations.length).to.equal(1);
 
@@ -239,13 +239,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: ['connected'],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = result.get(0).content;
+      const enumElement = parseResult.get(0).content;
       expect(enumElement).to.be.instanceof(namespace.elements.Enum);
       expect(enumElement.enumerations.length).to.equal(1);
 
@@ -260,13 +260,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: [[1, 2]],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = result.get(0).content;
+      const enumElement = parseResult.get(0).content;
       expect(enumElement).to.be.instanceof(namespace.elements.Enum);
       expect(enumElement.enumerations.length).to.equal(1);
 
@@ -281,13 +281,13 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         enum: [{ message: 'Hello' }],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = result.get(0).content;
+      const enumElement = parseResult.get(0).content;
       expect(enumElement).to.be.instanceof(namespace.elements.Enum);
       expect(enumElement.enumerations.length).to.equal(1);
 
@@ -306,11 +306,11 @@ describe('Schema Object', () => {
           type: 'object',
           required: {},
         });
-        const result = parse(context, schema);
+        const parseResult = parse(context, schema);
 
-        expect(result.length).to.equal(2);
+        expect(parseResult.length).to.equal(2);
 
-        expect(result).to.contain.warning(
+        expect(parseResult).to.contain.warning(
           "'Schema Object' 'required' is not an array"
         );
       });
@@ -320,11 +320,11 @@ describe('Schema Object', () => {
           type: 'object',
           required: [1, true],
         });
-        const result = parse(context, schema);
+        const parseResult = parse(context, schema);
 
-        expect(result.length).to.equal(3);
+        expect(parseResult.length).to.equal(3);
 
-        expect(result.warnings.toValue()).to.deep.equal([
+        expect(parseResult.warnings.toValue()).to.deep.equal([
           "'Schema Object' 'required' array value is not a string",
           "'Schema Object' 'required' array value is not a string",
         ]);
@@ -338,13 +338,13 @@ describe('Schema Object', () => {
           },
           required: ['name'],
         });
-        const result = parse(context, schema);
+        const parseResult = parse(context, schema);
 
-        expect(result.length).to.equal(1);
-        expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-        expect(result).to.not.contain.annotations;
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+        expect(parseResult).to.not.contain.annotations;
 
-        const object = result.get(0).content;
+        const object = parseResult.get(0).content;
         expect(object).to.be.instanceof(namespace.elements.Object);
 
         const name = object.getMember('name');
@@ -359,11 +359,11 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         properties: [],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(2);
+      expect(parseResult.length).to.equal(2);
 
-      expect(result).to.contain.warning(
+      expect(parseResult).to.contain.warning(
         "'Schema Object' 'properties' is not an object"
       );
     });
@@ -375,13 +375,13 @@ describe('Schema Object', () => {
           name: { type: 'string' },
         },
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const object = result.get(0).content;
+      const object = parseResult.get(0).content;
       expect(object).to.be.instanceof(namespace.elements.Object);
 
       const name = object.get('name');
@@ -394,13 +394,13 @@ describe('Schema Object', () => {
           name: { type: 'string' },
         },
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumeration = result.get(0).content;
+      const enumeration = parseResult.get(0).content;
       expect(enumeration).to.be.instanceof(namespace.elements.Enum);
 
       const objects = enumeration.enumerations.filter(isObject);
@@ -425,13 +425,13 @@ describe('Schema Object', () => {
           name: { $ref: '#/components/schemas/name' },
         },
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const object = result.get(0).content;
+      const object = parseResult.get(0).content;
       expect(object).to.be.instanceof(namespace.elements.Object);
 
       const name = object.get('name');
@@ -445,11 +445,11 @@ describe('Schema Object', () => {
       const schema = new namespace.elements.Object({
         items: [],
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(2);
+      expect(parseResult.length).to.equal(2);
 
-      expect(result).to.contain.warning(
+      expect(parseResult).to.contain.warning(
         "'Schema Object' is not an object"
       );
     });
@@ -461,13 +461,13 @@ describe('Schema Object', () => {
           type: 'string',
         },
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const array = result.get(0).content;
+      const array = parseResult.get(0).content;
       expect(array).to.be.instanceof(namespace.elements.Array);
       expect(array.attributes.getValue('typeAttributes')).to.deep.equal(['fixedType']);
 
@@ -481,13 +481,13 @@ describe('Schema Object', () => {
           type: 'string',
         },
       });
-      const result = parse(context, schema);
+      const parseResult = parse(context, schema);
 
-      expect(result.length).to.equal(1);
-      expect(result.get(0)).to.be.instanceof(namespace.elements.DataStructure);
-      expect(result).to.not.contain.annotations;
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
 
-      const enumeration = result.get(0).content;
+      const enumeration = parseResult.get(0).content;
       expect(enumeration).to.be.instanceof(namespace.elements.Enum);
 
       const arrays = enumeration.enumerations.filter(isArray);


### PR DESCRIPTION
Renaming this variable was requested by @honzajavorek in some PR feedback somewhere