### PR TITLE
Move parse result logic into separate files

### DIFF
--- a/packages/api-elements/lib/define-source-map-value.js
+++ b/packages/api-elements/lib/define-source-map-value.js
@@ -1,0 +1,22 @@
+module.exports = (namespace) => {
+  const { Element } = namespace;
+
+  /**
+   * @name sourceMapValue
+   * @type Array
+   * @memberof Element.prototype
+   */
+  if (!Object.getOwnPropertyNames(Element.prototype).includes('sourceMapValue')) {
+    Object.defineProperty(Element.prototype, 'sourceMapValue', {
+      get() {
+        const sourceMap = this.attributes.get('sourceMap');
+
+        if (sourceMap) {
+          return sourceMap.first.toValue();
+        }
+
+        return undefined;
+      },
+    });
+  }
+};

--- a/packages/api-elements/lib/elements/annotation.js
+++ b/packages/api-elements/lib/elements/annotation.js
@@ -1,0 +1,29 @@
+module.exports = (namespace) => {
+  const StringElement = namespace.getElementClass('string');
+
+  /**
+   * @class Annotation
+   *
+   * @param {string} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends StringElement
+   */
+  class Annotation extends StringElement {
+    constructor(...args) {
+      super(...args);
+      this.element = 'annotation';
+    }
+
+    get code() {
+      return this.attributes.get('code');
+    }
+
+    set code(value) {
+      this.attributes.set('code', value);
+    }
+  }
+
+  namespace.register('annotation', Annotation);
+};

--- a/packages/api-elements/lib/elements/parse-result.js
+++ b/packages/api-elements/lib/elements/parse-result.js
@@ -1,0 +1,59 @@
+module.exports = (namespace) => {
+  const ArrayElement = namespace.getElementClass('array');
+
+  /**
+   * @class ParseResult
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
+  class ParseResult extends ArrayElement {
+    constructor(...args) {
+      super(...args);
+      this.element = 'parseResult';
+    }
+
+    /**
+     * @name api
+     * @type Category
+     * @memberof ParseResult.prototype
+     */
+    get api() {
+      return this.children.filter(item => item.classes.contains('api')).first;
+    }
+
+    /**
+     * @name annotations
+     * @type ArraySlice
+     * @memberof ParseResult.prototype
+     */
+    get annotations() {
+      return this.children.filter(item => item.element === 'annotation');
+    }
+
+    /**
+     * @name warnings
+     * @type ArraySlice
+     * @memberof ParseResult.prototype
+     */
+    get warnings() {
+      return this.children
+        .filter(item => item.element === 'annotation' && item.classes.contains('warning'));
+    }
+
+    /**
+     * @name errors
+     * @type ArraySlice
+     * @memberof ParseResult.prototype
+     */
+    get errors() {
+      return this.children
+        .filter(item => item.element === 'annotation' && item.classes.contains('error'));
+    }
+  }
+
+  namespace.register('parseResult', ParseResult);
+};

--- a/packages/api-elements/lib/elements/source-map.js
+++ b/packages/api-elements/lib/elements/source-map.js
@@ -1,0 +1,28 @@
+module.exports = (namespace) => {
+  const ArrayElement = namespace.getElementClass('array');
+
+  /**
+   * @class SourceMap
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
+  class SourceMap extends ArrayElement {
+    constructor(...args) {
+      super(...args);
+      this.element = 'sourceMap';
+    }
+
+    // Override toValue because until Refract 1.0
+    // sourceMap is special element that contains array of array
+    // TODO Remove in next minor release
+    toValue() {
+      return this.content.map(value => value.map(element => element.toValue()));
+    }
+  }
+
+  namespace.register('sourceMap', SourceMap);
+};

--- a/packages/api-elements/lib/parse-result.js
+++ b/packages/api-elements/lib/parse-result.js
@@ -11,35 +11,15 @@ const apiDescription = require('./api-description');
 const parseResult = require('./elements/parse-result');
 const annotation = require('./elements/annotation');
 const sourceMap = require('./elements/source-map');
+const defineSourceMapValue = require('./define-source-map-value');
 
 const namespace = (options) => {
-  const namespace = options.base;
-  const { Element } = namespace;
-
-  parseResult(namespace);
+  parseResult(options.base);
   annotation(options.base);
   sourceMap(options.base);
+  defineSourceMapValue(options.base);
 
-  /**
-   * @name sourceMapValue
-   * @type Array
-   * @memberof Element.prototype
-   */
-  if (!Object.getOwnPropertyNames(Element.prototype).includes('sourceMapValue')) {
-    Object.defineProperty(Element.prototype, 'sourceMapValue', {
-      get() {
-        const sourceMap = this.attributes.get('sourceMap');
-
-        if (sourceMap) {
-          return sourceMap.first.toValue();
-        }
-
-        return undefined;
-      },
-    });
-  }
-
-  namespace.use(apiDescription);
+  options.base.use(apiDescription);
 };
 
 module.exports = { namespace };

--- a/packages/api-elements/lib/parse-result.js
+++ b/packages/api-elements/lib/parse-result.js
@@ -10,38 +10,15 @@
 const apiDescription = require('./api-description');
 const parseResult = require('./elements/parse-result');
 const annotation = require('./elements/annotation');
+const sourceMap = require('./elements/source-map');
 
 const namespace = (options) => {
-  parseResult(options.base);
+  const namespace = options.base;
+  const { Element } = namespace;
+
+  parseResult(namespace);
   annotation(options.base);
-
-  const minim = options.base;
-  const { Element } = minim;
-  const StringElement = minim.getElementClass('string');
-  const ArrayElement = minim.getElementClass('array');
-
-  /**
-   * @class SourceMap
-   *
-   * @param {Array} content
-   * @param meta
-   * @param attributes
-   *
-   * @extends ArrayElement
-   */
-  class SourceMap extends minim.elements.Array {
-    constructor(...args) {
-      super(...args);
-      this.element = 'sourceMap';
-    }
-
-    // Override toValue because until Refract 1.0
-    // sourceMap is special element that contains array of array
-    // TODO Remove in next minor release
-    toValue() {
-      return this.content.map(value => value.map(element => element.toValue()));
-    }
-  }
+  sourceMap(options.base);
 
   /**
    * @name sourceMapValue
@@ -62,9 +39,7 @@ const namespace = (options) => {
     });
   }
 
-  minim
-    .use(apiDescription)
-    .register('sourceMap', SourceMap);
+  namespace.use(apiDescription);
 };
 
 module.exports = { namespace };

--- a/packages/api-elements/lib/parse-result.js
+++ b/packages/api-elements/lib/parse-result.js
@@ -9,38 +9,16 @@
 
 const apiDescription = require('./api-description');
 const parseResult = require('./elements/parse-result');
+const annotation = require('./elements/annotation');
 
 const namespace = (options) => {
   parseResult(options.base);
+  annotation(options.base);
 
   const minim = options.base;
   const { Element } = minim;
   const StringElement = minim.getElementClass('string');
   const ArrayElement = minim.getElementClass('array');
-
-  /**
-   * @class Annotation
-   *
-   * @param {string} content
-   * @param meta
-   * @param attributes
-   *
-   * @extends StringElement
-   */
-  class Annotation extends StringElement {
-    constructor(...args) {
-      super(...args);
-      this.element = 'annotation';
-    }
-
-    get code() {
-      return this.attributes.get('code');
-    }
-
-    set code(value) {
-      this.attributes.set('code', value);
-    }
-  }
 
   /**
    * @class SourceMap
@@ -86,7 +64,6 @@ const namespace = (options) => {
 
   minim
     .use(apiDescription)
-    .register('annotation', Annotation)
     .register('sourceMap', SourceMap);
 };
 

--- a/packages/api-elements/lib/parse-result.js
+++ b/packages/api-elements/lib/parse-result.js
@@ -8,66 +8,15 @@
  */
 
 const apiDescription = require('./api-description');
+const parseResult = require('./elements/parse-result');
 
 const namespace = (options) => {
+  parseResult(options.base);
+
   const minim = options.base;
   const { Element } = minim;
   const StringElement = minim.getElementClass('string');
   const ArrayElement = minim.getElementClass('array');
-
-  /**
-   * @class ParseResult
-   *
-   * @param {Array} content
-   * @param meta
-   * @param attributes
-   *
-   * @extends ArrayElement
-   */
-  class ParseResult extends ArrayElement {
-    constructor(...args) {
-      super(...args);
-      this.element = 'parseResult';
-    }
-
-    /**
-     * @name api
-     * @type Category
-     * @memberof ParseResult.prototype
-     */
-    get api() {
-      return this.children.filter(item => item.classes.contains('api')).first;
-    }
-
-    /**
-     * @name annotations
-     * @type ArraySlice
-     * @memberof ParseResult.prototype
-     */
-    get annotations() {
-      return this.children.filter(item => item.element === 'annotation');
-    }
-
-    /**
-     * @name warnings
-     * @type ArraySlice
-     * @memberof ParseResult.prototype
-     */
-    get warnings() {
-      return this.children
-        .filter(item => item.element === 'annotation' && item.classes.contains('warning'));
-    }
-
-    /**
-     * @name errors
-     * @type ArraySlice
-     * @memberof ParseResult.prototype
-     */
-    get errors() {
-      return this.children
-        .filter(item => item.element === 'annotation' && item.classes.contains('error'));
-    }
-  }
 
   /**
    * @class Annotation
@@ -137,7 +86,6 @@ const namespace = (options) => {
 
   minim
     .use(apiDescription)
-    .register('parseResult', ParseResult)
     .register('annotation', Annotation)
     .register('sourceMap', SourceMap);
 };


### PR DESCRIPTION
Brings the organisation of the files to be consistent, next step to remove the functions which wrap them.