### PR TITLE
Support generating body from schema with references

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Added primitive support for 'examples' in 'Media Type Object'. The first
   example value is used for JSON media types.
 
-- Added primitive support for generating a JSON message body from a schema for
-  JSON media types. Referencing is not supported for this feature.
+- Added support for generating a JSON message body from a schema for
+  JSON media types.
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -119,7 +119,14 @@ function parseComponentsObject(context, element) {
       validateIsObject,
       R.compose(parseObject(context, name, parseMember), getValue),
       (object) => {
-        context.state.components.push(new namespace.elements.Member(member.key, object));
+        const contextMember = context.state.components.getMember(member.key.toValue());
+
+        if (contextMember) {
+          contextMember.value = object;
+        } else {
+          context.state.components.push(new namespace.elements.Member(member.key, object));
+        }
+
         return object;
       })(member);
   };
@@ -169,7 +176,8 @@ function parseComponentsObject(context, element) {
     [R.T, createInvalidMemberWarning(namespace, name)],
   ]);
 
-  return parseObject(context, name, parseMember)(element);
+  const order = ['schemas'];
+  return parseObject(context, name, parseMember, [], order)(element);
 }
 
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
@@ -115,7 +115,18 @@ function parseMediaTypeObject(context, MessageBodyClass, element) {
       const dataStructure = mediaTypeObject.get('schema');
 
       if (!messageBody && dataStructure && isJSONMediaType(mediaType)) {
-        const value = dataStructure.content.valueOf();
+        let elements = [];
+        const { components } = context.state;
+        if (components) {
+          const schemas = components.get('schemas');
+          if (schemas) {
+            elements = schemas.content
+              .filter(e => e.value && e.value.content)
+              .map(e => e.value.content);
+          }
+        }
+
+        const value = dataStructure.content.valueOf(undefined, elements);
 
         if (value) {
           const body = JSON.stringify(value);

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/media-type-object-schema.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/media-type-object-schema.json
@@ -83,6 +83,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"name\":\"\",\"company\":{\"name\":\"\"}}"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "User"

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/responses-object-response-with-schema.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/responses-object-response-with-schema.json
@@ -83,6 +83,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{}"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "UserObject"

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
@@ -136,6 +136,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[{\"id\":0,\"name\":\"\",\"tag\":\"\"}]"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "Pets"
@@ -289,6 +310,27 @@
                         }
                       },
                       "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[{\"id\":0,\"name\":\"\",\"tag\":\"\"}]"
+                        },
                         {
                           "element": "dataStructure",
                           "content": {

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -386,6 +386,27 @@
                       },
                       "content": [
                         {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[{\"id\":0,\"name\":\"\",\"tag\":\"\"}]"
+                        },
+                        {
                           "element": "dataStructure",
                           "content": {
                             "element": "Pets"
@@ -814,6 +835,27 @@
                         }
                       },
                       "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "[{\"id\":0,\"name\":\"\",\"tag\":\"\"}]"
+                        },
                         {
                           "element": "dataStructure",
                           "content": {

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponseObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponseObject-test.js
@@ -175,18 +175,13 @@ describe('Response Object', () => {
         },
       });
 
-      const dataStructure = new namespace.elements.DataStructure();
-      dataStructure.id = 'Node';
-
+      const pets = new namespace.elements.Array();
+      pets.id = 'Pets';
       context.state.components = new namespace.elements.Object({
         schemas: {
-          Node: dataStructure,
+          Pets: new namespace.elements.DataStructure(pets),
         },
       });
-
-      context.state.components.set('schemas', new namespace.elements.Object([
-        new namespace.elements.Member('Pets', new namespace.elements.Array()),
-      ]));
 
       const parseResult = parse(context, response);
 

--- a/packages/minim-api-description/test/value-of-test.js
+++ b/packages/minim-api-description/test/value-of-test.js
@@ -4,6 +4,7 @@ const apiDescription = require('../lib/api-description');
 
 const namespace = minim.namespace().use(apiDescription);
 
+const { Element } = namespace;
 const ArrayElement = namespace.elements.Array;
 const ObjectElement = namespace.elements.Object;
 const BooleanElement = namespace.elements.Boolean;
@@ -1104,5 +1105,102 @@ describe('valueOf ObjectElement with source', () => {
     const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal([null, 'nullable']);
+  });
+});
+
+
+describe('valueOf RefElement', () => {
+  it('returns value from referenced element', () => {
+    const name = new StringElement('doe');
+    name.id = 'name';
+
+    const element = name.toRef('element');
+    const value = element.valueOf(undefined, [name]);
+
+    expect(value).to.equal('doe');
+  });
+
+  it('returns value from referenced elements content', () => {
+    const name = new StringElement('doe');
+    const container = new Element(name);
+    container.id = 'name';
+
+    const element = container.toRef('content');
+    const value = element.valueOf(undefined, [container]);
+
+    expect(value).to.equal('doe');
+  });
+
+  it('returns value from referenced element recursively', () => {
+    const name = new StringElement('doe');
+    name.id = 'name';
+
+    const names = new ArrayElement([name.toRef()]);
+
+    const value = names.valueOf(undefined, [name]);
+
+    expect(value).to.deep.equal(['doe']);
+  });
+});
+
+describe('valueOf RefElement with source', () => {
+  it('returns value from referenced element', () => {
+    const name = new StringElement('doe');
+    name.id = 'name';
+
+    const element = name.toRef('element');
+    const value = element.valueOf({ source: true }, [name]);
+
+    expect(value).to.deep.equal(['doe', 'content']);
+  });
+
+  it('returns value from referenced elements content', () => {
+    const name = new StringElement('doe');
+    const container = new Element(name);
+    container.id = 'name';
+
+    const element = container.toRef('content');
+    const value = element.valueOf({ source: true }, [container]);
+
+    expect(value).to.deep.equal(['doe', 'content']);
+  });
+
+  it('returns value from referenced element recursively', () => {
+    const name = new StringElement('doe');
+    name.id = 'name';
+
+    const names = new ArrayElement([name.toRef()]);
+
+    const value = names.valueOf({ source: true }, [name]);
+
+    expect(value).to.deep.equal([['doe'], 'content']);
+  });
+});
+
+describe('valueOf referenced element', () => {
+  it('returns value from dereferenced element', () => {
+    const name = new StringElement('doe');
+    name.id = 'name';
+
+    const element = new Element();
+    element.element = 'name';
+
+    const value = element.valueOf(undefined, [name]);
+
+    expect(value).to.equal('doe');
+  });
+});
+
+describe('valueOf referenced element with source', () => {
+  it('returns value from dereferenced element', () => {
+    const name = new StringElement('doe');
+    name.id = 'name';
+
+    const element = new Element();
+    element.element = 'name';
+
+    const value = element.valueOf({ source: true }, [name]);
+
+    expect(value).to.deep.equal(['doe', 'content']);
   });
 });


### PR DESCRIPTION
Supports referencing in `valueOf` in minim-api-description, then we can make use of it in the OAS 3 parser to generate bodies for referenced elements.

### Dependencies

- [ ] This PR depends on https://github.com/apiaryio/api-elements.js/pull/197