### PR TITLE
Fix source map locations for OAS 3 warnings

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
@@ -96,7 +96,7 @@ function parseMediaTypeObject(context, MessageBodyClass, element) {
       }
 
       if (examples.length > 1) {
-        parseResult.push(createWarning(namespace, `'${name}' 'examples' only one example is supported, other examples have been ignored`, examples));
+        parseResult.push(createWarning(namespace, `'${name}' 'examples' only one example is supported, other examples have been ignored`, examples.content[1]));
       }
 
       return parseResult;

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSchemaObject.js
@@ -131,8 +131,13 @@ function validateValuesMatchSchema(context, schema) {
 function parseSchema(context) {
   const { namespace } = context;
 
-  const ensureValidType = R.unless(isValidType, createWarning(namespace,
-    `'Schema Object' 'type' must be either ${types.join(', ')}`));
+  const ensureValidType = R.unless(
+    isValidType,
+    R.compose(
+      createWarning(namespace, `'Schema Object' 'type' must be either ${types.join(', ')}`),
+      getValue
+    )
+  );
 
   const parseType = pipeParseResult(namespace,
     parseString(context, name, false),


### PR DESCRIPTION
I discovered missing source maps on two types of warnings, will comment below.