### PR TITLE
Enable Node 12 tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,5 +63,6 @@ workflows:
       - test-node6
       - test-node8
       - test-node10
+      - test-node12
       - lint
       - docs

--- a/packages/fury-adapter-remote/test/fury-test.js
+++ b/packages/fury-adapter-remote/test/fury-test.js
@@ -256,7 +256,7 @@ describe('Adapter works with Fury interface', () => {
       fury.parse({ source: blueprintSource, mediaType: 'text/vnd.apiblueprint' }, (err, result) => {
         expect(result).to.be.undefined;
         expect(err).to.be.instanceof(Error);
-        expect(err).to.have.property('message', 'getaddrinfo ENOTFOUND some.stupid.non.existing.domain some.stupid.non.existing.domain:80');
+        expect(err.message).to.match(/ENOTFOUND some\.stupid\.non\.existing\.domain/);
         done();
       });
     });


### PR DESCRIPTION
Missing change from https://github.com/apiaryio/api-elements.js/pull/242. There is one remote test which fails because they've changed the error message in Node JS, before the error message was:

> getaddrinfo ENOTFOUND some.stupid.non.existing.domain some.stupid.non.existing.domain:80

Now it is:

> ENOTFOUND some.stupid.non.existing.domain

I've used regex matching to support both, you can see from CI builds.