### PR TITLE
No longer catch exceptions throw by adapters

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     'scope-enum': [2, 'always', [
       'project',
+      'core',
       'cli',
       'oas3',
       'oas2',

--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury Changelog
 
+## Master
+
+### Breaking
+
+- Fury will no longer catch exceptions thrown by an adapter during a
+  `parse`, or `serialize`.  
+  [#158](https://github.com/apiaryio/api-elements.js/issues/158)
+
 ## 3.0.0-beta.9 (2019-02-26)
 
 ### Breaking

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -105,27 +105,23 @@ class Fury {
       return done(new Error('Document did not match any registered parsers!'));
     }
 
-    try {
-      let options = { generateSourceMap, minim: this.minim, source };
+    let options = { generateSourceMap, minim: this.minim, source };
 
-      if (adapterOptions) {
-        options = Object.assign(options, adapterOptions);
+    if (adapterOptions) {
+      options = Object.assign(options, adapterOptions);
+    }
+
+    return adapter.parse(options, (err, parseResult) => {
+      if (err) {
+        return done(err);
       }
 
-      return adapter.parse(options, (err, parseResult) => {
-        if (err) {
-          return done(err);
-        }
+      if (!(parseResult instanceof this.minim.Element)) {
+        return done(null, this.load(parseResult));
+      }
 
-        if (!(parseResult instanceof this.minim.Element)) {
-          return done(null, this.load(parseResult));
-        }
-
-        return done(null, parseResult);
-      });
-    } catch (err) {
-      return done(err);
-    }
+      return done(null, parseResult);
+    });
   }
 
   /*
@@ -135,14 +131,10 @@ class Fury {
     const adapter = findAdapter(this.adapters, mediaType, 'serialize');
 
     if (adapter) {
-      try {
-        return adapter.serialize({ api, minim: this.minim }, done);
-      } catch (err) {
-        return done(err);
-      }
-    } else {
-      return done(new Error('Media type did not match any registered serializer!'));
+      return adapter.serialize({ api, minim: this.minim }, done);
     }
+
+    return done(new Error('Media type did not match any registered serializer!'));
   }
 }
 

--- a/packages/fury/test/fury-test.js
+++ b/packages/fury/test/fury-test.js
@@ -381,18 +381,6 @@ describe('Parser', () => {
       });
     });
 
-    it('should error on parser exception', (done) => {
-      const expected = new Error();
-      fury.adapters[fury.adapters.length - 1].parse = () => {
-        throw expected;
-      };
-
-      fury.parse({ source: 'dummy' }, (err) => {
-        assert.equal(err, expected);
-        done();
-      });
-    });
-
     it('should error on parser error', (done) => {
       const expectedError = new Error();
       fury.adapters[fury.adapters.length - 1].parse = (options, done2) => {
@@ -410,18 +398,6 @@ describe('Parser', () => {
       fury.adapters[fury.adapters.length - 1].parse = undefined;
       fury.parse({ source: 'dummy' }, (err) => {
         assert.instanceOf(err, Error);
-        done();
-      });
-    });
-
-    it('should error on serializer exception', (done) => {
-      const expected = new Error();
-      fury.adapters[fury.adapters.length - 1].serialize = () => {
-        throw expected;
-      };
-
-      fury.serialize({ api: 'dummy', mediaType: 'text/vnd.passthrough' }, (err) => {
-        assert.equal(err, expected);
         done();
       });
     });


### PR DESCRIPTION
BREAKING CHANGE: Internal errors may be thrown from an adapter which previously would not happen.

I think it causes more damage than this solves (such as #158) which will be tricky to solve in other ways.

There are a few ways in which numerous errors and exceptions can happen so I wanted to outline the intent:

- Fury throws an exception
    - This is generally due to unhandled errors, internal problems in the adapters that we didn't count for. Code errors. In ideal would this wouldn't happen, but here we are writing JavaScript...
    - May be when invalid input is provided to Fury such as no callback was provided.
- Fury returns an error in a callback
    - Handled errors that cause us to be unable to parse a document, such as a network timeout, etc
- Fury returns a parseResult in a callback which contains error annotations
    - The given document causes validation errors

Now, given #37 the first two error/exception cases become one. I am debating if it makes sense to keep the current callback interface and instead drop it for promises/async-await in the future (would welcome any feedback). Supporting 3 different asyncronous styles is perhaps not warranted in 2019 as the community seems to be settling with Promises and async/await. It's relatively simple to convert promise support into traditional callbacks. It's relatively easy to wrap a promise into a callback interface.

Fixes #158