### PR TITLE
Export the remote adapter class

### DIFF
--- a/packages/fury-adapter-remote/lib/adapter.js
+++ b/packages/fury-adapter-remote/lib/adapter.js
@@ -128,6 +128,4 @@ class FuryRemoteAdapter {
   }
 }
 
-module.exports = {
-  FuryRemoteAdapter,
-};
+module.exports = FuryRemoteAdapter;

--- a/packages/fury-adapter-remote/test/fury-test.js
+++ b/packages/fury-adapter-remote/test/fury-test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { Fury } = require('fury');
-const { FuryRemoteAdapter } = require('../lib/adapter');
+const FuryRemoteAdapter = require('../lib/adapter');
 
 const blueprintSource = 'FORMAT: 1A\n\n# API\n\n';
 const swaggerSource = '{ "swagger": "2.0", "info": { "version": "1.0.0", "title": "swg" } }';


### PR DESCRIPTION
In the README we document the module as:

```
const { Fury } = require('fury');
const FuryRemoteAdapter = require('fury-adapter-remote');

const fury = new Fury();
fury.use(new FuryRemoteAdapter(options);
```

However, since we export an object with `FuryRemoteAdapter` as a property it errors out.

In this PR I have aligned implementation with the docs.