### PR TITLE
Release fury-adapter-oas3-parser 0.7.5

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.7.5 (2019-05-23)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -25,7 +25,7 @@
     "fury-adapter-apiary-blueprint-parser": "^3.0.0-beta.7",
     "fury-adapter-apib-parser": "^0.14.0",
     "fury-adapter-apib-serializer": "^0.10.0",
-    "fury-adapter-oas3-parser": "^0.7.4",
+    "fury-adapter-oas3-parser": "^0.7.5",
     "fury-adapter-swagger": "^0.25.1",
     "js-yaml": "^3.12.0",
     "minim": "^0.23.1"


### PR DESCRIPTION
### Bug Fixes

- Prevents an exception being raised when using `freeze()` on the parse result returned by the parser when you reference a parameter component multiple times in an OpenAPI Document.