### PR TITLE
Fix serialising message payload without headers

### DIFF
--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury API Blueprint Serializer
 
+## Master
+
+### Bug Fixes
+
+- Fixes an issue where the serialiser would raise an exception when dealing
+  with message body payloads which do not contain headers.
+
 ## 0.9.0 (2019-02-26)
 
 ### Enhancements

--- a/packages/fury-adapter-apib-serializer/lib/filters.js
+++ b/packages/fury-adapter-apib-serializer/lib/filters.js
@@ -34,18 +34,11 @@ const indent = (input, spaces, options = { first: false }) => {
   * use a shorthand syntax in the template.
   */
 const bodyOnly = (payload) => {
-  let headers;
+  // Headers, excluding content-type as that goes outside payload
+  // (e.g. `+ Response (application/json)`)
+  const hasHeaders = payload.headers && payload.headers.exclude('Content-Type').length > 0;
 
-  // First, we need to filter out the content-type header. This is handled
-  // outside of the payload (e.g. `+ Response (application/json)`)
-  if (payload.headers) {
-    headers = payload.headers.exclude('Content-Type');
-  }
-
-  return payload.messageBody && !(
-    headers.length || payload.dataStructure || payload.messageBodySchema
-     || payload.children.filter(item => item.element === 'copy').length
-  );
+  return payload.content.length === 1 && payload.messageBody !== undefined && !hasHeaders;
 };
 
 /*

--- a/packages/fury-adapter-apib-serializer/test/filters-test.js
+++ b/packages/fury-adapter-apib-serializer/test/filters-test.js
@@ -1,0 +1,55 @@
+const { expect } = require('chai');
+const { Fury } = require('fury');
+const { bodyOnly } = require('../lib/filters');
+
+const fury = new Fury();
+const { minim: namespace } = fury;
+
+describe('filters', () => {
+  describe('bodyOnly', () => {
+    it('returns false when message payload is empty', () => {
+      const payload = new namespace.elements.HttpRequest();
+
+      expect(bodyOnly(payload)).to.be.false;
+    });
+
+    it('returns true when message payload only contains a body', () => {
+      const asset = new namespace.elements.Asset();
+      asset.classes = ['messageBody'];
+      const payload = new namespace.elements.HttpRequest([asset]);
+
+      expect(bodyOnly(payload)).to.be.true;
+    });
+
+    it('returns false when message payload contains a body and other elements', () => {
+      const copy = new namespace.elements.Copy('Hello World');
+
+      const asset = new namespace.elements.Asset();
+      asset.classes = ['messageBody'];
+      const payload = new namespace.elements.HttpRequest([copy, asset]);
+
+      expect(bodyOnly(payload)).to.be.false;
+    });
+
+    it('returns true when message payload only contains a body and headers', () => {
+      const payload = new namespace.elements.HttpRequest();
+      payload.headers = new namespace.elements.HttpHeaders({
+        Accept: 'application/json',
+      });
+
+      expect(bodyOnly(payload)).to.be.false;
+    });
+
+    it('returns true when message payload only contains a body and a single Content-Type header', () => {
+      const asset = new namespace.elements.Asset();
+      asset.classes = ['messageBody'];
+
+      const payload = new namespace.elements.HttpRequest([asset]);
+      payload.headers = new namespace.elements.HttpHeaders({
+        'Content-Type': 'application/json',
+      });
+
+      expect(bodyOnly(payload)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Our API Blueprint Serialiser is emitting the following exception in the case that it is handling a HTTP Message Payload (Request or Response) which contains a body but does not contain any headers.

```
$ npx fury blueprint.api --format text/vnd.apiblueprint
{ Template render error: (/Users/kyle/Projects/apiaryio/api-elements.js/packages/fury-adapter-apib-serializer/template.nunjucks) [Line 69, Column 14]
  TypeError: Cannot read property 'length' of undefined
    at Object.exports.prettifyError (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/lib.js:34:15)
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:486:31
    at new_cls.root [as rootRenderFunc] (eval at _compile (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:630:3)
    at new_cls.render (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:479:15)
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:312:35
    at createTemplate (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:234:25)
    at handle (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:249:25)
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/environment.js:263:21
    at next (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/lib.js:207:13)
    at Object.exports.asyncIter (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/nunjucks/src/lib.js:214:5) name: 'Template render error' }
```

I've updated the handling so we can count for this.