### PR TITLE
Fix handling of invalid schema components

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Added primitive support for generating a JSON message body from a schema for
   JSON media types. Referencing is not supported for this feature.
 
+### Bug Fixes
+
+- Prevents an exception being raised due to improper handling of invalid
+  schemas found in the reusable components section of an OpenAPI 3 document.
+
 ## 0.6.0 (2019-02-26)
 
 ### Enhancements

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -120,8 +120,12 @@ function parseComponentsObject(context, element) {
       R.compose(parseObject(context, name, parseMember), getValue));
   };
 
-  // eslint-disable-next-line no-param-reassign
-  const setDataStructureId = (dataStructure, key) => { dataStructure.content.id = key.clone(); };
+  const setDataStructureId = (dataStructure, key) => {
+    if (dataStructure) {
+      // eslint-disable-next-line no-param-reassign
+      dataStructure.content.id = key.clone();
+    }
+  };
   const parseSchemas = pipeParseResult(namespace,
     parseComponentObjectMember(parseSchemaObject),
     (object) => {

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -144,11 +144,14 @@ function parseOASObject(context, object) {
 
       const components = object.get('components');
       if (components) {
-        const schemas = components.get('schemas');
-        if (schemas) {
+        const schemas = R.or(components.get('schemas'), new namespace.elements.Array())
+          .content
+          .filter(member => member.value)
+          .map(getValue);
+
+        if (schemas.length > 0) {
           const dataStructures = new namespace.elements.Category(
-            schemas.content.map(getValue),
-            { classes: ['dataStructures'] }
+            schemas, { classes: ['dataStructures'] }
           );
           api.push(dataStructures);
         }
@@ -156,7 +159,6 @@ function parseOASObject(context, object) {
 
       return api;
     });
-
 
   if (context.options.generateSourceMap) {
     return filterColumnLine(parseOASObject(object));

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -50,6 +50,27 @@ describe('Components Object', () => {
       expect(schemas).to.be.instanceof(namespace.elements.Object);
       expect(schemas.get('User')).to.be.instanceof(namespace.elements.DataStructure);
     });
+
+    it('parses invalid schema into empty member', () => {
+      const components = new namespace.elements.Object({
+        schemas: {
+          User: null,
+        },
+      });
+
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(2);
+
+      const parsedComponents = parseResult.get(0);
+      expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
+
+      const schemas = parsedComponents.get('schemas');
+      expect(schemas).to.be.instanceof(namespace.elements.Object);
+
+      const member = schemas.getMember('User');
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.undefined;
+    });
   });
 
   describe('#parameters', () => {

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
@@ -47,36 +47,59 @@ describe('#parseOpenAPIObject', () => {
     expect(parseResult.api.get(0).href.toValue()).to.equal('/');
   });
 
-  it('can parse a document with schema components into data structures', () => {
-    const object = new namespace.elements.Object({
-      openapi: '3.0.0',
-      info: {
-        title: 'My API',
-        version: '1.0.0',
-      },
-      paths: {},
-      components: {
-        schemas: {
-          User: {
-            type: 'object',
+  describe('with schema components', () => {
+    it('can parse a document with schema components into data structures', () => {
+      const object = new namespace.elements.Object({
+        openapi: '3.0.0',
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        paths: {},
+        components: {
+          schemas: {
+            User: {
+              type: 'object',
+            },
           },
         },
-      },
+      });
+
+      const parseResult = parse(context, object);
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.api.title.toValue()).to.equal('My API');
+      expect(parseResult.api.length).to.equal(1);
+
+      const dataStructures = parseResult.api.get(0);
+      expect(dataStructures).to.be.instanceof(namespace.elements.Category);
+      expect(dataStructures.classes.toValue()).to.deep.equal(['dataStructures']);
+      expect(dataStructures.length).to.equal(1);
+
+      const userStructure = dataStructures.get(0);
+      expect(userStructure).to.be.instanceof(namespace.elements.DataStructure);
+      expect(userStructure.content.id.toValue()).to.equal('User');
     });
 
-    const parseResult = parse(context, object);
-    expect(parseResult.length).to.equal(1);
-    expect(parseResult.api.title.toValue()).to.equal('My API');
-    expect(parseResult.api.length).to.equal(1);
+    it('can parse a document with invalid schema component', () => {
+      const object = new namespace.elements.Object({
+        openapi: '3.0.0',
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        paths: {},
+        components: {
+          schemas: {
+            User: null,
+          },
+        },
+      });
 
-    const dataStructures = parseResult.api.get(0);
-    expect(dataStructures).to.be.instanceof(namespace.elements.Category);
-    expect(dataStructures.classes.toValue()).to.deep.equal(['dataStructures']);
-    expect(dataStructures.length).to.equal(1);
-
-    const userStructure = dataStructures.get(0);
-    expect(userStructure).to.be.instanceof(namespace.elements.DataStructure);
-    expect(userStructure.content.id.toValue()).to.equal('User');
+      const parseResult = parse(context, object);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult.api.title.toValue()).to.equal('My API');
+      expect(parseResult.api.isEmpty).to.be.true;
+    });
   });
 
   it('provides error for missing openapi version', () => {


### PR DESCRIPTION
I discovered two bugs that caused invalid schema objects inside a componenent object to cause an exception to be thrown due to our processing. For example using the following OAS 3 document:

```yaml
openapi: 3.0.0
info:
  title: bar
  version: 1.0.0
paths: {}
components:
  schemas:
    Foo: null
```

The following error would be thrown:

```json
{ "errorMessage": "Cannot read property 'content' of undefined", "errorType": "TypeError", "stackTrace": [ "setDataStructureId (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js:118:70)", "content.forEach.item (/var/task/node_modules/minim/lib/primitives/ObjectElement.js:203:63)", "Array.forEach (<anonymous>)", "ObjectElement.forEach (/var/task/node_modules/minim/lib/primitives/ObjectElement.js:203:25)", "pipeParseResult (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js:122:14)", "run (/var/task/node_modules/fury-adapter-oas3-parser/lib/pipeParseResult.js:56:25)", "XWrap.f (/var/task/node_modules/ramda/src/reduceWhile.js:40:27)", "XWrap.@@transducer/step (/var/task/node_modules/ramda/src/internal/_xwrap.js:12:17)", "_arrayReduce (/var/task/node_modules/ramda/src/internal/_reduce.js:11:34)", "_reduce (/var/task/node_modules/ramda/src/internal/_reduce.js:45:12)" ] }
```

Instead the user should get a warning:

> warning: 'Schema Object' is not an object - line 8
