### PR TITLE
Support number status codes in Responses Object

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Removed `null` as a valid type for a Schema Object, `null` is not supported
   as a type in OpenAPI 3 Schema Object. `nullable` should be used instead.
 - Added check for `required` in a Path Parameter.
+- The parser will now handle Responses Object which contains status codes that
+  are not strings. Previously the parser would throw an error, we will now
+  coerce number status codes to a string and emit a warning when a status code
+  is not a string.
 
 ## 0.5.1 (30-01-19)
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponsesObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponsesObject.js
@@ -19,7 +19,7 @@ function isStatusCode(member) {
 
 // Returns if member has key that is 3 digit HTTP status code with X to represent range
 function isStatusCodeRange(member) {
-  return member.key.toValue().match(/^[\dX]{3}$/);
+  return String(member.key.toValue()).match(/^[\dX]{3}$/);
 }
 
 const isResponseField = R.anyPass([isStatusCode, isStatusCodeRange, hasKey('default')]);

--- a/packages/fury-adapter-oas3-parser/lib/predicates.js
+++ b/packages/fury-adapter-oas3-parser/lib/predicates.js
@@ -38,6 +38,13 @@ const hasValue = (value, member) => member.value.toValue() === value;
 const isExtension = member => member.key.toValue().startsWith('x-');
 
 /**
+ * Returns the key for the given member element
+ * @param member {MemberElement}
+ * @returns {Element}
+ */
+const getKey = member => member.key;
+
+/**
  * Returns the value for the given member element
  * @param member {MemberElement}
  * @returns {Element}
@@ -58,5 +65,7 @@ module.exports = {
   hasKey: R.curry(hasKey),
   hasValue: R.curry(hasValue),
   isExtension,
+
+  getKey,
   getValue,
 };

--- a/packages/fury-adapter-oas3-parser/lib/predicates.js
+++ b/packages/fury-adapter-oas3-parser/lib/predicates.js
@@ -35,7 +35,7 @@ const hasValue = (value, member) => member.value.toValue() === value;
  * @param member {MemberElement}
  * @returns {boolean}
  */
-const isExtension = member => member.key.toValue().startsWith('x-');
+const isExtension = member => member.key && isString(member.key) && member.key.toValue().startsWith('x-');
 
 /**
  * Returns the key for the given member element

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
@@ -68,6 +68,29 @@ describe('Responses Object', () => {
     expect(response.statusCode.toValue()).to.equal('200');
   });
 
+  it('can parse a number status code with warning', () => {
+    const statusCode = new namespace.elements.Number(200);
+    const responses = new namespace.elements.Object([
+      new namespace.elements.Member(statusCode, {
+        description: 'dummy',
+      }),
+    ]);
+
+    const parseResult = parse(context, responses);
+
+    const array = parseResult.get(0);
+    expect(array).to.be.instanceof(namespace.elements.Array);
+    expect(array.length).to.equal(1);
+
+    const response = array.get(0);
+    expect(response).to.be.instanceof(namespace.elements.HttpResponse);
+    expect(response.statusCode.toValue()).to.equal('200');
+
+    expect(parseResult).to.contain.warning(
+      "'Responses Object' response status code must be a string and should be wrapped in quotes"
+    );
+  });
+
   it('parses default response as warning', () => {
     const responses = new namespace.elements.Object({
       default: {},

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
@@ -39,6 +39,20 @@ describe('Responses Object', () => {
     expect(parseResult).to.contain.warning("'Responses Object' contains invalid key 'invalid'");
   });
 
+  it('provides warning for invalid numerical keys', () => {
+    const statusCode = new namespace.elements.Number(20);
+    const responses = new namespace.elements.Object([
+      new namespace.elements.Member(statusCode, {}),
+    ]);
+
+    const parseResult = parse(context, responses);
+    expect(parseResult.length).to.equal(2);
+
+    expect(parseResult).to.contain.warning(
+      "'Responses Object' contains invalid key '20'"
+    );
+  });
+
   it('provides warning for response range', () => {
     const responses = new namespace.elements.Object({
       invalid: '',


### PR DESCRIPTION
The parser will now handle Responses Object which contains status codes that are not strings. Previously the parser would throw an error, we will now coerce number status codes to a string and emit a warning when a status code is not a string.

Fixes #157