### PR TITLE
Release fury 3.0.0-beta.9

### DIFF
--- a/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 3.0.0-beta.6 (2019-02-26)
 
 ### Enhancements
 

--- a/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9).
+
 ## 3.0.0-beta.5 (2018-12-21)
 
 ### Breaking

--- a/packages/fury-adapter-apiary-blueprint-parser/package.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apiary-blueprint-parser",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "description": "Parser for Fury.js for the deprecated Apiary Blueprint language",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-apiary-blueprint-parser/package.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/package.json
@@ -21,12 +21,12 @@
     "deckardcain": "^0.4.0"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.8"
+    "fury": "3.0.0-beta.9"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "glob": "^7.1.2",
     "mocha": "^5.0.2"
   },

--- a/packages/fury-adapter-apib-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apib-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury API Blueprint Parser Changelog
 
+## Master
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9).
+
 ## 0.13.0-beta (2019-01-10)
 
 This update now uses drafter-npm 2.0.0-pre.1. Please see [drafter-npm

--- a/packages/fury-adapter-apib-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apib-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury API Blueprint Parser Changelog
 
-## Master
+## 0.13.0 (2019-02-26)
 
 ### Enhancements
 

--- a/packages/fury-adapter-apib-parser/package.json
+++ b/packages/fury-adapter-apib-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-parser",
-  "version": "0.13.0-beta",
+  "version": "0.13.0",
   "description": "API Blueprint parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-apib-parser/package.json
+++ b/packages/fury-adapter-apib-parser/package.json
@@ -21,12 +21,12 @@
     "drafter": "2.0.0-pre.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.8"
+    "fury": "3.0.0-beta.9"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "mocha": "^5.0.2"
   },
   "engines": {

--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury API Blueprint Serializer
 
-## Master
+## 0.9.0 (2019-02-26)
 
 ### Enhancements
 

--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury API Blueprint Serializer
 
+## Master
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9).
+
 ## 0.8.0 (2018-12-21)
 
 ### Breaking

--- a/packages/fury-adapter-apib-serializer/package.json
+++ b/packages/fury-adapter-apib-serializer/package.json
@@ -20,12 +20,12 @@
     "nunjucks": "^2.0.0"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.8"
+    "fury": "3.0.0-beta.9"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "glob": "^7.1.2",
     "mocha": "^5.0.2"
   },

--- a/packages/fury-adapter-apib-serializer/package.json
+++ b/packages/fury-adapter-apib-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-serializer",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "API Blueprint serializer for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9).
+
 ### Bug Fixes
 
 - Fix handling of empty `!!set` and `!!map` in YAML parsing.

--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.6.0 (26-02-19)
 
 ### Enhancements
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -25,12 +25,12 @@
     "yaml-js": "^0.2.3"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.8"
+    "fury": "3.0.0-beta.9"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "mocha": "^5.0.2"
   },
   "engines": {

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9).
+
 ### Bug Fixes
 
 - Removed uses of `process.nextTick` which could cause any exceptions raised by

--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.24.0 (2019-02-26)
 
 ### Enhancements
 

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -28,12 +28,12 @@
     "z-schema": "^3.16.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.8"
+    "fury": "3.0.0-beta.9"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "glob": "^7.1.2",
     "mocha": "^5.0.2",
     "swagger-zoo": "2.20.0"

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-cli/CHANGELOG.md
+++ b/packages/fury-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Master
+
+This update uses [Fury 3.0.0 Beta
+9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9)
+toolchain.
+
 ## 0.8.9 (2019-01-30)
 
 ### Enhancements

--- a/packages/fury-cli/CHANGELOG.md
+++ b/packages/fury-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Master
+## 0.9.10 (2019-02-26)
 
 This update uses [Fury 3.0.0 Beta
 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9)

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -25,7 +25,7 @@
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.5",
     "fury-adapter-apib-parser": "0.13.0-beta",
     "fury-adapter-apib-serializer": "^0.8.0",
-    "fury-adapter-oas3-parser": "^0.5.0",
+    "fury-adapter-oas3-parser": "^0.6.0",
     "fury-adapter-swagger": "^0.24.0",
     "js-yaml": "^3.6",
     "minim": "^0.23.1"

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -22,7 +22,7 @@
     "cardinal": "^2.1.1",
     "commander": "^2.9",
     "fury": "3.0.0-beta.9",
-    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.5",
+    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.6",
     "fury-adapter-apib-parser": "0.13.0-beta",
     "fury-adapter-apib-serializer": "^0.8.0",
     "fury-adapter-oas3-parser": "^0.6.0",

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -26,7 +26,7 @@
     "fury-adapter-apib-parser": "0.13.0-beta",
     "fury-adapter-apib-serializer": "^0.8.0",
     "fury-adapter-oas3-parser": "^0.5.0",
-    "fury-adapter-swagger": "^0.23.0",
+    "fury-adapter-swagger": "^0.24.0",
     "js-yaml": "^3.6",
     "minim": "^0.23.1"
   },

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -23,7 +23,7 @@
     "commander": "^2.9",
     "fury": "3.0.0-beta.9",
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.6",
-    "fury-adapter-apib-parser": "0.13.0-beta",
+    "fury-adapter-apib-parser": "0.13.0",
     "fury-adapter-apib-serializer": "^0.8.0",
     "fury-adapter-oas3-parser": "^0.6.0",
     "fury-adapter-swagger": "^0.24.0",

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -24,7 +24,7 @@
     "fury": "3.0.0-beta.9",
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.6",
     "fury-adapter-apib-parser": "0.13.0",
-    "fury-adapter-apib-serializer": "^0.8.0",
+    "fury-adapter-apib-serializer": "^0.9.0",
     "fury-adapter-oas3-parser": "^0.6.0",
     "fury-adapter-swagger": "^0.24.0",
     "js-yaml": "^3.6",

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "cardinal": "^2.1.1",
     "commander": "^2.9",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.5",
     "fury-adapter-apib-parser": "0.13.0-beta",
     "fury-adapter-apib-serializer": "^0.8.0",

--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Changelog
 
-## Master
+## 3.0.0-beta.9 (2019-02-26)
 
 ### Breaking
 

--- a/packages/fury/package.json
+++ b/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "API Description SDK",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
This releases the entire toolchain (all adapters and CLI) for Fury Beta 9.