### PR TITLE
Never return an error and a result

### DIFF
--- a/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
@@ -28,7 +28,7 @@ class Parser {
         ]);
       }
 
-      return done(err, this.result);
+      return done(null, this.result);
     }
 
     this.api = new Category();

--- a/packages/fury-adapter-apiary-blueprint-parser/test/adapter-test.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/adapter-test.js
@@ -128,8 +128,10 @@ Test Section 1
       expect(annotation).to.eql(expectedAnnotation);
     });
 
-    it('has an error', () => {
-      expect(parseError).to.exist;
+    it('has an error element', () => {
+      expect(parseError).to.be.null;
+      expect(parseResult).to.exist;
+      expect(parseResult.errors.isEmpty).to.be.false;
     });
   });
 });

--- a/packages/fury-adapter-swagger/lib/parser.js
+++ b/packages/fury-adapter-swagger/lib/parser.js
@@ -77,7 +77,7 @@ class Parser {
       }
 
       this.generateSourceMap = generateSourceMap;
-      return done(new Error(err.message), this.result);
+      return done(null, this.result);
     }
 
     if (!_.isObject(loaded)) {
@@ -144,7 +144,7 @@ class Parser {
             queue.shift();
           }
 
-          return done(new Error(err.message), this.result);
+          return done(null, this.result);
         }
 
         // Maybe there is some information in the error itself? Let's check
@@ -167,7 +167,7 @@ class Parser {
           ]);
         }
 
-        return done(new Error(err.message), this.result);
+        return done(null, this.result);
       }
 
       try {

--- a/packages/fury-adapter-swagger/test/adapter-test.js
+++ b/packages/fury-adapter-swagger/test/adapter-test.js
@@ -116,9 +116,9 @@ describe('Swagger 2.0 adapter', () => {
   context('cannot parse invalid Swagger YAML', () => {
     const source = 'swagger: "2.0"\nbad: }';
 
-    it('returns error for bad input yaml', (done) => {
+    it('returns error parse result for bad input yaml', (done) => {
       fury.parse({ source }, (err, parseResult) => {
-        expect(err).to.exist;
+        expect(err).to.be.null;
         expect(parseResult).to.exist;
         expect(parseResult.errors.isEmpty).to.be.false;
         expect(parseResult.warnings.isEmpty).to.be.true;
@@ -126,9 +126,9 @@ describe('Swagger 2.0 adapter', () => {
       });
     });
 
-    it('returns error for bad input yaml with source maps', (done) => {
+    it('returns error parse result for bad input yaml with source maps', (done) => {
       fury.parse({ source, generateSourceMap: true }, (err, parseResult) => {
-        expect(err).to.exist;
+        expect(err).to.be.null;
         expect(parseResult).to.exist;
         expect(parseResult.errors.isEmpty).to.be.false;
         expect(parseResult.warnings.isEmpty).to.be.true;

--- a/packages/fury-adapter-swagger/test/inherit-parameters-test.js
+++ b/packages/fury-adapter-swagger/test/inherit-parameters-test.js
@@ -252,14 +252,14 @@ describe('Inherit Path Parameters', () => {
       source.paths['/'].parameters.push(makeParameter('test', 'body'));
       source.paths['/'].get.parameters.push(makeParameter('foo', 'body'));
 
-      doParse(
-        source,
-        (err) => {
-          expect(err.message).to.equal('Validation failed. /paths//get has 2 body parameters. Only one is allowed.');
-          done();
-        },
-        () => {}
-      );
+      fury.parse({ source }, (err, parseResult) => {
+        expect(err).to.be.null;
+        expect(parseResult.errors.toValue()).to.deep.equal([
+          'Validation failed. /paths//get has 2 body parameters. Only one is allowed.',
+        ]);
+
+        done();
+      });
     });
 
     it('on Path and Operation is same Parameter', (done) => {

--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Fury Changelog
 
+## Master
+
+### Breaking
+
+- Fury asynchronous APIs will no longer include both an error and a result
+  value. The APIs will now contain an error if the method could not proceed, or
+  a result. In the case of the `validate` and `parse` functions, these will
+  return a parse result with any error annotations upon a validation error and
+  will no longer include an error in the asynchronous callback.
+
 ## 3.0.0-beta.8 (2018-12-21)
 
 ### Breaking

--- a/packages/fury/test/fury-test.js
+++ b/packages/fury/test/fury-test.js
@@ -395,14 +395,13 @@ describe('Parser', () => {
 
     it('should error on parser error', (done) => {
       const expectedError = new Error();
-      const expectedElements = { element: 'string', content: 'Hello' };
       fury.adapters[fury.adapters.length - 1].parse = (options, done2) => {
-        done2(expectedError, expectedElements);
+        done2(expectedError);
       };
 
-      fury.parse({ source: 'dummy' }, (err, elements) => {
+      fury.parse({ source: 'dummy' }, (err, parseResult) => {
         assert.equal(err, expectedError);
-        assert.deepEqual(elements, fury.load(expectedElements));
+        assert.isUndefined(parseResult);
         done();
       });
     });

--- a/packages/fury/test/validate-test.js
+++ b/packages/fury/test/validate-test.js
@@ -41,7 +41,7 @@ describe('Validation', () => {
     it('should error when validating with no matching validator', (done) => {
       fury.validate({ source: 'dummy' }, (err, res) => {
         expect(err).not.to.be.null;
-        expect(res).to.be.null;
+        expect(res).to.be.undefined;
         done();
       });
     });


### PR DESCRIPTION
BREAKING CHANGE: Asynchronous callbacks will never be called with an error and a parse result anymore.

This changeset aligns with how callbacks work in general in Node, you would never usually expect to see both a result (in our case a parse result element) and an error in a returned callback (https://nodejs.org/dist/latest-v10.x/docs/api/errors.html#errors_error_first_callbacks). This breaks behaviours such as promises and async/await. We do regard a parsing a problematic document (such as one with invalid API Blueprint syntax or one that does not meet validation requirements) a success in terms that we could parse the document and we have returned a valid parse result. Not to mention, the error property of the callback for some of our parsers may not even be an instance of `Error` but an annotation. Going forward, the error field would be used for actual failures to parse the document, for example Drafter had problems allocating memory or some system API failed us and we was not able to parse the document. Another example would be with a remote Fury adapter which hits a HTTP parsing API where the connection could fail, the attempt to parse the document failed.

In past we've had to work around these behaviours, such as in https://gist.github.com/kylef/aea36b5992acac4a3782981393e9f998#file-fury-server-js-L11-L30.