### PR TITLE
Fury support detection by method

### DIFF
--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancement
 
 - Fury now pass into operations parse(), validate(), serialize() mediaType as one of adapter options
+- Fury now allows distinguish among Media Types for individual oprations (for more info see README)
 
 ## 3.0.0-beta.9 (2019-02-26)
 

--- a/packages/fury/README.md
+++ b/packages/fury/README.md
@@ -117,15 +117,41 @@ fury1.parse(...);
 
 Adapters convert from an input format such as API Blueprint into refract elements. This allows a single, consistent interface to be used to interact with multiple input API description formats. Writing your own adapter allows you to add support for new input formats.
 
+Note about `mediaTypes`: it allows two kinds of definitions. First one is **array** type. It is intended to "catch all" implementation.
+It is useful if your adapter implements only one of fury methods, or if all methods accepts same types of Media Type.
+
+Another possible option is to use object with mapping name of method to array of MediaTypes. It allows better granularity for detection.
+
+Examples:
+
+If your adapter support just one method or all methods supports same kind of input Media Type:
+
+```js
+export const mediaTypes = ['text/vnd.my-adapter'];
+```
+
+If you need to distinguish among supported input Media Types for methods use:
+
+```js
+export const mediaTypes = {
+  parse: ['text/vnd.my-parsing', 'text/vnd.another-supported-parsing],
+  serialize: ['text/vnd.my-serialization'],
+  };
+```
+
+
 Adapters are made up of a name, a list of media types, and up to three optional public functions: `detect`, `parse`, and `serialize`. A simple example might look like this:
 
 ```js
 export const name = 'my-adapter';
 export const mediaTypes = ['text/vnd.my-adapter'];
 
-export function detect(source) {
+export function detect(source[, method]) {
   // If no media type is know, then we fall back to auto-detection. Here you
   // can check the source and see if you think you can parse it.
+  // 
+  // optional parmeter `method` give you hint about caller is going to invoke
+  // note that value can be undefined
   return source.match(/some-test/i) !== null;
 }
 

--- a/packages/fury/README.md
+++ b/packages/fury/README.md
@@ -134,7 +134,7 @@ If you need to distinguish among supported input Media Types for methods use:
 
 ```js
 export const mediaTypes = {
-  parse: ['text/vnd.my-parsing', 'text/vnd.another-supported-parsing],
+  parse: ['text/vnd.my-parsing', 'text/vnd.another-supported-parsing'],
   serialize: ['text/vnd.my-serialization'],
   };
 ```

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -11,8 +11,11 @@ const minim = minimModule.namespace()
  */
 const findAdapter = (adapters, mediaType, method) => {
   for (let i = 0; i < adapters.length; i += 1) {
-    if (adapters[i].mediaTypes.indexOf(mediaType) !== -1 && adapters[i][method]) {
-      return adapters[i];
+    const adapter = adapters[i];
+    if (Array.isArray(adapter.mediaTypes) && adapter.mediaTypes.includes(mediaType) && adapter[method]) {
+      return adapter;
+    } if (typeof adapter.mediaTypes === 'object' && adapter.mediaTypes[method] && adapter.mediaTypes[method].includes(mediaType) && adapter[method]) {
+      return adapter;
     }
   }
 
@@ -95,13 +98,17 @@ class Fury {
 
   /**
    * Returns an array of adapters which can handle the given API Description Source
+   * it is internali invoked while `mediaType` is not sent
+   * into methods `parse()`, `validate()` or `serialized()`
    *
    * @param source {string}
+   * @param method {string} - optional
    *
    * @return {FuryAdapter}
    */
-  detect(source) {
-    return this.adapters.filter(adapter => adapter.detect && adapter.detect(source));
+  detect(source, method) {
+    const adapters = this.adapters.filter(adapter => (adapter.detect && adapter.detect(source, method)) && (method === undefined || adapter[method]));
+    return adapters;
   }
 
   findAdapter(source, mediaType, method) {

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -98,7 +98,7 @@ class Fury {
 
   /**
    * Returns an array of adapters which can handle the given API Description Source
-   * it is internali invoked while `mediaType` is not sent
+   * it is internally invoked while `mediaType` is not sent
    * into methods `parse()`, `validate()` or `serialized()`
    *
    * @param source {string}


### PR DESCRIPTION
Fury now internally call `detect()` method with parameter `method`
It allows to adapter distinguish among supported method for given
operation instead "catch all" implementation.

Calling with `method` parameter is optional old backward compatible
style is fully supported as before.

Support `mediaTypes` two diferent formats, first is "catch all" and
backward compatilble array:
```
AdapterWithArrayMediaTypes = {
 ...
  mediaTypes: [
    'text/vnd.parseable',
    'text/vnd.serializable',
  ]
  ...
}
```

And advanced definition which better granularity to allows distinguish
among individual supported mediaTypes with relation to operation

```
AdapterWithObjectMediaTypes = {
 ...
  mediaTypes: {
    parse: [ 'text/vnd.parseable' ],
    serialize: [ 'text/vnd.serializable' ],
  ...
}
```