### PR TITLE
Validate media types

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.7.1 (2019-04-01)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury OAS3 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Added validation of media types, previously we would throw an error while
+  handling invalid media types.
+
 ## 0.7.0 (2019-03-26)
 
 ### Enhancements

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
@@ -21,6 +21,14 @@ describe('Media Type Object', () => {
     expect(parseResult).to.contain.warning("'Media Type Object' is not an object");
   });
 
+  it('provides warning when media type is invalid', () => {
+    const mediaType = new namespace.elements.Member('foo', {});
+
+    const parseResult = parse(context, messageBodyClass, mediaType);
+
+    expect(parseResult).to.contain.warning("'Media Type Object' media type 'foo' is invalid");
+  });
+
   it('returns a HTTP message body', () => {
     const mediaType = new namespace.elements.Member('application/json', {});
 

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -25,7 +25,7 @@
     "fury-adapter-apiary-blueprint-parser": "^3.0.0-beta.7",
     "fury-adapter-apib-parser": "^0.14.0",
     "fury-adapter-apib-serializer": "^0.10.0",
-    "fury-adapter-oas3-parser": "^0.7.0",
+    "fury-adapter-oas3-parser": "^0.7.1",
     "fury-adapter-swagger": "^0.25.0",
     "js-yaml": "^3.6",
     "minim": "^0.23.1"


### PR DESCRIPTION
This changeset adds validation of media types, upon an invalid media type we will warn out and prevent further parsing the media type object. This prevents the following error from being thrown:

```
TypeError: invalid media type
at Object.parse (/var/task/node_modules/fury-adapter-oas3-parser/node_modules/media-typer/index.js:96:11)
at isJSONMediaType (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js:20:27)
at pipeParseResult (/var/task/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js:117:44)
```