### PR TITLE
Warn for invalid 'Parameter Object' 'in'

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -8,6 +8,8 @@
   Schema Object properties.
 - Added support for response headers.
 - Added partial support for the `example` in Parameter Object
+- A warning will now be emitted when an invalid 'Parameter Object' 'in' value
+  is set, previously this would cause an error.
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
@@ -65,11 +65,11 @@ function validateRequiredForPathParameter(context, object, parameter) {
 function parseParameterObject(context, object) {
   const { namespace } = context;
 
-  const createInvalidInError = R.compose(
-    createError(namespace, `'${name}' 'in' must be either 'query, 'header', 'path' or 'cookie'`),
+  const createInvalidInWarning = R.compose(
+    createWarning(namespace, `'${name}' 'in' must be either 'query, 'header', 'path' or 'cookie'`),
     getValue
   );
-  const validateIn = R.unless(isValidInValue, createInvalidInError);
+  const validateIn = R.unless(isValidInValue, createInvalidInWarning);
 
   const isSupportedIn = R.anyPass([hasValue('path'), hasValue('query')]);
   const createUnsupportedInWarning = member => createWarning(namespace,

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -77,7 +77,7 @@ describe('Parameter Object', () => {
       expect(parseResult).to.contain.error("'Parameter Object' 'in' is not a string");
     });
 
-    it('provides an error when value is not a permitted value', () => {
+    it('provides a warning when value is not a permitted value', () => {
       const parameter = new namespace.elements.Object({
         name: 'example',
         in: 'space',
@@ -86,7 +86,7 @@ describe('Parameter Object', () => {
       const parseResult = parse(context, parameter);
 
       expect(parseResult.length).to.equal(1);
-      expect(parseResult).to.contain.error("'Parameter Object' 'in' must be either 'query, 'header', 'path' or 'cookie'");
+      expect(parseResult).to.contain.warning("'Parameter Object' 'in' must be either 'query, 'header', 'path' or 'cookie'");
     });
 
     it('provides an unsupported error for header parameters', () => {


### PR DESCRIPTION
Previously we errored for invalid 'in' values as it was a required property which causes the entire 'Parameter Object' to fail parsing. This was done at the time to keep the implementation simpler, after the changes in https://github.com/apiaryio/api-elements.js/pull/113 this allows us to make this a warning. Since `parseObject` will fail object parsing when one of the members is not correctly parsed.