### PR TITLE
Don't duplicate property descriptions on member

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Supports data structure generation for references for a value inside another
   definition. For example a reference to `#/definitions/User/properties/name`.
 
+- Removes duplicate description values placed on members for data structure
+  properties.
+
 ## 0.24.0 (2019-02-26)
 
 ### Enhancements

--- a/packages/fury-adapter-swagger/lib/schema.js
+++ b/packages/fury-adapter-swagger/lib/schema.js
@@ -43,11 +43,6 @@ class DataStructureGenerator {
     const member = new MemberElement();
     member.key = new StringElement(name);
     member.value = this.generateElement(property);
-
-    if (property.description) {
-      member.description = property.description;
-    }
-
     return member;
   }
 

--- a/packages/fury-adapter-swagger/test/schema-test.js
+++ b/packages/fury-adapter-swagger/test/schema-test.js
@@ -384,9 +384,9 @@ describe('JSON Schema to Data Structure', () => {
       expect(dataStructure.element).to.equal('dataStructure');
       expect(dataStructure.content).to.be.instanceof(ObjectElement);
 
-      expect(dataStructure.content.content[0].description.toValue()).to.equal('Name');
       const value = dataStructure.content.get('name');
       expect(value.element).to.equal('string');
+      expect(value.description.toValue()).to.equal('Name');
     });
 
     it('produces object members from required schema properties', () => {

--- a/packages/swagger-zoo/fixtures/features/api-elements/recursion.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/recursion.json
@@ -247,12 +247,6 @@
                   },
                   {
                     "element": "member",
-                    "meta": {
-                      "description": {
-                        "element": "string",
-                        "content": "A list of categories"
-                      }
-                    },
                     "attributes": {
                       "typeAttributes": {
                         "element": "array",

--- a/packages/swagger-zoo/fixtures/features/api-elements/recursion.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/recursion.sourcemap.json
@@ -620,12 +620,6 @@
                   },
                   {
                     "element": "member",
-                    "meta": {
-                      "description": {
-                        "element": "string",
-                        "content": "A list of categories"
-                      }
-                    },
                     "attributes": {
                       "typeAttributes": {
                         "element": "array",


### PR DESCRIPTION
Spotted by Standa, previous we have been duplicating descriptions on the member element when you have a property that contains a description:

```yaml
definitions:
  User:
    type: object
    properties:
      name:
        type: string
        description: a name
```

The previous logic was an attempt to "move" the description from a property from the member to align with other parsers. However due to language differences I think that this does not make sense because in JSON Schema the description is apart of the type. Especially when it comes to referencing:

```yaml
definitions:
  User:
    type: object
    properties:
      name:
        $ref: '#/definitions/name'
  name:
    type: string
    description: a name
```