### PR TITLE
Parsing openapi version should return version on success

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury OAS3 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a bug where parsing an OpenAPI 3.1.0 or higher document will result in
+  an parse result containing only a warning and missing the API Category.
+
 ## 0.7.2 (2019-04-01)
 
 ### Bug Fixes

--- a/packages/fury-adapter-oas3-parser/lib/parser/openapi.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/openapi.js
@@ -26,7 +26,7 @@ function parseOpenAPI(context, openapi) {
   }
 
   if (parseInt(versionInfo[2], 10) > supportedMinorVersion) {
-    return new namespace.elements.ParseResult([createWarning(namespace, `Version '${openapi.value.toValue()}' is not fully supported`, openapi.value)]);
+    return new namespace.elements.ParseResult([openapi, createWarning(namespace, `Version '${openapi.value.toValue()}' is not fully supported`, openapi.value)]);
   }
 
 

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/openapi-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/openapi-test.js
@@ -43,6 +43,7 @@ describe('#parseOpenAPI', () => {
     const parseResult = parseOpenAPI(context, openapi);
     expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
     expect(parseResult).to.not.contain.annotations;
+    expect(parseResult.get(0).value.toValue()).to.equal('3.0.0');
   });
 
   it('allows openapi patch version 3.0.11', () => {
@@ -51,6 +52,7 @@ describe('#parseOpenAPI', () => {
     const parseResult = parseOpenAPI(context, openapi);
     expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
     expect(parseResult).to.not.contain.annotations;
+    expect(parseResult.get(0).value.toValue()).to.equal('3.0.11');
   });
 
   it('warns for unsuported minor versions', () => {
@@ -59,5 +61,6 @@ describe('#parseOpenAPI', () => {
     const parseResult = parseOpenAPI(context, openapi);
     expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
     expect(parseResult).to.contain.warning("Version '3.1.0' is not fully supported");
+    expect(parseResult.get(0).value.toValue()).to.equal('3.1.0');
   });
 });


### PR DESCRIPTION
If you try to parse a document such as:

```yaml
openapi: 3.1.0
info:
  title: xyz
  version abc
paths: {}
```

You would incorrectly get a parse result which ONLY contains a warning because the "required" parameter "openapi" didn't exist as the parser was not returning a value in this particular warning case.