### PR TITLE
Added partial support for the `example` in Parameter Object

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for the `nullable`, `description`, `default` and `example`
   Schema Object properties.
 - Added support for response headers.
+- Added partial support for the `example` in Parameter Object
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
@@ -17,7 +17,7 @@ const name = 'Parameter Object';
 const requiredKeys = ['name', 'in'];
 const unsupportedKeys = [
   'deprecated', 'allowEmptyValue', 'style', 'explode', 'allowReserved',
-  'schema', 'example', 'examples', 'content',
+  'schema', 'examples', 'content',
 ];
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 
@@ -95,6 +95,7 @@ function parseParameterObject(context, object) {
     [hasKey('in'), parseIn],
     [hasKey('description'), parseString(context, name, false)],
     [hasKey('required'), parseBoolean(context, name, false)],
+    [hasKey('example'), (e => e)],
 
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],
 
@@ -111,7 +112,8 @@ function parseParameterObject(context, object) {
     parseObject(context, name, parseMember, requiredKeys),
     R.when(isPathParameter, R.curry(validateRequiredForPathParameter)(context, object)),
     (parameter) => {
-      const member = new namespace.elements.Member(parameter.get('name'));
+      const example = parameter.get('example');
+      const member = new namespace.elements.Member(parameter.get('name'), example);
 
       const description = parameter.get('description');
       if (description) {

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -144,6 +144,84 @@ describe('Parameter Object', () => {
     });
   });
 
+  describe('#example', () => {
+    it('attaches string example to member', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        example: 'example_value',
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value.toValue()).to.equal('example_value');
+    });
+
+    it('attaches integer example to member', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        example: 10,
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value.toValue()).to.equal(10);
+    });
+
+    it('attaches boolean example to member', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        example: true,
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value.toValue()).to.equal(true);
+    });
+
+    it('attaches array example to member', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        example: [1, 2, 3, 4],
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value.toValue()).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it('attaches object example to member', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        example: {
+          foo: 1,
+          bar: 'baz',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value.toValue()).to.deep.equal({
+        foo: 1,
+        bar: 'baz',
+      });
+    });
+  });
+
   describe('#required', () => {
     it('create typeAttribute required', () => {
       const parameter = new namespace.elements.Object({
@@ -328,18 +406,6 @@ describe('Parameter Object', () => {
       const parseResult = parse(context, parameter);
 
       expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'schema'");
-    });
-
-    it('provides warning for unsupported example property', () => {
-      const parameter = new namespace.elements.Object({
-        name: 'direction',
-        in: 'query',
-        example: 'east',
-      });
-
-      const parseResult = parse(context, parameter);
-
-      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'example'");
     });
 
     it('provides warning for unsupported examples property', () => {


### PR DESCRIPTION
Added support for `example` in parameters:

```yaml
      parameters:
        -
          name: code
          in: query
          required: true
          description: 'Code to check'
          example: ABCDEFG
          schema:
            type: string
```

Not working with
```yaml
      parameters:
        -
          name: code
          in: query
          required: true
          description: 'Code to check'
          schema:
            type: string
            example: ABCDEFG
```
yet.

This helps me to (partially) resolve issue https://github.com/apiaryio/dredd/issues/1236

Not sure, if this is correct, it is my first contribution. So please, feel free to correct my code.