### PR TITLE
Test on Node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,17 +15,22 @@ defaults: &defaults
 
 jobs:
   test-node6:
+    <<: *defaults
     docker:
       - image: circleci/node:6
-    <<: *defaults
 
   test-node8:
+    <<: *defaults
     docker:
       - image: circleci/node:8
-    <<: *defaults
 
   test-node10:
     <<: *defaults
+
+  test-node12:
+    <<: *defaults
+    docker:
+      - image: circleci/node:12
 
   lint:
     <<: *defaults


### PR DESCRIPTION
Node 12 has reached current version, let's make sure it works for users to aid future upgrading (https://nodejs.org/en/about/releases/).