### PR TITLE
Rename minim option as namespace

### DIFF
--- a/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
@@ -2,15 +2,15 @@ const url = require('url');
 const ApiaryBlueprintParser = require('apiary-blueprint-parser');
 
 class Parser {
-  constructor({ minim, source }) {
-    this.minim = minim;
+  constructor({ namespace, source }) {
+    this.namespace = namespace;
     this.source = source;
   }
 
   parse() {
     const {
       Annotation, Category, Copy, ParseResult,
-    } = this.minim.elements;
+    } = this.namespace.elements;
 
     this.result = new ParseResult();
 
@@ -22,7 +22,7 @@ class Parser {
       this.result.push(annotation);
 
       if (err.offset) {
-        const { SourceMap } = this.minim.elements;
+        const { SourceMap } = this.namespace.elements;
         annotation.attributes.set('sourceMap', [
           new SourceMap([[err.offset, 1]]),
         ]);
@@ -36,7 +36,7 @@ class Parser {
     this.api.title = this.blueprint.name;
 
     if (this.blueprint.location) {
-      const { Member: MemberElement } = this.minim.elements;
+      const { Member: MemberElement } = this.namespace.elements;
       const member = new MemberElement('HOST', this.blueprint.location);
       member.meta.set('classes', ['user']);
       this.api.attributes.set('metadata', [member]);
@@ -80,7 +80,7 @@ class Parser {
     // A "resource" in Apiary blueprint isn't the same as a "resource" in API
     // Elements. It maps closer to an "action".
 
-    const { Copy, Category, Resource } = this.minim.elements;
+    const { Copy, Category, Resource } = this.namespace.elements;
 
     const group = new Category();
     group.title = section.name;
@@ -114,7 +114,7 @@ class Parser {
   }
 
   handleResource(resource) {
-    const { Copy, Transition, HttpTransaction } = this.minim.elements;
+    const { Copy, Transition, HttpTransaction } = this.namespace.elements;
     const transition = new Transition();
     transition.title = resource.method;
 
@@ -137,7 +137,7 @@ class Parser {
   }
 
   handleRequest(resource, request, schema) {
-    const { Asset, HttpRequest } = this.minim.elements;
+    const { Asset, HttpRequest } = this.namespace.elements;
     const httpRequest = new HttpRequest();
     httpRequest.method = resource.method;
     const headers = this.handleHeaders(request.headers);
@@ -159,7 +159,7 @@ class Parser {
   }
 
   handleResponse(response, schema) {
-    const { Asset, HttpResponse } = this.minim.elements;
+    const { Asset, HttpResponse } = this.namespace.elements;
     const httpResponse = new HttpResponse();
 
     httpResponse.statusCode = response.status;
@@ -186,8 +186,8 @@ class Parser {
       return null;
     }
 
-    const { HttpHeaders } = this.minim.elements;
-    const { Member: MemberElement } = this.minim.elements;
+    const { HttpHeaders } = this.namespace.elements;
+    const { Member: MemberElement } = this.namespace.elements;
 
     const httpHeaders = new HttpHeaders();
 
@@ -200,7 +200,7 @@ class Parser {
 
   // Create schema asset
   handleSchema(body) {
-    const { Asset } = this.minim.elements;
+    const { Asset } = this.namespace.elements;
     const asset = new Asset(body);
     asset.classes.push('messageBodySchema');
     asset.contentType = 'application/schema+json';

--- a/packages/fury-adapter-oas3-parser/lib/adapter.js
+++ b/packages/fury-adapter-oas3-parser/lib/adapter.js
@@ -15,7 +15,7 @@ function detect(source) {
 
 function parse(options) {
   const context = new Context(
-    options.minim,
+    options.namespace,
     {
       generateSourceMap: options.generateSourceMap,
     }

--- a/packages/fury-adapter-remote/lib/adapter.js
+++ b/packages/fury-adapter-remote/lib/adapter.js
@@ -72,7 +72,7 @@ class FuryRemoteAdapter {
     return false;
   }
 
-  parse({ source, minim, mediaType }) {
+  parse({ source, namespace, mediaType }) {
     const inputMediaType = mediaType || detectMediaType(source, defaultInputMediaType);
 
     return axios({
@@ -86,10 +86,10 @@ class FuryRemoteAdapter {
       },
       // allow code 422 to be identified as valid response
       validateStatus: status => ((status >= 200 && status < 300) || status === 422),
-    }).then(response => minim.serialiser.deserialise(response.data));
+    }).then(response => namespace.serialiser.deserialise(response.data));
   }
 
-  validate({ source, minim, mediaType }) {
+  validate({ source, namespace, mediaType }) {
     const inputMediaType = mediaType || detectMediaType(source, defaultInputMediaType);
 
     return axios({
@@ -105,11 +105,11 @@ class FuryRemoteAdapter {
         'Content-Type': 'application/json',
         Accept: outputMediaType,
       },
-    }).then(response => minim.serialiser.deserialise(response.data));
+    }).then(response => namespace.serialiser.deserialise(response.data));
   }
 
-  serialize({ api, minim, mediaType }) {
-    const content = minim.serialiser.serialise(api);
+  serialize({ api, namespace, mediaType }) {
+    const content = namespace.serialiser.serialise(api);
     const inputMediaType = (content.element && content.element === 'parseResult') ? 'application/vnd.refract+json' : 'application/vnd.refract.parse-result+json';
 
     return axios({

--- a/packages/fury-adapter-swagger/lib/generator.js
+++ b/packages/fury-adapter-swagger/lib/generator.js
@@ -41,7 +41,7 @@ function generateBody(schema) {
 
 const bodyFromSchema = (schema, payload, parser, contentType = 'application/json') => {
   const dereferencedSchema = dereference(schema, schema);
-  const { Asset } = parser.minim.elements;
+  const { Asset } = parser.namespace.elements;
   let asset = null;
 
   try {

--- a/packages/fury-adapter-swagger/lib/headers.js
+++ b/packages/fury-adapter-swagger/lib/headers.js
@@ -2,7 +2,7 @@ const { inferred } = require('./link');
 const annotations = require('./annotations');
 
 const createHeaders = (payload, parser) => {
-  const { HttpHeaders } = parser.minim.elements;
+  const { HttpHeaders } = parser.namespace.elements;
 
   const headers = new HttpHeaders();
 
@@ -11,7 +11,7 @@ const createHeaders = (payload, parser) => {
 };
 
 const pushHeader = (key, value, payload, parser, fragment) => {
-  const { Member: MemberElement } = parser.minim.elements;
+  const { Member: MemberElement } = parser.namespace.elements;
   let header;
 
   createHeaders(payload, parser);
@@ -29,7 +29,7 @@ const pushHeader = (key, value, payload, parser, fragment) => {
     inferred(fragment, header, parser);
   } else {
     // eslint-disable-next-line no-underscore-dangle
-    header._meta = parser.minim.toElement({});
+    header._meta = parser.namespace.toElement({});
   }
 
   if (fragment === undefined && parser.generateSourceMap) {

--- a/packages/fury-adapter-swagger/lib/link.js
+++ b/packages/fury-adapter-swagger/lib/link.js
@@ -1,5 +1,5 @@
 const baseLink = (element, parser, relation, options = {}) => {
-  const { String: StringElement, Link } = parser.minim.elements;
+  const { String: StringElement, Link } = parser.namespace.elements;
 
   const opts = {
     path: options.path || [],

--- a/packages/fury-adapter-swagger/lib/parser.js
+++ b/packages/fury-adapter-swagger/lib/parser.js
@@ -23,9 +23,9 @@ const {
 // the input Swagger into Refract elements. The `parse` function is its main
 // interface.
 class Parser {
-  constructor({ minim, source, generateSourceMap }) {
+  constructor({ namespace, source, generateSourceMap }) {
     // Parser options
-    this.minim = minim;
+    this.namespace = namespace;
     this.source = source;
     this.generateSourceMap = generateSourceMap;
 
@@ -47,7 +47,7 @@ class Parser {
   parse(done) {
     const {
       Category, ParseResult, SourceMap,
-    } = this.minim.elements;
+    } = this.namespace.elements;
     const swaggerParser = new SwaggerParser();
 
     this.result = new ParseResult();
@@ -244,7 +244,7 @@ class Parser {
         const annotation = this.createAnnotation(annotations.AST_UNAVAILABLE, null, message);
 
         if (err.problem_mark && err.problem_mark.pointer) {
-          const SourceMap = this.minim.getElementClass('sourceMap');
+          const SourceMap = this.namespace.getElementClass('sourceMap');
           const position = err.problem_mark.pointer;
 
           annotation.attributes.set('sourceMap', [
@@ -309,7 +309,7 @@ class Parser {
 
   // Converts the Swagger title and description
   handleSwaggerInfo() {
-    const { Copy } = this.minim.elements;
+    const { Copy } = this.namespace.elements;
 
     if (this.swagger.info) {
       this.withPath('info', () => {
@@ -357,7 +357,7 @@ class Parser {
 
   // Converts the Swagger hostname and schemes to a Refract host metadata entry.
   handleSwaggerHost() {
-    const { Member: MemberElement } = this.minim.elements;
+    const { Member: MemberElement } = this.namespace.elements;
 
     if (this.swagger.host) {
       this.withPath('host', () => {
@@ -393,7 +393,7 @@ class Parser {
 
   // Conver api key name into Refract elements
   apiKeyName(element, apiKey) {
-    const { Member: MemberElement } = this.minim.elements;
+    const { Member: MemberElement } = this.namespace.elements;
     let config;
 
     if (apiKey.in === 'query') {
@@ -413,7 +413,7 @@ class Parser {
 
   // Convert Oauth2 flow into Refract elements
   oauthGrantType(element, flow) {
-    const { Member: MemberElement } = this.minim.elements;
+    const { Member: MemberElement } = this.namespace.elements;
     let grantType = flow;
 
     if (flow === 'password') {
@@ -439,7 +439,7 @@ class Parser {
       Member: MemberElement,
       Array: ArrayElement,
       String: StringElement,
-    } = this.minim.elements;
+    } = this.namespace.elements;
 
     const scopes = new ArrayElement();
     let descriptions = null;
@@ -477,7 +477,7 @@ class Parser {
 
   // Conver OAuth2 transition information into Refract elements
   oauthTransitions(element, oauth) {
-    const { Transition } = this.minim.elements;
+    const { Transition } = this.namespace.elements;
 
     if (oauth.authorizationUrl) {
       const transition = new Transition();
@@ -510,7 +510,7 @@ class Parser {
 
   // Convert a Swagger auth object into Refract elements.
   handleSwaggerAuth() {
-    const { Category, AuthScheme } = this.minim.elements;
+    const { Category, AuthScheme } = this.namespace.elements;
     const schemes = [];
 
     if (this.swagger.securityDefinitions) {
@@ -592,7 +592,7 @@ class Parser {
   }
 
   handleSwaggerSecurity(security, schemes) {
-    const { AuthScheme } = this.minim.elements;
+    const { AuthScheme } = this.namespace.elements;
 
     _.forEach(security, (item, index) => {
       _.keys(item).forEach((name) => {
@@ -626,8 +626,8 @@ class Parser {
   }
 
   handleSwaggerDefinitions(definitions) {
-    const { Category } = this.minim.elements;
-    const generator = new DataStructureGenerator(this.minim, this.referencedSwagger);
+    const { Category } = this.namespace.elements;
+    const generator = new DataStructureGenerator(this.namespace, this.referencedSwagger);
     const dataStructures = new Category();
     dataStructures.classes.push('dataStructures');
 
@@ -658,7 +658,7 @@ class Parser {
 
   // Convert a Swagger path into a Refract resource.
   handleSwaggerPath(pathValue, href) {
-    const { Copy, Resource } = this.minim.elements;
+    const { Copy, Resource } = this.namespace.elements;
     const resource = new Resource();
 
     this.withPath('paths', href, () => {
@@ -736,7 +736,7 @@ class Parser {
       .value();
 
     if (Object.keys(extensions).length > 0) {
-      const { Link, Extension } = this.minim.elements;
+      const { Link, Extension } = this.namespace.elements;
 
       const profileLink = new Link();
       profileLink.relation = 'profile';
@@ -750,7 +750,7 @@ class Parser {
 
   // Convert a Swagger method into a Refract transition.
   handleSwaggerMethod(resource, href, resourceParams, methodValue, method) {
-    const { Copy, Transition } = this.minim.elements;
+    const { Copy, Transition } = this.namespace.elements;
     const transition = new Transition();
 
     resource.content.push(transition);
@@ -1039,7 +1039,7 @@ class Parser {
       return;
     }
 
-    const { DataStructure, Object: ObjectElement } = this.minim.elements;
+    const { DataStructure, Object: ObjectElement } = this.namespace.elements;
 
     if (!contentType) {
       // No content type was provided, lets default to first form
@@ -1087,7 +1087,7 @@ class Parser {
     transaction, methodValue, responseValue,
     statusCode, responseBody, contentType
   ) {
-    const { Asset, Copy } = this.minim.elements;
+    const { Asset, Copy } = this.namespace.elements;
     const { response } = transaction;
 
     this.withPath('responses', statusCode, () => {
@@ -1228,7 +1228,7 @@ class Parser {
 
   // Update the current group by either selecting or creating it.
   updateResourceGroup(name) {
-    const { Category, Copy } = this.minim.elements;
+    const { Category, Copy } = this.namespace.elements;
 
     if (name) {
       this.group = this.api.find(el => el.element === 'category' && el.classes.contains('resourceGroup') && el.title.toValue() === name).first;
@@ -1277,7 +1277,7 @@ class Parser {
     const {
       Array: ArrayElement, Boolean: BooleanElement, Number: NumberElement,
       String: StringElement,
-    } = this.minim.elements;
+    } = this.namespace.elements;
 
     const types = {
       string: StringElement,
@@ -1297,11 +1297,11 @@ class Parser {
 
     if (schema.type === 'file') {
       // files don't have types
-      return this.minim.toElement(value);
+      return this.namespace.toElement(value);
     }
 
     if (validator.validate(value, schema)) {
-      element = this.minim.toElement(value);
+      element = this.namespace.toElement(value);
 
       if (this.generateSourceMap) {
         this.createSourceMap(element, this.path);
@@ -1314,7 +1314,7 @@ class Parser {
       // Coerce parameter to correct type
       if (schema.type === 'string') {
         if (typeof value === 'number' || typeof value === 'boolean') {
-          element = new this.minim.elements.String(String(value));
+          element = new this.namespace.elements.String(String(value));
         }
       }
     }
@@ -1324,7 +1324,7 @@ class Parser {
 
   // Convert a Swagger parameter into a Refract element.
   convertParameterToElement(parameter, setAttributes = false) {
-    const { Array: ArrayElement, Enum: EnumElement } = this.minim.elements;
+    const { Array: ArrayElement, Enum: EnumElement } = this.namespace.elements;
 
     const Type = this.typeForParameter(parameter);
     const schema = this.schemaForParameterValue(parameter);
@@ -1422,7 +1422,7 @@ class Parser {
   // Convert a Swagger parameter into a Refract member element for use in an
   // object element (or subclass).
   convertParameterToMember(parameter) {
-    const MemberElement = this.minim.getElementClass('member');
+    const MemberElement = this.namespace.getElementClass('member');
     const memberValue = this.convertParameterToElement(parameter);
     const member = new MemberElement(parameter.name, memberValue);
 
@@ -1448,8 +1448,8 @@ class Parser {
   // Make a new source map for the given element
   createSourceMap(element, path, produceLineColumnAttributes) {
     if (this.ast) {
-      const NumberElement = this.minim.elements.Number;
-      const SourceMap = this.minim.getElementClass('sourceMap');
+      const NumberElement = this.namespace.elements.Number;
+      const SourceMap = this.namespace.getElementClass('sourceMap');
       const position = this.ast.getPosition(path);
 
       if (position && position.start && position.end
@@ -1471,7 +1471,7 @@ class Parser {
 
   // Make a new annotation for the given path and message
   createAnnotation(info, path, message) {
-    const { Annotation } = this.minim.elements;
+    const { Annotation } = this.namespace.elements;
 
     const annotation = new Annotation(message);
     annotation.classes.push(info.type);
@@ -1493,7 +1493,7 @@ class Parser {
   // Create a new HrefVariables element from a parameter list. Returns either
   // the new HrefVariables element or `undefined`.
   createHrefVariables(params) {
-    const { HrefVariables } = this.minim.elements;
+    const { HrefVariables } = this.namespace.elements;
     const hrefVariables = new HrefVariables();
 
     _.forEach(params, (parameter, index) => {
@@ -1544,7 +1544,7 @@ class Parser {
 
   // Create a Refract asset element containing JSON Schema and push into payload
   pushSchemaAsset(schema, jsonSchema, payload, path) {
-    const Asset = this.minim.getElementClass('asset');
+    const Asset = this.namespace.getElementClass('asset');
     const schemaAsset = new Asset(JSON.stringify(jsonSchema));
 
     schemaAsset.classes.push('messageBodySchema');
@@ -1577,7 +1577,7 @@ class Parser {
 
   pushDataStructureAsset(schema, payload) {
     try {
-      const generator = new DataStructureGenerator(this.minim, this.referencedSwagger);
+      const generator = new DataStructureGenerator(this.namespace, this.referencedSwagger);
       const dataStructure = generator.generateDataStructure(schema);
       if (dataStructure) {
         payload.content.push(dataStructure);
@@ -1589,7 +1589,7 @@ class Parser {
 
   // Create a new Refract transition element with a blank request and response.
   createTransaction(transition, method, schemes) {
-    const { HttpRequest, HttpResponse, HttpTransaction } = this.minim.elements;
+    const { HttpRequest, HttpResponse, HttpTransaction } = this.namespace.elements;
     const transaction = new HttpTransaction();
     transaction.content = [new HttpRequest(), new HttpResponse()];
 

--- a/packages/fury-adapter-swagger/test/generator-test.js
+++ b/packages/fury-adapter-swagger/test/generator-test.js
@@ -2,10 +2,10 @@ const { expect } = require('chai');
 const { Fury } = require('fury');
 const { bodyFromSchema } = require('../lib/generator');
 
-const { minim } = new Fury();
+const { minim: namespace } = new Fury();
 
 describe('bodyFromSchema', () => {
-  const parser = { minim };
+  const parser = { namespace };
 
   it('can generate a JSON body', () => {
     const schema = {

--- a/packages/fury-adapter-swagger/test/parameter-test.js
+++ b/packages/fury-adapter-swagger/test/parameter-test.js
@@ -2,12 +2,12 @@ const { expect } = require('chai');
 const { Fury } = require('fury');
 const Parser = require('../lib/parser');
 
-const { minim } = new Fury();
-const { Annotation } = minim.elements;
+const { minim: namespace } = new Fury();
+const { Annotation } = namespace.elements;
 
 describe('Parameter to Member converter', () => {
   it('can convert a parameter to a member with x-example', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'tags',
@@ -16,12 +16,12 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.String);
+    expect(member.value).to.be.instanceof(namespace.elements.String);
     expect(member.value.toValue()).to.equal('hello');
   });
 
   it('can convert a parameter to a member with array x-example', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'tags',
@@ -30,12 +30,12 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value).to.be.instanceof(namespace.elements.Array);
     expect(member.value.toValue()).to.deep.equal(['one', 'two']);
   });
 
   it('can convert a parameter to a member with array x-example and items', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'tags',
@@ -47,12 +47,12 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value).to.be.instanceof(namespace.elements.Array);
     expect(member.value.toValue()).to.deep.equal(['one', 'two']);
   });
 
   it('can convert a parameter to a member with array empty items', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'tags',
@@ -62,12 +62,12 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value).to.be.instanceof(namespace.elements.Array);
     expect(member.value.toValue()).to.deep.equal([]);
   });
 
   it('can convert a parameter to a member with array x-example and items but with string example', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'tags',
@@ -78,21 +78,21 @@ describe('Parameter to Member converter', () => {
       'x-example': "['one', 'two']",
     };
 
-    parser.result = new minim.elements.ParseResult();
+    parser.result = new namespace.elements.ParseResult();
 
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value).to.be.instanceof(namespace.elements.Array);
 
     expect(member.value.length).to.equal(1);
-    expect(member.value.get(0)).to.be.instanceof(minim.elements.String);
+    expect(member.value.get(0)).to.be.instanceof(namespace.elements.String);
     expect(member.value.get(0).toValue()).to.be.undefined;
 
     expect(parser.result.toValue()).to.deep.equal(['Expected type array but found type string']);
   });
 
   it('can convert a parameter with enum values to a member with enumerations', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'order',
@@ -101,15 +101,15 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Element);
+    expect(member.value).to.be.instanceof(namespace.elements.Element);
     const enumerations = member.value.attributes.get('enumerations');
 
-    expect(enumerations).to.be.instanceof(minim.elements.Array);
+    expect(enumerations).to.be.instanceof(namespace.elements.Array);
     expect(enumerations.toValue()).to.deep.equal(['ascending', 'descending']);
   });
 
   it('can convert a parameter with array enum values to a member with enumerations', () => {
-    const parser = new Parser({ minim, source: '' });
+    const parser = new Parser({ namespace, source: '' });
     const parameter = {
       in: 'query',
       name: 'tags',
@@ -123,16 +123,16 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Element);
+    expect(member.value).to.be.instanceof(namespace.elements.Element);
     const enumerations = member.value.attributes.get('enumerations');
 
-    expect(enumerations).to.be.instanceof(minim.elements.Array);
+    expect(enumerations).to.be.instanceof(namespace.elements.Array);
     expect(enumerations.toValue()).to.deep.equal([['hello']]);
   });
 
   it('creates a warning when example does not match parameter type', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
     parser.convertParameterToMember({
       type: 'string',
       'x-example': 5,
@@ -143,8 +143,8 @@ describe('Parameter to Member converter', () => {
   });
 
   it('creates a warning when default does not match parameter type', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
     parser.convertParameterToMember({
       type: 'string',
       default: 5,
@@ -155,8 +155,8 @@ describe('Parameter to Member converter', () => {
   });
 
   it('creates a warning when enum type does not match parameter type', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
     parser.convertParameterToMember({
       type: 'string',
       enum: [5],
@@ -167,8 +167,8 @@ describe('Parameter to Member converter', () => {
   });
 
   it('discards invalid parameter enumerations', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
 
     const parameter = {
       in: 'query',
@@ -182,8 +182,8 @@ describe('Parameter to Member converter', () => {
     };
     const member = parser.convertParameterToMember(parameter);
 
-    expect(member.value).to.be.instanceof(minim.elements.Array);
-    expect(member.value.get(0)).to.be.instanceof(minim.elements.Enum);
+    expect(member.value).to.be.instanceof(namespace.elements.Array);
+    expect(member.value.get(0)).to.be.instanceof(namespace.elements.Enum);
     expect(member.value.get(0).enumerations.toValue()).to.deep.equal(['red']);
 
     expect(parser.result.warnings.get(0)).to.be.instanceof(Annotation);
@@ -191,8 +191,8 @@ describe('Parameter to Member converter', () => {
   });
 
   it('creates a warning when example does not match items parameter type', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
     parser.convertParameterToMember({
       type: 'array',
       items: {
@@ -206,8 +206,8 @@ describe('Parameter to Member converter', () => {
   });
 
   it('coerces an integer value that does not match string parameter type', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
     const parameter = parser.convertParameterToElement({
       type: 'string',
       'x-example': 5,
@@ -218,8 +218,8 @@ describe('Parameter to Member converter', () => {
   });
 
   it('coerces an boolean value that does not match string parameter type', () => {
-    const parser = new Parser({ minim, source: '' });
-    parser.result = new minim.elements.ParseResult();
+    const parser = new Parser({ namespace, source: '' });
+    parser.result = new namespace.elements.ParseResult();
     const parameter = parser.convertParameterToElement({
       type: 'string',
       'x-example': true,

--- a/packages/fury-adapter-swagger/test/parser-test.js
+++ b/packages/fury-adapter-swagger/test/parser-test.js
@@ -6,7 +6,7 @@ describe('Parser', () => {
   let parser;
 
   before(() => {
-    parser = new Parser({ minim: fury.minim });
+    parser = new Parser({ namespace: fury.minim });
     parser.swagger = {
       consumes: [],
       produces: [],

--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -7,6 +7,9 @@
 - The interface between Fury and adapters now uses promises. Any adapters need
   to be updated to use a promise interface.
 
+- The `minim` option passed down to adapters has been renamed to `namespace`.
+  The underlying value is a namespace from minim.
+
 ## 3.0.0-beta.10 (2019-03-26)
 
 ### Breaking

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -41,7 +41,7 @@ const findAdapter = (adapters, mediaType, method) => {
  *
  * @param {Object} options
  * @param {string} options.source
- * @param {Namespace} options.minim
+ * @param {Namespace} options.namespace
  *
  * @returns {Promise}
  *
@@ -53,7 +53,7 @@ const findAdapter = (adapters, mediaType, method) => {
  *
  * @param {Object} options
  * @param {string} options.source
- * @param {Namespace} options.minim
+ * @param {Namespace} options.namespace
  *
  * @returns {Promise}
  *
@@ -65,7 +65,7 @@ const findAdapter = (adapters, mediaType, method) => {
  *
  * @param {Object} options
  * @param {Category} options.api
- * @param {Namespace} options.minim
+ * @param {Namespace} options.namespace
  *
  * @returns {Promise}
  *
@@ -155,7 +155,7 @@ class Fury {
       return;
     }
 
-    let options = { minim: this.minim, mediaType, source };
+    let options = { namespace: this.minim, mediaType, source };
 
     if (adapterOptions) {
       options = Object.assign(options, adapterOptions);
@@ -195,7 +195,7 @@ class Fury {
     }
 
     let options = {
-      generateSourceMap, minim: this.minim, mediaType, source,
+      generateSourceMap, namespace: this.minim, mediaType, source,
     };
 
     if (adapterOptions) {
@@ -236,7 +236,7 @@ class Fury {
     }
 
     adapter
-      .serialize({ api, minim: this.minim, mediaType })
+      .serialize({ api, namespace: this.minim, mediaType })
       .then(result => done(null, result), done);
   }
 }

--- a/packages/fury/test/parse-test.js
+++ b/packages/fury/test/parse-test.js
@@ -33,8 +33,8 @@ describe('Parser', () => {
 
   it('should parse when returning element instances', (done) => {
     // Modify the parse method to return an element instance
-    fury.adapters[fury.adapters.length - 1].parse = ({ minim, source }) => {
-      const { ParseResult } = minim.elements;
+    fury.adapters[fury.adapters.length - 1].parse = ({ namespace, source }) => {
+      const { ParseResult } = namespace.elements;
       return Promise.resolve(new ParseResult(source));
     };
 
@@ -47,8 +47,8 @@ describe('Parser', () => {
   it('should pass adapter options during parsing', (done) => {
     const { length } = fury.adapters;
 
-    fury.adapters[length - 1].parse = ({ minim, testOption = false }) => {
-      const BooleanElement = minim.getElementClass('boolean');
+    fury.adapters[length - 1].parse = ({ namespace, testOption = false }) => {
+      const BooleanElement = namespace.getElementClass('boolean');
       return Promise.resolve(new BooleanElement(testOption));
     };
 

--- a/packages/fury/test/serialize-test.js
+++ b/packages/fury/test/serialize-test.js
@@ -35,7 +35,7 @@ describe('Serialize', () => {
     fury.use({
       name: 'json',
       mediaTypes: ['application/json'],
-      serialize: ({ api, minim }) => Promise.resolve(JSON.stringify(minim.serialiser.serialise(api))),
+      serialize: ({ api, namespace }) => Promise.resolve(JSON.stringify(namespace.serialiser.serialise(api))),
     });
 
     const api = new fury.minim.elements.Category();

--- a/packages/fury/test/validate-test.js
+++ b/packages/fury/test/validate-test.js
@@ -97,8 +97,8 @@ describe('Validation', () => {
 
     it('should pass adapter options during validation', (done) => {
       shouldDetect = true;
-      fury.adapters[0].validate = ({ minim, testOption = false }) => {
-        const BooleanElement = minim.getElementClass('boolean');
+      fury.adapters[0].validate = ({ namespace, testOption = false }) => {
+        const BooleanElement = namespace.getElementClass('boolean');
         return Promise.resolve(new BooleanElement(testOption));
       };
 


### PR DESCRIPTION
Part of https://github.com/apiaryio/api-elements.js/issues/28, the `minim` option passed between Fury and the adapters has now been renamed to `namespace` which is clearer. "minim" is the library and "namespace" is the instance of Namespace from minim.

BREAKING CHANGE: The interface between Fury and the adapters now provides the Minim Namespace under the key `namespace` (previously `minim`)