### PR TITLE
Make the adapter interface use promises

### DIFF
--- a/packages/fury-adapter-apiary-blueprint-parser/lib/adapter.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/adapter.js
@@ -9,10 +9,10 @@ const mediaTypes = [
 
 const detect = source => mediaTypes.indexOf(deckardcain.identify(source)) !== -1;
 
-const parse = (options, done) => {
+function parse(options) {
   const parser = new Parser(options);
-  parser.parse(done);
-};
+  return Promise.resolve(parser.parse());
+}
 
 module.exports = {
   name, mediaTypes, detect, parse,

--- a/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
@@ -7,7 +7,7 @@ class Parser {
     this.source = source;
   }
 
-  parse(done) {
+  parse() {
     const {
       Annotation, Category, Copy, ParseResult,
     } = this.minim.elements;
@@ -28,7 +28,7 @@ class Parser {
         ]);
       }
 
-      return done(null, this.result);
+      return this.result;
     }
 
     this.api = new Category();
@@ -53,7 +53,7 @@ class Parser {
     });
 
     this.result.push(this.api);
-    return done(null, this.result);
+    return this.result;
   }
 
   // Parses a URL from the Apiary Blueprint AST

--- a/packages/fury-adapter-apib-parser/lib/adapter.js
+++ b/packages/fury-adapter-apib-parser/lib/adapter.js
@@ -11,27 +11,25 @@ const mediaTypes = [
 
 const detect = source => mediaTypes.indexOf(deckardcain.identify(source)) !== -1;
 
-const validate = ({ source, requireBlueprintName }, done) => {
+function validate({ source, requireBlueprintName }) {
   const options = {
     requireBlueprintName,
   };
 
-  drafter.validate(source, options, done);
-};
+  return drafter.validate(source, options);
+}
 
 /*
  * Parse an API Blueprint into refract elements.
  */
-const parse = ({
-  source, generateSourceMap, requireBlueprintName,
-}, done) => {
+function parse({ source, generateSourceMap, requireBlueprintName }) {
   const options = {
     exportSourcemap: !!generateSourceMap,
     requireBlueprintName,
   };
 
-  drafter.parse(source, options, done);
-};
+  return drafter.parse(source, options);
+}
 
 module.exports = {
   name, mediaTypes, detect, validate, parse,

--- a/packages/fury-adapter-apib-serializer/lib/adapter.js
+++ b/packages/fury-adapter-apib-serializer/lib/adapter.js
@@ -29,15 +29,17 @@ const mediaTypes = [
 /*
  * Serialize an API into API Blueprint.
  */
-const serialize = ({ api }, done) => {
-  nunjucks.render('template.nunjucks', { api }, (err, apib) => {
-    if (err) {
-      return done(err);
-    }
+function serialize({ api }) {
+  return new Promise((resolve, reject) => {
+    nunjucks.render('template.nunjucks', { api }, (err, apib) => {
+      if (err) {
+        return reject(err);
+      }
 
-    // Attempt to filter out extra spacing
-    return done(null, apib.replace(/\n\s*\n\s*\n/g, '\n\n'));
+      // Attempt to filter out extra spacing
+      return resolve(apib.replace(/\n\s*\n\s*\n/g, '\n\n'));
+    });
   });
-};
+}
 
 module.exports = { name, mediaTypes, serialize };

--- a/packages/fury-adapter-apib-serializer/test/adapter-test.js
+++ b/packages/fury-adapter-apib-serializer/test/adapter-test.js
@@ -6,13 +6,16 @@
 
 const { expect } = require('chai');
 const fs = require('fs');
-const fury = require('fury');
+const { Fury } = require('fury');
 const glob = require('glob');
 const path = require('path');
-const { serialize } = require('../lib/adapter');
+const adapter = require('../lib/adapter');
 const { indent } = require('../lib/filters');
 
 const base = path.join(__dirname, 'fixtures');
+
+const fury = new Fury();
+fury.use(adapter);
 
 describe('API Blueprint serializer adapter', () => {
   const files = glob.sync(path.join(base, '*.json'));
@@ -35,7 +38,7 @@ describe('API Blueprint serializer adapter', () => {
         return done(loadErr);
       }
 
-      return serialize({ api }, (serializeErr, serialized) => {
+      return fury.serialize({ api }, (serializeErr, serialized) => {
         if (serializeErr) {
           return done(serializeErr);
         }

--- a/packages/fury-adapter-oas3-parser/lib/adapter.js
+++ b/packages/fury-adapter-oas3-parser/lib/adapter.js
@@ -13,15 +13,26 @@ function detect(source) {
   return !!source.match(/(["']?)openapi\1\s*:\s*(["']?)3\.\d+\.\d+\2/g);
 }
 
-function parse(options, cb) {
+function parse(options) {
   const context = new Context(
     options.minim,
     {
       generateSourceMap: options.generateSourceMap,
     }
   );
-  const parseResult = parser(options.source, context);
-  cb(null, parseResult);
+
+  return new Promise((resolve, reject) => {
+    let parseResult;
+
+    try {
+      parseResult = parser(options.source, context);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    resolve(parseResult);
+  });
 }
 
 module.exports = {

--- a/packages/fury-adapter-oas3-parser/test/unit/adapter-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/adapter-test.js
@@ -78,11 +78,13 @@ describe('Adapter', () => {
   });
 
   it('parses a valid OAS3 document', (done) => {
-    const { minim: namespace } = new Fury();
+    const fury = new Fury();
+    fury.use(adapter);
+
     const source = 'openapi: "3.0.0"\ninfo: {title: My API, version: 1.0.0}\npaths: {}\n';
 
-    adapter.parse({ source, minim: namespace }, (err, parseResult) => {
-      expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
+    fury.parse({ source }, (err, parseResult) => {
+      expect(parseResult).to.be.instanceof(fury.minim.elements.ParseResult);
       expect(parseResult.length).to.equal(1);
       expect(parseResult.api.title.toValue()).to.equal('My API');
       done();

--- a/packages/fury-adapter-remote/lib/adapter.js
+++ b/packages/fury-adapter-remote/lib/adapter.js
@@ -72,10 +72,10 @@ class FuryRemoteAdapter {
     return false;
   }
 
-  parse({ source, minim, mediaType }, cb) {
+  parse({ source, minim, mediaType }) {
     const inputMediaType = mediaType || detectMediaType(source, defaultInputMediaType);
 
-    axios({
+    return axios({
       method: 'post',
       url: this.options.parseEndpoint,
       baseURL: this.options.url,
@@ -86,18 +86,13 @@ class FuryRemoteAdapter {
       },
       // allow code 422 to be identified as valid response
       validateStatus: status => ((status >= 200 && status < 300) || status === 422),
-    })
-      .then((response) => {
-        cb(null, minim.serialiser.deserialise(response.data));
-      }, (err) => {
-        cb(err, undefined);
-      });
+    }).then(response => minim.serialiser.deserialise(response.data));
   }
 
-  validate({ source, minim, mediaType }, cb) {
+  validate({ source, minim, mediaType }) {
     const inputMediaType = mediaType || detectMediaType(source, defaultInputMediaType);
 
-    axios({
+    return axios({
       method: 'post',
       url: this.options.validateEndpoint,
       baseURL: this.options.url,
@@ -110,19 +105,14 @@ class FuryRemoteAdapter {
         'Content-Type': 'application/json',
         Accept: outputMediaType,
       },
-    })
-      .then((response) => {
-        cb(null, minim.serialiser.deserialise(response.data));
-      }, (err) => {
-        cb(err, undefined);
-      });
+    }).then(response => minim.serialiser.deserialise(response.data));
   }
 
-  serialize({ api, minim, mediaType }, cb) {
+  serialize({ api, minim, mediaType }) {
     const content = minim.serialiser.serialise(api);
     const inputMediaType = (content.element && content.element === 'parseResult') ? 'application/vnd.refract+json' : 'application/vnd.refract.parse-result+json';
 
-    axios({
+    return axios({
       method: 'post',
       url: this.options.serializeEndpoint,
       baseURL: this.options.url,
@@ -131,12 +121,7 @@ class FuryRemoteAdapter {
         'Content-Type': inputMediaType,
         Accept: mediaType,
       },
-    })
-      .then((response) => {
-        cb(null, response.data);
-      }, (err) => {
-        cb(err, undefined);
-      });
+    }).then(response => response.data);
   }
 }
 

--- a/packages/fury-adapter-swagger/lib/adapter.js
+++ b/packages/fury-adapter-swagger/lib/adapter.js
@@ -16,10 +16,18 @@ const detect = source => !!(_.isString(source)
 /*
  * Parse Swagger 2.0 into Refract elements
  */
-const parse = (options, done) => {
-  const parser = new Parser(options);
-  parser.parse(done);
-};
+function parse(options) {
+  return new Promise((fulfil, reject) => {
+    const parser = new Parser(options);
+    parser.parse((error, parseResult) => {
+      if (error) {
+        reject(error);
+      } else {
+        fulfil(parseResult);
+      }
+    });
+  });
+}
 
 /**
  * @implements {FuryAdapter}

--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury Changelog
 
+## Master
+
+### Breaking
+
+- The interface between Fury and adapters now uses promises. Any adapters need
+  to be updated to use a promise interface.
+
 ## 3.0.0-beta.10 (2019-03-26)
 
 ### Breaking

--- a/packages/fury/README.md
+++ b/packages/fury/README.md
@@ -136,7 +136,7 @@ If you need to distinguish among supported input Media Types for methods use:
 export const mediaTypes = {
   parse: ['text/vnd.my-parsing', 'text/vnd.another-supported-parsing'],
   serialize: ['text/vnd.my-serialization'],
-  };
+};
 ```
 
 
@@ -155,28 +155,28 @@ export function detect(source[, method]) {
   return source.match(/some-test/i) !== null;
 }
 
-export function parse({minim, generateSourceMap, mediaType, source}, done) {
+export async function parse({minim, generateSourceMap, mediaType, source}) {
   // Here you convert the source into refract elements. Use the `minim`
   // variable to access refract element classes.
   const Resource = minim.getElementByClass('resource');
   // ...
-  done(null, elements);
+  return elements;
 }
 
-export function validate({minim, mediaType, source}, done) {
+export async function validate({minim, mediaType, source}) {
   // Here you validate the source and return a parse result for any warnings or
   // errors.
   //
   // NOTE: Implementing `validate` is optional, Fury will fallback to using
   // `parse` to find warnings or errors.
-  done(null, null);
+  return null;
 }
 
-export function serialize({api, mediaType, minim}, done) {
+export async function serialize({api, mediaType, minim}) {
   // Here you convert `api` from javascript element objects to the serialized
   // source format.
   // ...
-  done(null, outputString);
+  return outputString;
 }
 
 export default {name, mediaTypes, detect, parse, serialize};

--- a/packages/fury/test/validate-test.js
+++ b/packages/fury/test/validate-test.js
@@ -12,7 +12,7 @@ describe('Validation', () => {
       name: 'passthrough',
       mediaTypes: ['text/vnd.passthrough'],
       detect: () => shouldDetect,
-      validate: (options, done) => done(null, result),
+      validate: () => Promise.resolve(result),
     });
 
     beforeEach(() => {
@@ -97,9 +97,9 @@ describe('Validation', () => {
 
     it('should pass adapter options during validation', (done) => {
       shouldDetect = true;
-      fury.adapters[0].validate = ({ minim, testOption = false }, cb) => {
+      fury.adapters[0].validate = ({ minim, testOption = false }) => {
         const BooleanElement = minim.getElementClass('boolean');
-        return cb(null, new BooleanElement(testOption));
+        return Promise.resolve(new BooleanElement(testOption));
       };
 
       fury.validate({ source: 'dummy', adapterOptions: { testOption: true } }, (err, res) => {
@@ -118,7 +118,7 @@ describe('Validation', () => {
       name: 'passthrough',
       mediaTypes: ['text/vnd.passthrough'],
       detect: () => true,
-      parse: (options, done) => done(null, result),
+      parse: () => Promise.resolve(result),
     });
 
     before(() => {


### PR DESCRIPTION
As a part of #37, I've made the interfaces between Fury core and the adapters use promises. This is a relatively simple change, the biggest changes are in the tests.

I've made this a draft PR as I would like to release https://github.com/apiaryio/api-elements.js/pull/221 beforehand. I think we can review this and I can add release commits as we will need to make an entire toolchain release.