### PR TITLE
Release fury-adapter-oas3-parser 0.5.2

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.5.2 (19-02-19)
 
 ### Enhancements
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
### Enhancements

- Added support for the `nullable`, `description`, `default` and `example`
  Schema Object properties.
- Added support for response headers.
- Added partial support for the `example` in Parameter Object
### Bug Fixes
- Removed `null` as a valid type for a Schema Object, `null` is not supported
  as a type in OpenAPI 3 Schema Object. `nullable` should be used instead.
- Added check for `required` in a Path Parameter.
- The parser will now handle Responses Object which contains status codes that
  are not strings. Previously the parser would throw an error, we will now
  coerce number status codes to a string and emit a warning when a status code
is not a string.