### PR TITLE
Release entire toolchain

### DIFF
--- a/packages/api-elements/CHANGELOG.md
+++ b/packages/api-elements/CHANGELOG.md
@@ -1,10 +1,10 @@
 # API Elements (JavaScript) CHANGELOG
 
-## Master
+## 0.1.1 (2019-03-26)
 
 ### Enhancements
 
-- Update minim to 0.22.1.
+- Update minim to 0.22.1, minim-parse-result 0.11.1.
 
 ## 0.1.0
 

--- a/packages/api-elements/package.json
+++ b/packages/api-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-elements",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "API Elements JavaScript",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "minim": "^0.23.1",
-    "minim-parse-result": "^0.11.0"
+    "minim-parse-result": "^0.11.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.0-beta.7 (2019-03-26)
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 10](https://github.com/apiaryio/api-elements.js/releases/tag/fury@3.0.0-beta.10).
+
 ## 3.0.0-beta.6 (2019-02-26)
 
 ### Enhancements

--- a/packages/fury-adapter-apiary-blueprint-parser/package.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apiary-blueprint-parser",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "Parser for Fury.js for the deprecated Apiary Blueprint language",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -21,12 +21,12 @@
     "deckardcain": "^0.4.0"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.9"
+    "fury": "3.0.0-beta.10"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.9",
+    "fury": "3.0.0-beta.10",
     "glob": "^7.1.2",
     "mocha": "^5.0.2"
   },

--- a/packages/fury-adapter-apib-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apib-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury API Blueprint Parser Changelog
 
+## 0.14.0 (2019-03-26)
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 10](https://github.com/apiaryio/api-elements.js/releases/tag/fury@3.0.0-beta.10).
+
 ## 0.13.0 (2019-02-26)
 
 ### Enhancements

--- a/packages/fury-adapter-apib-parser/package.json
+++ b/packages/fury-adapter-apib-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-parser",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "API Blueprint parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -21,12 +21,12 @@
     "drafter": "2.0.0-pre.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.9"
+    "fury": "3.0.0-beta.10"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.9",
+    "fury": "3.0.0-beta.10",
     "mocha": "^5.0.2"
   },
   "engines": {

--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury API Blueprint Serializer
 
+## 0.10.0 (2019-03-26)
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 10](https://github.com/apiaryio/api-elements.js/releases/tag/fury@3.0.0-beta.10).
+
 ## 0.9.1 (2019-03-05)
 
 ### Bug Fixes

--- a/packages/fury-adapter-apib-serializer/package.json
+++ b/packages/fury-adapter-apib-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-serializer",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "API Blueprint serializer for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -20,12 +20,12 @@
     "nunjucks": "^2.0.0"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.9"
+    "fury": "3.0.0-beta.10"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.9",
+    "fury": "3.0.0-beta.10",
     "glob": "^7.1.2",
     "mocha": "^5.0.2"
   },

--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.7.0 (2019-03-26)
 
 ### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 10](https://github.com/apiaryio/api-elements.js/releases/tag/fury@3.0.0-beta.10).
 
 - Added primitive support for 'examples' in 'Media Type Object'. The first
   example value is used for JSON media types.

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -25,12 +25,12 @@
     "yaml-js": "^0.2.3"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.9"
+    "fury": "3.0.0-beta.10"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.9",
+    "fury": "3.0.0-beta.10",
     "mocha": "^5.0.2"
   },
   "engines": {

--- a/packages/fury-adapter-remote/CHANGELOG.md
+++ b/packages/fury-adapter-remote/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Fury Remote Adapter Changelog
+
+## 0.1.0 (2019-03-26)
+
+Initial release

--- a/packages/fury-adapter-remote/package.json
+++ b/packages/fury-adapter-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-remote",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Provide adapter for Element API based on callin remote API site",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -23,12 +23,12 @@
     "deckardcain": "^0.4.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.9"
+    "fury": "3.0.0-beta.10"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^5.15.1",
-    "fury": "3.0.0-beta.9",
+    "fury": "3.0.0-beta.10",
     "mocha": "^5.2.0"
   }
 }

--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury Swagger Parser Changelog
 
+## 0.25.0 (2019-03-26)
+
+### Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 10](https://github.com/apiaryio/api-elements.js/releases/tag/fury@3.0.0-beta.10).
+
 ## 0.24.2 (2019-03-15)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -28,15 +28,15 @@
     "z-schema": "^3.16.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.9"
+    "fury": "3.0.0-beta.10"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^5.9.0",
-    "fury": "3.0.0-beta.9",
+    "fury": "3.0.0-beta.10",
     "glob": "^7.1.2",
     "mocha": "^5.0.2",
-    "swagger-zoo": "2.20.1"
+    "swagger-zoo": "3.0.0"
   },
   "engines": {
     "node": ">=6"

--- a/packages/fury-cli/CHANGELOG.md
+++ b/packages/fury-cli/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Changelog
 
-## 0.9.11 (2019-03-05)
+## 0.8.12 (2019-03-26)
+
+This update incorporates changes from Fury Adapters:
+
+- fury-adapter-oas3-parser 0.7.0
+
+## 0.8.11 (2019-03-05)
 
 This update incorporates changes from Fury Adapters:
 
 - fury-adapter-swagger 0.24.1
 - fury-adapter-apib-serializer 0.9.1
 
-## 0.9.10 (2019-02-26)
+## 0.8.10 (2019-02-26)
 
 This update uses [Fury 3.0.0 Beta
 9](https://github.com/apiaryio/api-elements.js/releases/tag/fury-3.0.0-beta.9)

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -21,12 +21,12 @@
   "dependencies": {
     "cardinal": "^2.1.1",
     "commander": "^2.9",
-    "fury": "3.0.0-beta.9",
-    "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.6",
-    "fury-adapter-apib-parser": "^0.13.0",
-    "fury-adapter-apib-serializer": "^0.9.1",
-    "fury-adapter-oas3-parser": "^0.6.0",
-    "fury-adapter-swagger": "^0.24.1",
+    "fury": "3.0.0-beta.10",
+    "fury-adapter-apiary-blueprint-parser": "^3.0.0-beta.7",
+    "fury-adapter-apib-parser": "^0.14.0",
+    "fury-adapter-apib-serializer": "^0.10.0",
+    "fury-adapter-oas3-parser": "^0.7.0",
+    "fury-adapter-swagger": "^0.25.0",
     "js-yaml": "^3.6",
     "minim": "^0.23.1"
   },

--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Changelog
 
-## Master
+## 3.0.0-beta.10 (2019-03-26)
 
 ### Breaking
 

--- a/packages/fury/package.json
+++ b/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0-beta.10",
   "description": "API Description SDK",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "minim": "^0.23.1",
-    "minim-parse-result": "^0.11.0"
+    "minim-parse-result": "^0.11.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/minim-api-description/CHANGELOG.md
+++ b/packages/minim-api-description/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Minim API Description
 
-## 0.9.0 (26-02-19)
+## 0.9.1 (2019-03-26)
+
+### Enhancements
+
+- `Element.prototype.valueOf` can now accept an array of elements to be used
+  for handling references.
+
+## 0.9.0 (2019-02-26)
 
 ### Breaking
 

--- a/packages/minim-api-description/package.json
+++ b/packages/minim-api-description/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-api-description",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Minim API Description Namespace",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/minim-parse-result/CHANGELOG.md
+++ b/packages/minim-parse-result/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Minim Parse Result
 
-## 0.11.0 (26-02-19)
+## 0.11.1 (2019-03-26)
+
+### Enhancements
+
+- Update minim-api-description to 0.9.1.
+
+## 0.11.0 (2019-02-26)
 
 ### Breaking
 

--- a/packages/minim-parse-result/package.json
+++ b/packages/minim-parse-result/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-parse-result",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Minim Parse Result Namespace",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "minim-api-description": "^0.9.0"
+    "minim-api-description": "^0.9.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/swagger-zoo/package.json
+++ b/packages/swagger-zoo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.20.1",
+  "version": "3.0.0",
   "description": "Swagger example files for testing",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
Please do not merge and leave the rest to me once approved.

 - api-elements@0.1.1
 - fury-adapter-apiary-blueprint-parser@3.0.0-beta.7
 - fury-adapter-apib-parser@0.14.0
 - fury-adapter-apib-serializer@0.10.0
 - fury-adapter-oas3-parser@0.7.0
 - fury-adapter-remote@0.1.0
 - fury-adapter-swagger@0.25.0
 - fury-cli@0.8.12
 - fury@3.0.0-beta.10
 - minim-api-description@0.9.1
 - minim-parse-result@0.11.1
 - swagger-zoo@3.0.0

I discovered some minor inconsistencies in changelogs which have also been addressed (such as incorrect date format, incorrect past versions).