### PR TITLE
Improve YAML error message descriptions

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fixes the parser from throwing an error while handling invalid or unsupported
   security scheme components.
 
+- Added additional information to YAML parsing errors where available to make
+  the errors more understandable.
+
 ## 0.7.2 (2019-04-01)
 
 ### Bug Fixes

--- a/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
@@ -106,8 +106,17 @@ function parse(source, context) {
   try {
     ast = yaml.compose(source);
   } catch (error) {
+    let message;
+
+    if (error.problem) {
+      const problem = error.problem.replace('\t', '\\t');
+      message = `${problem}, ${error.context}`;
+    } else {
+      message = error.context;
+    }
+
     const annotation = new namespace.elements.Annotation(
-      `YAML Syntax: ${error.context}`,
+      `YAML Syntax: ${message}`,
       { classes: ['error'] }
     );
 

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/parseYAML-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/parseYAML-test.js
@@ -29,7 +29,7 @@ describe('#parseYAML', () => {
       expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
       expect(parseResult.errors.length).to.equal(1);
 
-      expect(parseResult).contain.error('YAML Syntax: while scanning for the next token').with.sourceMap([[14, 0]]);
+      expect(parseResult).contain.error('YAML Syntax: found character \\t that cannot start any token, while scanning for the next token').with.sourceMap([[14, 0]]);
     });
   });
 


### PR DESCRIPTION
The YAML parser sometimes includes "problem" in the error which contains a clearer message on the underlying problem. When available we can include this in our error annotations. For example if the parser hits a tab in the document which is not valid, it was showing an error "while scanning for the next token", we can be more detailed and include the problem so the error message can become: "found character \t that cannot start any token, while scanning for the next token".