### PR TITLE
Handle pre-parsing object members in parseObject

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -109,15 +109,19 @@ function parseComponentsObject(context, element) {
    * @param parser {function}
    * @param member {Member}
    *
-   * @returns ParseResult
+   * @returns ParseResult<ObjectElement>
    * @private
    */
   const parseComponentObjectMember = (parser) => {
     const parseMember = parseComponentMember(context, parser);
 
-    return pipeParseResult(context.namespace,
+    return member => pipeParseResult(context.namespace,
       validateIsObject,
-      R.compose(parseObject(context, name, parseMember), getValue));
+      R.compose(parseObject(context, name, parseMember), getValue),
+      (object) => {
+        context.state.components.push(new namespace.elements.Member(member.key, object));
+        return object;
+      })(member);
   };
 
   const setDataStructureId = (dataStructure, key) => {

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -106,19 +106,11 @@ function parseOASObject(context, object) {
     return new namespace.elements.ParseResult([array].concat(parseResult.annotations.elements));
   };
 
-  // Pre-parse 'components', this needs to be done first since other
-  // structures can reference it.
-  let components = object.get('components');
-  if (components) {
-    components = parseComponentsObject(context, components);
-    object.set('components', components);
-  }
-
   const parseMember = R.cond([
     [hasKey('openapi'), parseOpenAPI(context)],
     [hasKey('info'), R.compose(parseInfoObject(context), getValue)],
     [hasKey('paths'), R.compose(asArray, parsePathsObject(context), getValue)],
-    [hasKey('components'), getValue],
+    [hasKey('components'), R.compose(parseComponentsObject(context), getValue)],
 
     // FIXME Support exposing extensions into parse result
     [isExtension, () => new namespace.elements.ParseResult()],
@@ -130,7 +122,7 @@ function parseOASObject(context, object) {
   ]);
 
   const parseOASObject = pipeParseResult(namespace,
-    parseObject(context, name, parseMember, requiredKeys),
+    parseObject(context, name, parseMember, requiredKeys, ['components']),
     (object) => {
       const api = object.get('info');
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -112,9 +112,6 @@ function parseOASObject(context, object) {
   if (components) {
     components = parseComponentsObject(context, components);
     object.set('components', components);
-
-    // eslint-disable-next-line no-param-reassign
-    context.state.components = components.reject(isAnnotation).get(0);
   }
 
   const parseMember = R.cond([

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js
@@ -60,7 +60,7 @@ function validateApiKeyScheme(context, securityScheme) {
     [R.T, e => e],
   ]);
 
-  return parseObject(context, name, parseMember, ['name', 'in'], true)(securityScheme);
+  return parseObject(context, name, parseMember, ['name', 'in'], [], true)(securityScheme);
 }
 
 function validateHttpScheme(context, securityScheme) {
@@ -70,7 +70,7 @@ function validateHttpScheme(context, securityScheme) {
     [R.T, e => e],
   ]);
 
-  return parseObject(context, name, parseMember, ['scheme'], true)(securityScheme);
+  return parseObject(context, name, parseMember, ['scheme'], [], true)(securityScheme);
 }
 
 /**
@@ -116,7 +116,7 @@ function parseSecuritySchemeObject(context, object) {
   ]);
 
   const parseSecurityScheme = pipeParseResult(namespace,
-    parseObject(context, name, parseMember, requiredKeys, true),
+    parseObject(context, name, parseMember, requiredKeys, [], true),
     R.when(isApiKeyScheme, R.curry(validateApiKeyScheme)(context)),
     R.when(isHttpScheme, R.curry(validateHttpScheme)(context)),
     (securityScheme) => {


### PR DESCRIPTION
Currently the components parsing has custom code to parse it first as it can be a dependency from other elements. We will need to do the same for options inside the components parser so I've made this a generic approach which can be reused.