### PR TITLE
Fix handling of YAML errors while scanning for next token in OAS 3

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
@@ -110,12 +110,15 @@ function parse(source, context) {
       `YAML Syntax: ${error.context}`,
       { classes: ['error'] }
     );
+
+    const marker = error.context_mark || error.problem_mark;
     copySourceMap(
-      error.context_mark,
-      error.context_mark,
+      marker,
+      marker,
       annotation,
       namespace
     );
+
     parseResult.push(annotation);
     return parseResult;
   }

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/parseYAML-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/parseYAML-test.js
@@ -13,13 +13,24 @@ describe('#parseYAML', () => {
     context = new Context(namespace, { generateSourceMap: true });
   });
 
-  it('fails to parse an OAS3 document with invalid YAML', () => {
-    const parseResult = parseYAML('{}{}', context);
+  describe('error handling', () => {
+    it('fails to parse an OAS3 document with invalid YAML', () => {
+      const parseResult = parseYAML('{}{}', context);
 
-    expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
-    expect(parseResult.errors.length).to.equal(1);
+      expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
+      expect(parseResult.errors.length).to.equal(1);
 
-    expect(parseResult).contain.error("YAML Syntax: expected '<document start>', but found {").with.sourceMap([[2, 0]]);
+      expect(parseResult).contain.error("YAML Syntax: expected '<document start>', but found {").with.sourceMap([[2, 0]]);
+    });
+
+    it('fails to parse an OAS3 document while scanning for next token', () => {
+      const parseResult = parseYAML('openapi: 3.0.0\t', context);
+
+      expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
+      expect(parseResult.errors.length).to.equal(1);
+
+      expect(parseResult).contain.error('YAML Syntax: while scanning for the next token').with.sourceMap([[14, 0]]);
+    });
   });
 
   it('can parse a string into a string element', () => {


### PR DESCRIPTION
Discovered the following:

```json
{
    "errorMessage": "Cannot read property 'pointer' of null",
    "errorType": "TypeError",
    "stackTrace": [
        "copySourceMap (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser/parseYAML.js:21:15)",
        "parse (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser/parseYAML.js:113:5)",
        "parse (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser.js:13:20)",
        "Object.parse (/var/task/node_modules/fury-adapter-oas3-parser/lib/adapter.js:23:23)",
        "Fury.parse (/var/task/node_modules/fury/lib/fury.js:115:22)",
        "parseFury (/var/task/lib/parser.js:63:8)",
        "Object.parse (/var/task/lib/parser.js:51:3)",
        "parse (/var/task/lib/transform.js:21:10)",
        "nextTask (/var/task/node_modules/async/dist/async.js:5310:14)",
        "next (/var/task/node_modules/async/dist/async.js:5317:9)"
    ]
}
```

I found some YAML errors don't contain context_mark and thus the above exception is thrown, instead there is problem_mark for some types of errors. I'll comment in the tests with the actual exception below.