### PR TITLE
Fix support for header referencing

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Added additional information to YAML parsing errors where available to make
   the errors more understandable.
 
+- Fix referencing a headers component. Previously this would return an error
+  that the headers components was undefined.
+
 ## 0.7.2 (2019-04-01)
 
 ### Bug Fixes

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -177,7 +177,7 @@ function parseComponentsObject(context, element) {
     [R.T, createInvalidMemberWarning(namespace, name)],
   ]);
 
-  const order = ['schemas'];
+  const order = ['schemas', 'headers'];
   return parseObject(context, name, parseMember, [], order)(element);
 }
 

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -9,7 +9,6 @@ const {
 } = require('../annotations');
 const parseObject = require('../parseObject');
 const pipeParseResult = require('../../pipeParseResult');
-const parseMap = require('../parseMap');
 const parseSchemaObject = require('./parseSchemaObject');
 const parseParameterObject = require('./parseParameterObject');
 const parseResponseObject = require('./parseResponseObject');
@@ -166,7 +165,7 @@ function parseComponentsObject(context, element) {
     [hasKey('responses'), parseComponentObjectMember(parseResponseObject)],
     [hasKey('requestBodies'), parseComponentObjectMember(parseRequestBodyObject)],
     [hasKey('examples'), parseComponentObjectMember(parseExampleObject)],
-    [hasKey('headers'), parseMap(context, name, 'headers', parseHeaderObject)],
+    [hasKey('headers'), parseComponentObjectMember(parseHeaderObject)],
     [hasKey('securitySchemes'), parseSecuritySchemes],
 
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],

--- a/packages/fury-adapter-oas3-parser/test/integration/components-test.js
+++ b/packages/fury-adapter-oas3-parser/test/integration/components-test.js
@@ -34,6 +34,11 @@ describe('components', () => {
     return testParseFixture(file);
   });
 
+  it("'Response Object' headers references", () => {
+    const file = path.join(fixtures, 'response-object-headers');
+    return testParseFixture(file);
+  });
+
   it("'Schema Object' circular references", () => {
     const file = path.join(fixtures, 'schema-object-circular');
     return testParseFixture(file);

--- a/packages/fury-adapter-oas3-parser/test/integration/components-test.js
+++ b/packages/fury-adapter-oas3-parser/test/integration/components-test.js
@@ -34,6 +34,11 @@ describe('components', () => {
     return testParseFixture(file);
   });
 
+  it("'Responses Object' respomnse references with headers", () => {
+    const file = path.join(fixtures, 'responses-object-response-with-headers');
+    return testParseFixture(file);
+  });
+
   it("'Response Object' headers references", () => {
     const file = path.join(fixtures, 'response-object-headers');
     return testParseFixture(file);

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/response-object-headers.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/response-object-headers.json
@@ -1,0 +1,159 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Headers Components"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/user"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "View the current User"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "X-Rate-Limit-Limit"
+                                },
+                                "value": {
+                                  "element": "string"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "hi"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 18
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 352
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 18
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 18
+                        }
+                      },
+                      "content": 11
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Header Object' contains unsupported key 'description'"
+    }
+  ]
+}

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/response-object-headers.yaml
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/response-object-headers.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Headers Components
+paths:
+  /user:
+    get:
+      summary: View the current User
+      responses:
+        '200':
+          description: hi
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: '#/components/headers/X-Rate-Limit-Limit'
+components:
+  headers:
+    X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/responses-object-response-with-headers.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/responses-object-response-with-headers.json
@@ -1,0 +1,159 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Response Components with Headers"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/user"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "View the current User"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "X-Rate-Limit-Limit"
+                                },
+                                "value": {
+                                  "element": "string"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "A user"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 21
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 7
+                        }
+                      },
+                      "content": 439
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 21
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 18
+                        }
+                      },
+                      "content": 11
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "'Header Object' contains unsupported key 'description'"
+    }
+  ]
+}

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/responses-object-response-with-headers.yaml
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/components/responses-object-response-with-headers.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Response Components with Headers
+paths:
+  /user:
+    get:
+      summary: View the current User
+      responses:
+        '200':
+          $ref: '#/components/responses/UserResponse'
+components:
+  responses:
+    UserResponse:
+      description: A user
+      headers:
+        X-Rate-Limit-Limit:
+          $ref: '#/components/headers/X-Rate-Limit-Limit'
+  headers:
+    X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period


### PR DESCRIPTION
I discovered that header references was not working. The following ADF parses with error "'#/components/headers' is not defined":

```yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: Headers Components
paths:
  /user:
    get:
      summary: View the current User
      responses:
        '200':
          description: hi
          headers:
            X-Rate-Limit-Limit:
              $ref: '#/components/headers/X-Rate-Limit-Limit'
components:
  headers:
    X-Rate-Limit-Limit:
      description: The number of allowed requests in the current period
      schema:
        type: integer
```

I've added an integration test and then fixed it by using the common parseComponentMember which deals with registering the component which was the problem with the existing code path.

I've also added a test and fixed support for referencing headers from a responses component in the second commit.