### PR TITLE
Add JSDoc comments to Fury

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -28,6 +28,7 @@ const valueIsObject = R.compose(isObject, getValue);
  *
  * @param parseResult {ParseResult}
  * @returns boolean
+ * @private
  */
 const isParseResultEmpty = parseResult => R.reject(isAnnotation, parseResult).isEmpty;
 
@@ -48,6 +49,7 @@ const isParseResultEmpty = parseResult => R.reject(isAnnotation, parseResult).is
  *   the reusable component
  *
  * @returns ParseResult
+ * @private
  */
 const parseComponentMember = R.curry((context, parser, member) => {
   // Create a Member Element with `member.key` as the key
@@ -77,6 +79,7 @@ const parseComponentMember = R.curry((context, parser, member) => {
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject
+ * @private
  */
 function parseComponentsObject(context, element) {
   const { namespace } = context;
@@ -106,6 +109,7 @@ function parseComponentsObject(context, element) {
    * @param member {Member}
    *
    * @returns ParseResult
+   * @private
    */
   const parseComponentObjectMember = (parser) => {
     const parseMember = parseComponentMember(context, parser);

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseHeaderObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseHeaderObject.js
@@ -21,6 +21,7 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#headerObject
+ * @private
  */
 function parseHeaderObject(context, object) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseInfoObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseInfoObject.js
@@ -21,6 +21,7 @@ const unsupportedKeys = ['termsOfService', 'contact', 'license'];
  * @param member {MemberElement}
  * @returns {boolean}
  * @see unsupportedKeys
+ * @private
  */
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 
@@ -28,6 +29,7 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
  * Parse the OpenAPI 'Info Object' (`#/info`)
  * @see https://github.com/OAI/OpenAPI-Specification/blob/50c152549263cda0f05608d514ba78546b390d0e/versions/3.0.0.md#infoObject
  * @returns ParseResult<Category>
+ * @private
  */
 function parseInfo(context, info) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
@@ -53,6 +53,7 @@ const parseSchema = parseReference('schemas', parseSchemaObject);
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/50c152549263cda0f05608d514ba78546b390d0e/versions/3.0.0.md#media-type-object
+ * @private
  */
 function parseMediaTypeObject(context, MessageBodyClass, element) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -25,6 +25,7 @@ const unsupportedKeys = ['servers', 'security', 'tags', 'externalDocs'];
  * @param member {MemberElement}
  * @returns {boolean}
  * @see unsupportedKeys
+ * @private
  */
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOperationObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOperationObject.js
@@ -87,6 +87,7 @@ function hrefFromParameters(path, queryParameters) {
  * @returns ParseResult<Transition>
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject
+ * @private
  */
 function parseOperationObject(context, path, member) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObject.js
@@ -61,6 +61,7 @@ function validateRequiredForPathParameter(context, object, parameter) {
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject
+ * @private
  */
 function parseParameterObject(context, object) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObjects.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseParameterObjects.js
@@ -20,6 +20,7 @@ const isPathOrQuery = R.anyPass([hasKey('path'), hasKey('query')]);
  * @return {ParseResult<ObjectElement>} An object containing parameters grouped
  *   by their `in` value (`path`, `query` etc) as members. The object can
  *   be treated as a "named tuple".
+ * @private
  */
 function parseParameterObjects(context, name, array) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathItemObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathItemObject.js
@@ -24,6 +24,7 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
  * For example `/{resource}` would return `['resource']`
  * @param path {string}
  * @return array
+ * @private
  */
 function extractPathVariables(path) {
   const matches = path.match(/({.*?})/gm);
@@ -45,6 +46,7 @@ function createErrorForMissingPathVariable(namespace, path, variable) {
  * @param path {StringElement}
  * @param hrefVariables {HrefVariables}
  * @retuns ParseResult<HrefVariables>
+ * @private
  */
 const validateHrefVariablesInPath = R.curry((namespace, path, hrefVariables) => {
   const pathVariables = extractPathVariables(path.toValue());
@@ -65,6 +67,7 @@ const validateHrefVariablesInPath = R.curry((namespace, path, hrefVariables) => 
  * @param namespace
  * @param path {StringElement}
  * @param member {MemberElement} parameters member from an object element
+ * @private
  */
 function parseParameters(context, path, member) {
   const { namespace } = context;
@@ -114,6 +117,7 @@ function hrefFromParameters(path, parameters) {
  * Parse Path Item Object
  * @returns Resource
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#path-item-object
+ * @private
  */
 function parsePathItemObject(context, member) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathsObject.js
@@ -13,6 +13,7 @@ const isPathField = member => member.key.toValue().startsWith('/');
  * Parse Paths Object
  * @returns ParseResult<Resource>
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathsObject
+ * @private
  */
 function parsePaths(context, paths) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
@@ -23,6 +23,7 @@ const requiredKeys = ['$ref'];
  * element was not successfully parsed, an empty parse result.
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#referenceObject
+ * @private
  */
 function parseReferenceObject(context, componentName, element, returnReferenceElement) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseRequestBodyObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseRequestBodyObject.js
@@ -29,6 +29,7 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject
+ * @private
  */
 function parseRequestBodyObject(context, element) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponseObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponseObject.js
@@ -32,6 +32,7 @@ const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject
+ * @private
  */
 function parseResponseObject(context, element) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponsesObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseResponsesObject.js
@@ -33,6 +33,7 @@ const isKeyString = R.compose(isString, getKey);
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject
+ * @private
  */
 function parseResponsesObject(context, element) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSchemaObject.js
@@ -228,6 +228,7 @@ function parseSchema(context) {
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
+ * @private
  */
 function parseSchemaObject(context, element) {
   const DataStructure = R.constructN(1, context.namespace.elements.DataStructure);

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecurityRequirementObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecurityRequirementObject.js
@@ -15,6 +15,7 @@ const name = 'Security Requirement Object';
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securityRequirementObject
+ * @private
  */
 function parseSecurityRequirementObject(context, object) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js
@@ -81,6 +81,7 @@ function validateHttpScheme(context, securityScheme) {
  * @returns ParseResult
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
+ * @private
  */
 function parseSecuritySchemeObject(context, object) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseArray.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseArray.js
@@ -11,6 +11,7 @@ const parseResultHasErrors = parseResult => !parseResult.errors.isEmpty;
  * Transform every non-annotation element in the parse result and then flatten all of the results into a parse result
  * @param transform {function}
  * @param parseResult {ParseResult}
+ * @private
  */
 const chainParseResult = R.curry((transform, parseResult) => {
   const result = R.chain(transform, parseResult);
@@ -28,6 +29,7 @@ const chainParseResult = R.curry((transform, parseResult) => {
  * @callback transformValue
  * @param element {Element}
  * @returns {Element} Either a ParseResult to be unwrapped, or an element
+ * @private
  */
 
 /**
@@ -58,6 +60,7 @@ const chainParseResult = R.curry((transform, parseResult) => {
  * @param array {ArrayElement} - The array containing values to transform
  *
  * @returns {ParseResult<ArrayElement>}
+ * @private
  */
 function parseArray(context, name, parseValue) {
   const { namespace } = context;
@@ -73,6 +76,7 @@ function parseArray(context, name, parseValue) {
    * Converts the given parse result of values into parse result of an array
    * @param parseResult {ParseResult<Element>}
    * @returns {ParseResult<Array>}
+   * @private
    */
   const convertParseResultMembersToArray = (parseResult) => {
     const values = R.reject(isAnnotation, parseResult);

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseBoolean.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseBoolean.js
@@ -9,6 +9,7 @@ const {
  * Returns true iff the given member elements value is a boolean
  * @param member {MemberElement}
  * @returns {boolean}
+ * @private
  */
 const isValueBoolean = R.compose(isBoolean, getValue);
 
@@ -18,6 +19,7 @@ const isValueBoolean = R.compose(isBoolean, getValue);
  * @param member {MemberElement}
  *
  * @returns {ParseResult<MemberElement<BooleanElement>>}
+ * @private
  */
 const parseOptionalBoolean = (context, name, member) => new context.namespace.elements.ParseResult([
   R.unless(
@@ -33,6 +35,7 @@ const parseOptionalBoolean = (context, name, member) => new context.namespace.el
  * @param member {MemberElement}
  *
  * @returns {ParseResult<MemberElement<BooleanElement>>}
+ * @private
  */
 const parseRequiredBoolean = (context, name, member) => new context.namespace.elements.ParseResult([
   R.unless(
@@ -49,6 +52,7 @@ const parseRequiredBoolean = (context, name, member) => new context.namespace.el
  * @pram required {boolean} - Whether the member is required, indicates if we return a warning or an error
  * @pram member {MemberElement}
  * @returns {ParseResult<MemberElement<BooleanElement>>}
+ * @private
  */
 function parseBoolean(context, name, required, member) {
   if (required) {

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseCopy.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseCopy.js
@@ -15,6 +15,7 @@ const createCopy = R.curry((namespace, element) => {
  * @pram required {boolean} - Whether the member is required, indicates if we return a warning or an error
  * @pram member {MemberElement}
  * @returns {ParseResult<MemberElement<Copy>>}
+ * @private
  */
 function parseCopy(context, name, required, member) {
   const parseResult = parseString(context, name, required, member);

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseMap.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseMap.js
@@ -37,6 +37,7 @@ const parseMapMember = R.curry((context, parser, member) => {
  * @param member {Member}
  *
  * @returns ParseResult
+ * @private
  */
 const parseMap = (context, name, key, valueParser) => pipeParseResult(context.namespace,
   validateMapValueIsObject(context.namespace, name, key),

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseObject.js
@@ -9,6 +9,7 @@ const pipeParseResult = require('../pipeParseResult');
  * Returns true iff the given element is either an annotation or member element
  * @param element {Element}
  * @returns {boolean}
+ * @private
  */
 const isAnnotationOrMember = R.anyPass([isAnnotation, isMember]);
 
@@ -16,6 +17,7 @@ const isAnnotationOrMember = R.anyPass([isAnnotation, isMember]);
  * Transform every non-annotation element in the parse result and then flatten all of the results into a parse result
  * @param transform {function}
  * @param parseResult {ParseResult}
+ * @private
  */
 const chainParseResult = R.curry((transform, parseResult) => {
   const result = R.chain(transform, parseResult);
@@ -66,6 +68,7 @@ const validateObjectContainsRequiredKeysNoError = R.curry((namespace, requiredKe
  * @callback transformMember
  * @param member {MemberElement}
  * @returns {Element} Either a ParseResult to be unwrapped, or an element
+ * @private
  */
 
 /**
@@ -98,6 +101,7 @@ const validateObjectContainsRequiredKeysNoError = R.curry((namespace, requiredKe
  * @param object {ObjectElement} - The object containing members to transform
  *
  * @returns {ParseResult<ObjectElement>}
+ * @private
  */
 function parseObject(context, name, parseMember, requiredKeys = [], sendWarning = false) {
   const { namespace } = context;
@@ -124,6 +128,7 @@ function parseObject(context, name, parseMember, requiredKeys = [], sendWarning 
    * Converts the given parse result of members into parse result of an object
    * @param parseResult {ParseResult<Member>}
    * @returns {ParseResult<Object>}
+   * @private
    */
   const convertParseResultMembersToObject = (parseResult) => {
     const members = R.filter(isMember, parseResult);

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseString.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseString.js
@@ -9,6 +9,7 @@ const {
  * Returns true iff the given member elements value is a string
  * @param member {MemberElement}
  * @returns {boolean}
+ * @private
  */
 const isValueString = R.compose(isString, getValue);
 
@@ -18,6 +19,7 @@ const isValueString = R.compose(isString, getValue);
  * @param member {MemberElement}
  *
  * @returns {ParseResult<MemberElement<StringElement>>}
+ * @private
  */
 const parseOptionalString = (namespace, name, member) => new namespace.elements.ParseResult([
   R.unless(
@@ -33,6 +35,7 @@ const parseOptionalString = (namespace, name, member) => new namespace.elements.
  * @param member {MemberElement}
  *
  * @returns {ParseResult<MemberElement<StringElement>>}
+ * @private
  */
 const parseRequiredString = (namespace, name, member) => new namespace.elements.ParseResult([
   R.unless(
@@ -49,6 +52,7 @@ const parseRequiredString = (namespace, name, member) => new namespace.elements.
  * @pram required {boolean} - Whether the member is required, indicates if we return a warning or an error
  * @pram member {MemberElement}
  * @returns {ParseResult<MemberElement<StringElement>>}
+ * @private
  */
 function parseString(context, name, required, member) {
   const { namespace } = context;

--- a/packages/fury-adapter-oas3-parser/lib/pipeParseResult.js
+++ b/packages/fury-adapter-oas3-parser/lib/pipeParseResult.js
@@ -5,6 +5,7 @@ const { isAnnotation, isParseResult } = require('./predicates');
  * Returns true iff the parse result does not contain errors
  * @param parseResult {ParseResult}
  * @returns boolean
+ * @private
  */
 const hasNoErrors = parseResult => parseResult.errors.isEmpty;
 
@@ -12,6 +13,7 @@ const hasNoErrors = parseResult => parseResult.errors.isEmpty;
  * Returns true iff the parse result contains non-annotation values
  * @param parseResult {ParseResult}
  * @returns boolean
+ * @private
  */
 const hasValue = parseResult => !R.reject(isAnnotation, parseResult).isEmpty;
 
@@ -27,6 +29,7 @@ const hasNoErrorsAndHasValue = R.allPass([hasNoErrors, hasValue]);
  * @param lhs {Element[]}
  * @param rhs {Element[]}
  * @returns {ParseResult}
+ * @private
  */
 function concatParseResult(namespace, lhs, rhs) {
   return new namespace.elements.ParseResult(lhs.concat(rhs));
@@ -47,6 +50,7 @@ function concatParseResult(namespace, lhs, rhs) {
  * @param {...Function} functions
  * @return {Function}
  * @see R.pipe
+ * @private
  */
 function pipeParseResult(namespace, ...functions) {
   // Return a closure that takes the element to pipe

--- a/packages/fury-adapter-oas3-parser/lib/predicates.js
+++ b/packages/fury-adapter-oas3-parser/lib/predicates.js
@@ -1,6 +1,9 @@
 const R = require('ramda');
 
-/** @module predicates */
+/**
+ * @module predicates
+ * @private
+ */
 
 const isArray = element => element.element === 'array';
 const isAnnotation = element => element.element === 'annotation';
@@ -19,6 +22,7 @@ const isDataStructure = element => element.element === 'dataStructure';
  * @param key {string}
  * @param member {MemberElement}
  * @returns {boolean}
+ * @private
  */
 const hasKey = (key, member) => member.key.toValue() === key;
 
@@ -27,6 +31,7 @@ const hasKey = (key, member) => member.key.toValue() === key;
  * @param value {string}
  * @param member {MemberElement}
  * @returns {boolean}
+ * @private
  */
 const hasValue = (value, member) => member.value.toValue() === value;
 
@@ -34,6 +39,7 @@ const hasValue = (value, member) => member.value.toValue() === value;
  * Returns whether the given member element is a an OpenAPI extension.
  * @param member {MemberElement}
  * @returns {boolean}
+ * @private
  */
 const isExtension = member => member.key && isString(member.key) && member.key.toValue().startsWith('x-');
 
@@ -41,6 +47,7 @@ const isExtension = member => member.key && isString(member.key) && member.key.t
  * Returns the key for the given member element
  * @param member {MemberElement}
  * @returns {Element}
+ * @private
  */
 const getKey = member => member.key;
 
@@ -48,6 +55,7 @@ const getKey = member => member.key;
  * Returns the value for the given member element
  * @param member {MemberElement}
  * @returns {Element}
+ * @private
  */
 const getValue = member => member.value;
 

--- a/packages/fury-adapter-swagger/lib/adapter.js
+++ b/packages/fury-adapter-swagger/lib/adapter.js
@@ -21,6 +21,9 @@ const parse = (options, done) => {
   parser.parse(done);
 };
 
+/**
+ * @implements {FuryAdapter}
+ */
 module.exports = {
   name, mediaTypes, detect, parse,
 };

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -36,6 +36,8 @@ const parseReference = (reference) => {
  * @param reference {string} - Example: #/definitions/User/properties/name
  * @param root {object} - The object to resolve the given reference
  * @param depth {number} - A limit to resolving the depth
+ *
+ * @private
  */
 const lookupReference = (reference, root, depth) => {
   const parts = reference.split('/').reverse();
@@ -210,7 +212,10 @@ const convertSubSchema = (schema, references, swagger) => {
   return actualSchema;
 };
 
-/** Returns true if the given schema contains any references
+/**
+ * Returns true if the given schema contains any references
+ *
+ * @private
  */
 const checkSchemaHasReferences = (schema) => {
   if (!schema) {
@@ -234,8 +239,10 @@ const checkSchemaHasReferences = (schema) => {
   });
 };
 
-/** Traverses the entire schema to find all of the references
+/**
+ * Traverses the entire schema to find all of the references
  * @returns array of each reference that is found in the schema
+ * @private
  */
 const findReferences = (schema) => {
   if (schema.$ref) {
@@ -295,11 +302,13 @@ const findReferences = (schema) => {
   return references;
 };
 
-/** Convert Swagger schema to JSON Schema
+/**
+ * Convert Swagger schema to JSON Schema
  * @param schema - The Swagger schema to convert
  * @param root - The document root (this contains the JSON schema definitions)
  * @param swagger - The swagger document root (this contains the Swagger schema definitions)
  * @param copyDefinitins - Whether to copy the referenced definitions to the resulted schema
+ * @private
  */
 const convertSchema = (schema, root, swagger, copyDefinitions = true) => {
   let references = [];

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -19,14 +19,67 @@ const findAdapter = (adapters, mediaType, method) => {
   return null;
 };
 
+/**
+ * @interface FuryAdapter
+ *
+ * @property name {string}
+ * @property mediaTypes {string[]}
+ */
+
+/**
+ * @function detect
+ *
+ * @param source {string}
+ * @returns {boolean}
+ *
+ * @memberof FuryAdapter
+ */
+
+/**
+ * @function validate
+ *
+ * @param {Object} options
+ * @param {string} options.source
+ * @param {Namespace} options.minim
+ * @param {ParseCallback} callback
+ *
+ * @memberof FuryAdapter
+ */
+
+/**
+ * @function parse
+ *
+ * @param {Object} options
+ * @param {string} options.source
+ * @param {Namespace} options.minim
+ * @param {ParseCallback} callback
+ *
+ * @memberof FuryAdapter
+ */
+
+/**
+ * @function serialize
+ *
+ * @param {Object} options
+ * @param {Category} options.api
+ * @param {Namespace} options.minim
+ * @param {SerializeCallback} callback
+ *
+ * @memberof FuryAdapter
+ */
+
+/**
+ */
 class Fury {
   constructor() {
     this.minim = minim;
     this.adapters = [];
   }
 
-  /*
+  /**
    * Register to use an adapter with this Fury instance.
+   *
+   * @param {FuryAdapter}
    */
   use(adapter) {
     this.adapters.push(adapter);
@@ -40,7 +93,13 @@ class Fury {
     return this.minim.fromRefract(elements);
   }
 
-  // Returns an array of adapters which can handle the given API Description Source
+  /**
+   * Returns an array of adapters which can handle the given API Description Source
+   *
+   * @param source {string}
+   *
+   * @return {FuryAdapter}
+   */
   detect(source) {
     return this.adapters.filter(adapter => adapter.detect && adapter.detect(source));
   }
@@ -53,6 +112,22 @@ class Fury {
     return this.detect(source).filter(adapter => adapter[method])[0];
   }
 
+  /**
+   * @callback ParseCallback
+   *
+   * @param {Error} error
+   * @param {ParseResult} parseResult
+   */
+
+  /**
+   * Validate an API Description Document
+   *
+   * @param {Object} options
+   * @param {string} options.source
+   * @param {string} [options.mediaType]
+   * @param {Object} [options.adapterOptions]
+   * @param callback {ParseCallback}
+   */
   validate({ source, mediaType, adapterOptions }, done) {
     const adapter = this.findAdapter(source, mediaType, 'validate');
 
@@ -90,11 +165,18 @@ class Fury {
     });
   }
 
-  /*
-   * Parse an input document into Javascript objects. This method uses
-   * the registered adapters to automatically detect the input format,
-   * then uses the adapter to convert into refract elements and loads
-   * these into objects.
+  /**
+   * Parse an API Description Document
+   *
+   * This method uses the registered adapters to automatically detect the
+   * input format, then uses the adapter to convert into refract elements
+   * and loads these into objects.
+   *
+   * @param {Object} options
+   * @param {string} options.source
+   * @param {string} [options.mediaType]
+   * @param {Object} [options.adapterOptions]
+   * @param callback {ParseCallback}
    */
   parse({
     source, mediaType, generateSourceMap = false, adapterOptions,
@@ -128,8 +210,20 @@ class Fury {
     }
   }
 
-  /*
-   * Serialize a parsed API into the given output format.
+  /**
+   * @callback SerializeCallback
+   *
+   * @param {Error} error
+   * @param {string} source
+   */
+
+  /**
+   * Serialize an API Description into the given output format.
+   *
+   * @param {Object} options
+   * @param {Category} options.api
+   * @param {string} [options.mediaType]
+   * @param callback {SerializeCallback}
    */
   serialize({ api, mediaType = 'text/vnd.apiblueprint' }, done) {
     const adapter = findAdapter(this.adapters, mediaType, 'serialize');


### PR DESCRIPTION
I think it can be unclear what the public API to Fury, and the API between Fury and adapters actually is, so I have added documentation describing the properties and types. This isn't complete, it's to kick it off. I think next step we need to integrate it into our Sphinx docs. I have not really written much about any of the interface, this is more specifying the structures and types at the moment.

In doing so, I've updated existing jsdoc comments on internal interfaces to `@private` so they don't show up. Those developing can generate documentation exposing private interfaces. Perhaps we can host internal API docs too in Sphinx at a later date.

```shell
$ jsdoc --recurse packages/*/lib node_modules/minim/lib/
```

Using jsdoc I've generated the docs and put them online at https://apielements.rigidapp.com/Fury.html to make it easier to review.