### PR TITLE
Handle invalid schema object examples in OAS 2

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a potential parser crash while handling an example value for a 'Schema
+  Object' which contains an invalid reference.
+
 ## 0.25.0 (2019-03-26)
 
 ### Enhancements

--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.25.1 (2019-04-26)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-swagger/test/fixtures/schema-references-example-invalid.json
+++ b/packages/fury-adapter-swagger/test/fixtures/schema-references-example-invalid.json
@@ -1,0 +1,79 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "My API"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "array",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "definitions/Test"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "object",
+                    "content": [
+                      {
+                        "element": "member",
+                        "content": {
+                          "key": {
+                            "element": "string",
+                            "content": "$ref"
+                          },
+                          "value": {
+                            "element": "string",
+                            "content": "#/info"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/fury-adapter-swagger/test/fixtures/schema-references-example-invalid.yaml
+++ b/packages/fury-adapter-swagger/test/fixtures/schema-references-example-invalid.yaml
@@ -1,0 +1,10 @@
+swagger: '2.0'
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+definitions:
+  Test:
+    type: array
+    example:
+      - $ref: '#/info'

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -26,7 +26,7 @@
     "fury-adapter-apib-parser": "^0.14.0",
     "fury-adapter-apib-serializer": "^0.10.0",
     "fury-adapter-oas3-parser": "^0.7.4",
-    "fury-adapter-swagger": "^0.25.0",
+    "fury-adapter-swagger": "^0.25.1",
     "js-yaml": "^3.12.0",
     "minim": "^0.23.1"
   },


### PR DESCRIPTION
Fixes https://github.com/apiaryio/api-elements.js/issues/217

More context can be found in the large comment I added inside the function that is altered below.