### PR TITLE
impl(remote): initial commit of configurable "remote" parser

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,6 +9,7 @@ module.exports = {
       'oas2',
       'apib',
       'apiaryb',
+      'remote',
     ]],
     'scope-empty': [2, 'never'],
   },

--- a/packages/fury-adapter-remote/README.md
+++ b/packages/fury-adapter-remote/README.md
@@ -3,14 +3,13 @@
 [![NPM version](https://img.shields.io/npm/v/fury-adapter-remote.svg)](https://www.npmjs.org/package/fury-adapter-remote)
 [![License](https://img.shields.io/npm/l/fury-adapter-remote.svg)](https://www.npmjs.org/package/fury-adapter-remote)
 
-This adapter provides support for parsing, validation and serialization via [Public API Service](http://api.apielements.org/) in [Fury](https://github.com/apiaryio/api-elements.js/tree/master/packages/fury).
+This adapter provides support for parsing, validation and serialization via the [API Elements Web Service](https://api.apielements.org/) in [Fury](https://github.com/apiaryio/api-elements.js/tree/master/packages/fury).
 
-In adapter is configurable and can be configured to work with any public API service compatible with [API BlueprintAPI Service](https://apiblueprintapi.docs.apiary.io)
-It provide default configuration connected to [Public API Service](http://api.apielements.org/) to working "out of the box"
+The remote adapter can be configured to work with any API service compatible with [API Blueprint API](https://apiblueprintapi.docs.apiary.io).
+By default the [API Elements Web Service](http://api.apielements.org/) is used.
 
 ```js
 const defaultOptions = {
-  // the default value, but consumers should be able to override to use their own deployment
   url: 'https://api.apielements.org',
 
   parseEndpoint: '/parser',
@@ -45,7 +44,7 @@ const defaultOptions = {
 ## Install
 
 ```sh
-npm install fury-adapter-remote
+$ npm install fury-adapter-remote
 ```
 
 ## Usage
@@ -55,10 +54,9 @@ const { Fury } = require('fury');
 const FuryRemoteAdapter = require('fury-adapter-remote');
 
 const fury = new Fury();
-fury.use(new FuryRemoteAdapter({});
+fury.use(new FuryRemoteAdapter(options);
 
 fury.validate(...);
 fury.parse(...);
 fury.serialise(...);
 ```
-

--- a/packages/fury-adapter-remote/README.md
+++ b/packages/fury-adapter-remote/README.md
@@ -1,0 +1,64 @@
+# Fury Remote Adapter
+
+[![NPM version](https://img.shields.io/npm/v/fury-adapter-remote.svg)](https://www.npmjs.org/package/fury-adapter-remote)
+[![License](https://img.shields.io/npm/l/fury-adapter-remote.svg)](https://www.npmjs.org/package/fury-adapter-remote)
+
+This adapter provides support for parsing, validation and serialization via [Public API Service](http://api.apielements.org/) in [Fury](https://github.com/apiaryio/api-elements.js/tree/master/packages/fury).
+
+In adpter is cofigurable and can be cofigured to work with any public API service compatible with [API BlueprintAPI Service](https://apiblueprintapi.docs.apiary.io)
+It provide default configuration connected to [Public API Service](http://api.apielements.org/) to working "out of the box"
+
+```js
+const defaultOptions = {
+  // the default value, but consumers should be able to override to use their own deployment
+  url: 'https://api.apielements.org',
+
+  parseEndpoint: '/parser',
+  validateEndpoint: '/validate',
+  serializeEndpoint: '/composer',
+
+  // the collection of "parse", media types we want this
+  // instance of the adapter to handle.
+  // NOTE, this allows you to use the API for one media type but
+  // another local adapter for another.
+  parseMediaTypes: [
+    'text/vnd.apiblueprint',
+    'application/swagger+json',
+    'application/swagger+yaml',
+    'application/vnd.oai.openapi',
+    'application/vnd.oai.openapi+json',
+  ],
+
+  // the collection of "serialize", media types we want this
+  // instance of the adapter to handle.
+  serializeMediaTypes: [
+    'application/vnd.refract+json',
+    'application/vnd.refract.parse-result+json',
+  ],
+
+  // fallback to try send input, if not indentified by deckardcain
+  defaultParseMediaType: 'text/vnd.apiblueprint',
+  defaultSerializeMediaType: 'application/vnd.refract+json',
+};
+```
+
+## Install
+
+```sh
+npm install fury-adapter-remote
+```
+
+## Usage
+
+```js
+const { Fury } = require('fury');
+const FuryRemoteAdapter = require('fury-adapter-remote');
+
+const fury = new Fury();
+fury.use(new FuryRemoteAdapter({});
+
+fury.validate(...);
+fury.parse(...);
+fury.serialise(...);
+```
+

--- a/packages/fury-adapter-remote/README.md
+++ b/packages/fury-adapter-remote/README.md
@@ -5,7 +5,7 @@
 
 This adapter provides support for parsing, validation and serialization via [Public API Service](http://api.apielements.org/) in [Fury](https://github.com/apiaryio/api-elements.js/tree/master/packages/fury).
 
-In adpter is cofigurable and can be cofigured to work with any public API service compatible with [API BlueprintAPI Service](https://apiblueprintapi.docs.apiary.io)
+In adapter is configurable and can be configured to work with any public API service compatible with [API BlueprintAPI Service](https://apiblueprintapi.docs.apiary.io)
 It provide default configuration connected to [Public API Service](http://api.apielements.org/) to working "out of the box"
 
 ```js

--- a/packages/fury-adapter-remote/lib/adapter.js
+++ b/packages/fury-adapter-remote/lib/adapter.js
@@ -1,0 +1,133 @@
+const deckardcain = require('deckardcain');
+const axios = require('axios');
+
+const name = 'remote';
+
+const outputMediaType = 'application/vnd.refract.parse-result+json; version=1.0';
+
+const defaultOptions = {
+  // the default value, but consumers should be able to override to use their own deployment
+  url: 'https://api.apielements.org',
+
+  parseEndpoint: '/parser',
+  validateEndpoint: '/validate',
+  serializeEndpoint: '/composer',
+
+  // the collection of "parse", media types we want this
+  // instance of the adapter to handle.
+  // NOTE, this allows you to use the API for one media type but
+  // another local adapter for another.
+  parseMediaTypes: [
+    'text/vnd.apiblueprint',
+    'application/swagger+json',
+    'application/swagger+yaml',
+    'application/vnd.oai.openapi',
+    'application/vnd.oai.openapi+json',
+  ],
+
+  // the collection of "serialize", media types we want this
+  // instance of the adapter to handle.
+  serializeMediaTypes: [
+    'application/vnd.refract+json',
+    'application/vnd.refract.parse-result+json',
+  ],
+
+  // fallback to try send input, if not indentified by deckardcain
+  defaultParseMediaType: 'text/vnd.apiblueprint',
+  defaultSerializeMediaType: 'application/vnd.refract+json',
+};
+
+const detectMediaType = (source, defaultMediaType) => {
+  const mediaType = deckardcain.identify(source);
+  return mediaType || defaultMediaType;
+};
+
+class FuryRemoteAdapter {
+  constructor(options) {
+    this.name = name;
+    this.options = options || defaultOptions;
+    const parseMediaTypes = this.options.parseMediaTypes || [];
+    const serializeMediaTypes = this.options.serializeMediaTypes || [];
+
+    this.mediaTypes = parseMediaTypes.concat(serializeMediaTypes);
+  }
+
+  detect(source) {
+    return this.mediaTypes.includes(deckardcain.identify(source));
+  }
+
+  parse({ source, minim }, cb) {
+    const inputMediaType = detectMediaType(source, this.options.defaultInputMediaType);
+
+    axios({
+      method: 'post',
+      url: this.options.parseEndpoint,
+      baseURL: this.options.url,
+      data: source,
+      headers: {
+        'Content-Type': inputMediaType,
+        Accept: outputMediaType,
+      },
+      // allow code 422 to be identified as valid response
+      validateStatus: status => ((status >= 200 && status < 300) || status === 422),
+    })
+      .then((response) => {
+        cb(null, minim.serialiser.deserialise(response.data));
+      }, (err) => {
+        cb(err, undefined);
+      });
+  }
+
+  validate({ source, minim }, cb) {
+    const inputMediaType = detectMediaType(source, this.options.defaultInputMediaType);
+
+    axios({
+      method: 'post',
+      url: this.options.validateEndpoint,
+      baseURL: this.options.url,
+      data: {
+        input_document: source,
+        input_type: inputMediaType,
+        output_type: outputMediaType,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: outputMediaType,
+      },
+    })
+      .then((response) => {
+        cb(null, minim.serialiser.deserialise(response.data));
+      }, (err) => {
+        cb(err, undefined);
+      });
+  }
+
+  serialize({ api, minim }, cb) {
+    let inputMediaType = this.options.defaultSerializeMediaType;
+    const content = minim.serialiser.serialise(api);
+
+    if (content.element && content.element === 'parseResult') {
+      inputMediaType = 'application/vnd.refract.parse-result+json';
+    }
+
+    axios({
+      method: 'post',
+      url: this.options.serializeEndpoint,
+      baseURL: this.options.url,
+      data: content,
+      headers: {
+        'Content-Type': inputMediaType,
+        Accept: 'text/vnd.apiblueprint',
+      },
+    })
+      .then((response) => {
+        cb(null, response.data);
+      }, (err) => {
+        cb(err, undefined);
+      });
+  }
+}
+
+module.exports = {
+  FuryRemoteAdapter,
+};

--- a/packages/fury-adapter-remote/package.json
+++ b/packages/fury-adapter-remote/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "fury-adapter-remote",
+  "version": "0.0.1",
+  "description": "Provide adapter for Element API based on callin remote API site",
+  "author": "Apiary.io <support@apiary.io>",
+  "license": "MIT",
+  "main": "./lib/adapter.js",
+  "homepage": "https://github.com/apiaryio/api-elements.js/tree/master/packages/fury-adapter-remote",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apiaryio/api-elements.js.git"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "mocha test"
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "dependencies": {
+    "axios": "^0.18.0",
+    "deckardcain": "^0.4.1"
+  },
+  "peerDependencies": {
+    "fury": "3.0.0-beta.8"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "eslint": "^5.15.1",
+    "fury": "3.0.0-beta.8",
+    "mocha": "^5.2.0"
+  }
+}

--- a/packages/fury-adapter-remote/package.json
+++ b/packages/fury-adapter-remote/package.json
@@ -23,12 +23,12 @@
     "deckardcain": "^0.4.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.8"
+    "fury": "3.0.0-beta.9"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^5.15.1",
-    "fury": "3.0.0-beta.8",
+    "fury": "3.0.0-beta.9",
     "mocha": "^5.2.0"
   }
 }

--- a/packages/fury-adapter-remote/test/fury-test.js
+++ b/packages/fury-adapter-remote/test/fury-test.js
@@ -1,0 +1,245 @@
+const { expect } = require('chai');
+const { Fury } = require('fury');
+const { FuryRemoteAdapter } = require('../lib/adapter');
+
+const blueprintSource = 'FORMAT: 1A\n\n# API\n\n';
+const swaggerSource = '{ "swagger": "2.0", "info": { "version": "1.0.0", "title": "swg" } }';
+const invalidSwaggerSource = '{ "swagger": "2.0", "info": { "version": 1, "title": "swg" } }';
+
+
+describe('Adapter works with Fury interface (with default config)', () => {
+  const fury = new Fury();
+
+  before(() => {
+    fury.use(new FuryRemoteAdapter()); // with predefined options
+  });
+  describe('#parse', () => {
+    it('blueprint with mediaType', () => {
+      fury.parse({ source: blueprintSource, mediaType: 'text/vnd.apiblueprint' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.api.title.toValue()).to.equal('API');
+      });
+    });
+
+    it('blueprint with autodetect', () => {
+      fury.parse({ source: blueprintSource }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.api.title.toValue()).to.equal('API');
+      });
+    });
+
+    it('valid swagger with mediaType', () => {
+      fury.parse({ source: swaggerSource, mediaType: 'application/swagger+json' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.api.title.toValue()).to.equal('swg');
+      });
+    });
+
+    it('valid swagger with autodetect', () => {
+      fury.parse({ source: swaggerSource }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.api.title.toValue()).to.equal('swg');
+      });
+    });
+
+    it('invalid swagger with mediaType', () => {
+      fury.parse({ source: invalidSwaggerSource, mediaType: 'application/swagger+json' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.length).to.be.equal(1);
+        expect(result.annotations.length).to.be.equal(1);
+        expect(result.annotations.get(0).content).to.be.equal('API version number must be a string (e.g. "1.0.0") not a number.');
+      });
+    });
+  });
+
+  describe('#validate', () => {
+    it('blueprint with mediaType', () => {
+      fury.validate({ source: blueprintSource, mediaType: 'text/vnd.apiblueprint' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.length).to.be.equal(0);
+        expect(result.annotations.length).to.be.equal(0);
+      });
+    });
+
+    it('blueprint with autodetect', () => {
+      fury.validate({ source: blueprintSource }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.length).to.be.equal(0);
+        expect(result.annotations.length).to.be.equal(0);
+      });
+    });
+
+    it('valid swagger with mediaType', () => {
+      fury.validate({ source: swaggerSource, mediaType: 'application/swagger+json' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.length).to.be.equal(0);
+        expect(result.annotations.length).to.be.equal(0);
+      });
+    });
+
+    it('valid swagger with autodetect', () => {
+      fury.validate({ source: swaggerSource }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.length).to.be.equal(0);
+        expect(result.annotations.length).to.be.equal(0);
+      });
+    });
+
+    it('invalid swagger with mediaType', () => {
+      fury.parse({ source: invalidSwaggerSource, mediaType: 'application/swagger+json' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.length).to.be.equal(1);
+        expect(result.annotations.length).to.be.equal(1);
+        expect(result.annotations.get(0).content).to.be.equal('API version number must be a string (e.g. "1.0.0") not a number.');
+      });
+    });
+  });
+
+  describe('#serialize', () => {
+    const blueprintApi = fury.minim.serialiser.deserialise({
+      element: 'category',
+      meta: {
+        classes: {
+          element: 'array',
+          content: [
+            {
+              element: 'string',
+              content: 'api',
+            },
+          ],
+        },
+        title: {
+          element: 'string',
+          content: 'API',
+        },
+      },
+      content: [],
+    });
+
+    it('ApiElements to blueprint', () => {
+      fury.serialize({ api: blueprintApi }, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.string;
+        expect(result).to.be.equal(blueprintSource);
+      });
+    });
+
+    const parseResultApi = fury.minim.serialiser.deserialise({
+      element: 'parseResult',
+      content: [
+        {
+          element: 'category',
+          meta: {
+            classes: {
+              element: 'array',
+              content: [
+                {
+                  element: 'string',
+                  content: 'api',
+                },
+              ],
+            },
+            title: {
+              element: 'string',
+              content: 'API',
+            },
+          },
+          content: [],
+        },
+      ],
+    });
+
+    it('ParseResult to blueprint', () => {
+      fury.serialize({ api: parseResultApi }, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.string;
+        expect(result).to.be.equal(blueprintSource);
+      });
+    });
+  });
+});
+
+describe('Adapter works with Fury interface', () => {
+  describe('with own config', () => {
+    const fury = new Fury();
+
+    before(() => {
+      fury.use(new FuryRemoteAdapter({
+        url: 'https://api.apielements.org',
+        parseEndpoint: '/parser',
+        parseMediaTypes: [
+          'text/vnd.apiblueprint',
+        ],
+        defaultInputMediaType: 'text/vnd.apiblueprint',
+      }));
+    });
+
+    it('parses blueprint with mediaType', () => {
+      fury.parse({ source: blueprintSource, mediaType: 'text/vnd.apiblueprint' }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.api.title.toValue()).to.equal('API');
+      });
+    });
+
+    it('parses blueprint by detection', () => {
+      fury.parse({ source: blueprintSource }, (err, result) => {
+        expect(result).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(result.api.title.toValue()).to.equal('API');
+      });
+    });
+
+    it('do not parse swagger because swagger is not in supported mediaTypes', () => {
+      fury.parse({ source: swaggerSource, mediaType: 'application/swagger+json' }, (err, result) => {
+        expect(result).to.be.undefined;
+        expect(err).to.be.instanceof(Error);
+        expect(err).to.have.property('message', 'Document did not match any registered parsers!');
+      });
+    });
+  });
+
+  describe('with nonexisting domain', () => {
+    const fury = new Fury();
+
+    before(() => {
+      fury.use(new FuryRemoteAdapter({
+        url: 'http://some.stupid.non.existing.domain',
+        parseEndpoint: '/parser',
+        parseMediaTypes: [
+          'text/vnd.apiblueprint',
+        ],
+        defaultInputMediaType: 'text/vnd.apiblueprint',
+      }));
+    });
+
+    it('parses blueprint with mediaType', () => {
+      fury.parse({ source: blueprintSource, mediaType: 'text/vnd.apiblueprint' }, (err, result) => {
+        expect(result).to.be.undefined;
+        expect(err).to.be.instanceof(Error);
+        expect(err).to.have.property('message', 'getaddrinfo ENOTFOUND some.stupid.non.existing.domain some.stupid.non.existing.domain:80');
+      });
+    });
+  });
+
+  describe('with invalid endpoint', () => {
+    const fury = new Fury();
+
+    before(() => {
+      fury.use(new FuryRemoteAdapter({
+        url: 'https://api.apielements.org',
+        parseEndpoint: '/some.weird.endpoint',
+        parseMediaTypes: [
+          'text/vnd.apiblueprint',
+        ],
+        defaultInputMediaType: 'text/vnd.apiblueprint',
+      }));
+    });
+
+    it('parses blueprint with mediaType', () => {
+      fury.parse({ source: blueprintSource, mediaType: 'text/vnd.apiblueprint' }, (err, result) => {
+        expect(result).to.be.undefined;
+        expect(err).to.be.instanceof(Error);
+        expect(err).to.have.property('message', 'Request failed with status code 500');
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,11 @@ acorn@^6.0.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
   integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
 
+acorn@^6.0.7:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
 agent-base@4, agent-base@^4.1.0, agent-base@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
@@ -873,10 +878,20 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv@^6.5.3, ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.5.3, ajv@^6.5.5:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
   integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.9.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1082,6 +1097,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
 
 babel-polyfill@6.26.0:
   version "6.26.0"
@@ -1331,7 +1354,7 @@ catharsis@~0.8.9:
   dependencies:
     underscore-contrib "~0.3.0"
 
-chai@^4.1.2:
+chai@^4.1.2, chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -1352,7 +1375,16 @@ chalk@2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1783,7 +1815,7 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1815,7 +1847,7 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-deckardcain@^0.4.0:
+deckardcain@^0.4.0, deckardcain@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deckardcain/-/deckardcain-0.4.1.tgz#16eb3ccc8e0c0e0ef71a7ed4c87cf3ab27f27e3f"
   integrity sha512-7kp5y1Zv/ej5aKoUl8Hbe56NQK3/hqBM70iyaOMyLJDd1D+UZTtLDmDaWLHFaoRCIeitt3Py2Tu4BNuYDY4zQw==
@@ -1941,6 +1973,13 @@ doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -2150,6 +2189,14 @@ eslint-scope@^4.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.2.tgz#5f10cd6cabb1965bf479fa65745673439e21cb0e"
+  integrity sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-utils@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
@@ -2159,6 +2206,48 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint@^5.15.1:
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.15.1.tgz#8266b089fd5391e0009a047050795b1d73664524"
+  integrity sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.2"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
 
 eslint@^5.9.0:
   version "5.13.0"
@@ -2208,6 +2297,15 @@ espree@^5.0.0:
   integrity sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==
   dependencies:
     acorn "^6.0.2"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
@@ -2420,6 +2518,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -2478,6 +2583,20 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -2485,6 +2604,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@^1.3.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+  dependencies:
+    debug "^3.2.6"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -2590,6 +2716,14 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+fury@3.0.0-beta.8:
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/fury/-/fury-3.0.0-beta.8.tgz#ff1d56f8e18455157d050c76f64f538d38f75940"
+  integrity sha512-9jtVYHGM4/Z1g4UFx8Sg46DLXCXzwvEI9q2Xbn4eey9+DGcJHbEKSuh/oF1sTvrjyXwQ5daH85asoCbxpHW0rA==
+  dependencies:
+    minim "^0.22.1"
+    minim-parse-result "^0.10.1"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2770,7 +2904,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -3043,7 +3177,7 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-inquirer@^6.1.0, inquirer@^6.2.0:
+inquirer@^6.1.0, inquirer@^6.2.0, inquirer@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
@@ -3730,7 +3864,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
+lodash@4.17.11, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3946,6 +4080,26 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+minim-api-description@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/minim-api-description/-/minim-api-description-0.8.1.tgz#3ce003db2aee016d9207f99c2bd90dbba3676439"
+  integrity sha512-Tby/4oxIGD+bHimYFrOuQjA2h0jbyjIt9EmCFfyAOpkDjGkFWCXvfo137w49+ToUMj30cYNGM6TXyVoX3Zuuww==
+
+minim-parse-result@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/minim-parse-result/-/minim-parse-result-0.10.1.tgz#9a38d2714c824dc4861519d2f321a8e0cb2e9154"
+  integrity sha512-FZ9uZSsJOtGQ1fPjHOoT291J0K53BlL4XphiPIZc4zwNyrlS0m7o/QhupeAJ7xKz+6FNJJDKxfzw7LijPK0WBw==
+  dependencies:
+    minim-api-description "^0.8.1"
+
+minim@^0.22.1:
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/minim/-/minim-0.22.1.tgz#8f57ed7bcab770b764a37e2056188a222b80d94a"
+  integrity sha512-wi52rk6Kbzr+OATkLJH3aCqkpFRV1w/CyniDcDAJ5fOFKdeORzfE6FI2Kg/XET9VHiIobLroBaa34DhnEs6+yQ==
+  dependencies:
+    lodash "^4.15.0"
+    uptown "^1.1.0"
+
 minim@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/minim/-/minim-0.23.1.tgz#7820c03140048183223e9a1c394fd1c638d77839"
@@ -4029,7 +4183,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-mocha@^5.0.2:
+mocha@^5.0.2, mocha@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
@@ -5236,7 +5390,14 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@2.6.3, rimraf@^2.5.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -5682,7 +5843,7 @@ swagger-schema-official@2.0.0-bab6bed:
   resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz#70070468d6d2977ca5237b2e519ca7d06a2ea3fd"
   integrity sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=
 
-table@^5.0.2:
+table@^5.0.2, table@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
   integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
@@ -5944,6 +6105,13 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+uptown@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/uptown/-/uptown-1.1.0.tgz#e3a4a91e52188ab7f6b8c35bde181bd4cb3759b7"
+  integrity sha512-8CVRVG6jNECwHMVl/i4AjmRemtNp/JwQVENdj6DLWXCk0agxY2sBNXqGEyIRhr22fLPj1AD98TK+88i+U1JsWA==
+  dependencies:
+    lodash "^4.14.2"
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -6108,6 +6276,13 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 write@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,14 +2717,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-fury@3.0.0-beta.8:
-  version "3.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/fury/-/fury-3.0.0-beta.8.tgz#ff1d56f8e18455157d050c76f64f538d38f75940"
-  integrity sha512-9jtVYHGM4/Z1g4UFx8Sg46DLXCXzwvEI9q2Xbn4eey9+DGcJHbEKSuh/oF1sTvrjyXwQ5daH85asoCbxpHW0rA==
-  dependencies:
-    minim "^0.22.1"
-    minim-parse-result "^0.10.1"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -3864,7 +3856,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
+lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -4079,26 +4071,6 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
-
-minim-api-description@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/minim-api-description/-/minim-api-description-0.8.1.tgz#3ce003db2aee016d9207f99c2bd90dbba3676439"
-  integrity sha512-Tby/4oxIGD+bHimYFrOuQjA2h0jbyjIt9EmCFfyAOpkDjGkFWCXvfo137w49+ToUMj30cYNGM6TXyVoX3Zuuww==
-
-minim-parse-result@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/minim-parse-result/-/minim-parse-result-0.10.1.tgz#9a38d2714c824dc4861519d2f321a8e0cb2e9154"
-  integrity sha512-FZ9uZSsJOtGQ1fPjHOoT291J0K53BlL4XphiPIZc4zwNyrlS0m7o/QhupeAJ7xKz+6FNJJDKxfzw7LijPK0WBw==
-  dependencies:
-    minim-api-description "^0.8.1"
-
-minim@^0.22.1:
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/minim/-/minim-0.22.1.tgz#8f57ed7bcab770b764a37e2056188a222b80d94a"
-  integrity sha512-wi52rk6Kbzr+OATkLJH3aCqkpFRV1w/CyniDcDAJ5fOFKdeORzfE6FI2Kg/XET9VHiIobLroBaa34DhnEs6+yQ==
-  dependencies:
-    lodash "^4.15.0"
-    uptown "^1.1.0"
 
 minim@^0.23.1:
   version "0.23.1"
@@ -6104,13 +6076,6 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
-
-uptown@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/uptown/-/uptown-1.1.0.tgz#e3a4a91e52188ab7f6b8c35bde181bd4cb3759b7"
-  integrity sha512-8CVRVG6jNECwHMVl/i4AjmRemtNp/JwQVENdj6DLWXCk0agxY2sBNXqGEyIRhr22fLPj1AD98TK+88i+U1JsWA==
-  dependencies:
-    lodash "^4.14.2"
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
Inital commit.

There is a few problematic parts:
- `Fury` actually does not provide way to distinguish among individual MediaTypes related to operations, so implementation returns MediaType for all types of operation
- similar problem is, there is not MediaType passed into individual operations. So we need to detect it again in adapter, but in general it can differ from MediaType specified by user.

But I mean it not should be part of this PR, it should be introduced by individual commit and changes in `remote adapter` should follow it.

Closes #143