### PR TITLE
Handle invalid security scheme components

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fixes a bug where parsing an OpenAPI 3.1.0 or higher document will result in
   an parse result containing only a warning and missing the API Category.
 
+- Fixes the parser from throwing an error while handling invalid or unsupported
+  security scheme components.
+
 ## 0.7.2 (2019-04-01)
 
 ### Bug Fixes

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -150,9 +150,11 @@ function parseComponentsObject(context, element) {
       const array = new namespace.elements.Array([]);
 
       object.forEach((value, key) => {
-        // eslint-disable-next-line no-param-reassign
-        value.meta.id = key.clone();
-        array.push(value);
+        if (value) {
+          // eslint-disable-next-line no-param-reassign
+          value.meta.id = key.clone();
+          array.push(value);
+        }
       });
 
       return array;

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -322,6 +322,24 @@ describe('Components Object', () => {
       expect(securitySchemes.get(0)).to.be.instanceof(namespace.elements.AuthScheme);
       expect(securitySchemes.get(0).meta.id.toValue()).to.equal('token');
     });
+
+    it('handles invalid security scheme', () => {
+      const components = new namespace.elements.Object({
+        securitySchemes: {
+          Basic: null,
+        },
+      });
+
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(2);
+
+      const parsedComponents = parseResult.get(0);
+      expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
+
+      const schemes = parsedComponents.get('securitySchemes');
+      expect(schemes).to.be.instanceof(namespace.elements.Array);
+      expect(schemes.isEmpty).to.be.true;
+    });
   });
 
   describe('#examples', () => {


### PR DESCRIPTION
The parser is currently crashing for certain inputs, for example:

```yaml
openapi: 3.0.0
info:
  title: abc
  version: xyz
paths: {}
components:
  securitySchemes:
    Foo: {}
```

```
TypeError: Cannot read property 'meta' of undefined
    at object.forEach (/Users/kyle/Projects/apiaryio/api-elements.js/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js:154:17)
    at content.forEach.item (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/primitives/ObjectElement.js:203:63)
    at Array.forEach (<anonymous>)
    at ObjectElement.forEach (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/primitives/ObjectElement.js:203:25)
    at pipeParseResult (/Users/kyle/Projects/apiaryio/api-elements.js/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js:152:14)
    at run (/Users/kyle/Projects/apiaryio/api-elements.js/packages/fury-adapter-oas3-parser/lib/pipeParseResult.js:60:25)
    at XWrap.f (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/ramda/src/reduceWhile.js:40:27)
    at XWrap.@@transducer/step (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/ramda/src/internal/_xwrap.js:12:17)
    at _arrayReduce (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/ramda/src/internal/_reduce.js:11:34)
    at _reduce (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/ramda/src/internal/_reduce.js:45:12)
```