### PR TITLE
Referenced data structures are now correct type

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 - Added support for header parameters.
 
+- Instances of referenced data structures will now be instances of the
+  referenced type.
+
+  For example, given a schema named 'username' contains `type: string`.
+  When another data structure references the 'username' schema, it's instance
+  will be a `StringElement`.
+
 ### Bug Fixes
 
 - Prevents an exception being raised due to improper handling of invalid

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseReferenceObject.js
@@ -59,7 +59,16 @@ function parseReferenceObject(context, componentName, element, returnReferenceEl
     }
 
     if (returnReferenceElement) {
-      const element = new context.namespace.elements.Element();
+      let Element;
+
+      const referenced = component.get(componentId);
+      if (referenced instanceof context.namespace.elements.DataStructure) {
+        Element = referenced.content.constructor;
+      } else {
+        ({ Element } = context.namespace.elements);
+      }
+
+      const element = new Element();
       element.element = componentId;
       return element;
     }

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/media-type-object-schema.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/media-type-object-schema.json
@@ -83,6 +83,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{}"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "User"

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
@@ -136,6 +136,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[]"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "Pets"
@@ -289,6 +310,27 @@
                         }
                       },
                       "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[]"
+                        },
                         {
                           "element": "dataStructure",
                           "content": {

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -386,6 +386,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[]"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "Pets"
@@ -814,6 +835,27 @@
                         }
                       },
                       "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[]"
+                        },
                         {
                           "element": "dataStructure",
                           "content": {

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseReferenceObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseReferenceObject-test.js
@@ -14,6 +14,7 @@ describe('Reference Object', () => {
 
     dataStructure = new namespace.elements.DataStructure();
     dataStructure.id = 'Node';
+    dataStructure.content = new namespace.elements.Object();
 
     context.state.components = new namespace.elements.Object({
       schemas: {
@@ -21,7 +22,6 @@ describe('Reference Object', () => {
       },
     });
   });
-
 
   it('errors when parsing non-string $ref', () => {
     const reference = new namespace.elements.Object({
@@ -41,6 +41,19 @@ describe('Reference Object', () => {
     expect(parseResult.length).to.equal(1);
     const structure = parseResult.get(0);
     expect(structure).to.equal(dataStructure);
+  });
+
+  it('can parse a reference and return reference', () => {
+    const reference = new namespace.elements.Object({
+      $ref: '#/components/schemas/Node',
+    });
+    const parseResult = parse(context, 'schemas', reference, true);
+
+    expect(parseResult.length).to.equal(1);
+
+    const structure = parseResult.get(0);
+    expect(structure.element).to.equal('Node');
+    expect(structure).to.be.instanceof(namespace.elements.Object);
   });
 
   it('can parse a reference to a component with multiple values', () => {


### PR DESCRIPTION
This fixes internal state and fixes empty value generation for referenced types. This also makes it so anyone using the adapter will also have correct type. Such as "instanceof StringElement" will pass for stringly referenced types. Expected properties such as `length` will now be available on referenced strings etc.