### PR TITLE
Remove use of process.nextTick in OAS 2 parser

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Removed uses of `process.nextTick` which could cause any exceptions raised by
+  the Fury adapter to be uncaught exceptions in Node JS.
+  https://github.com/apiaryio/fury-adapter-swagger/issues/169
+
 ## 0.23.2 (2019-01-25)
 
 ### Bug Fixes


### PR DESCRIPTION
process.nextTick was used to prevent the OAS 2 parser from blocking the Node JS runloop for an extended period of time which was causing platform instability when we was running the OAS 2 parser on Heroku during some computationally expensive OAS 2 documents.

We've had various architecture changes since then so blocking the run-loop isn't a problem for us anymore. Removing the use of nextTick simplifies the code base and fixes problems with uncaught exceptions described in https://github.com/apiaryio/fury-adapter-swagger/issues/169.