### PR TITLE
Support async/await (and promises)

### DIFF
--- a/packages/fury/CHANGELOG.md
+++ b/packages/fury/CHANGELOG.md
@@ -11,7 +11,14 @@
   The underlying value is a namespace from minim.
 
 - Support for NodeJS 6 has been removed, upgrading to NodeJS 8 or newer is
-  recommended.
+
+### Enhancements
+
+- Fury can now be used with promises or async/await. For example:
+
+  ```js
+  const parseResult = await fury.parse({ source: '# Hello World' });
+  ```
 
 ## 3.0.0-beta.10 (2019-03-26)
 

--- a/packages/fury/README.md
+++ b/packages/fury/README.md
@@ -37,15 +37,14 @@ const source = 'FORMAT: 1A\n# My API\n...';
 fury.use(apibParser);
 
 // Parse the input and print 'My API'
-fury.parse({source}, function(err, result) {
-  console.log(result.api.title);
-});
+const parseResult = await fury.parse({ source });
+console.log(parseResult.api.title);
 ```
 
 Once you have a parsed API it is easy to traverse:
 
 ```js
-api.resourceGroups.forEach(function (resourceGroup) {
+parseResult.api.resourceGroups.forEach(function (resourceGroup) {
   console.log(resourceGroup.title);
 
   resourceGroup.resources.forEach(function (resource) {
@@ -108,7 +107,7 @@ import {Fury} from 'fury';
 const fury1 = new Fury();
 const fury2 = new Fury();
 
-fury1.parse(...);
+await fury1.parse(...);
 ```
 
 #### Writing an Adapter
@@ -190,7 +189,6 @@ import myAdapter from './my-adapter';
 fury.use(myAdapter);
 
 // Now parse my custom input format!
-fury.parse({source: 'some-test\n...'}, function (err, api) {
-  console.log(api.title);
-});
+const parseResult = await fury.parse({ source: 'some-test\n...' });
+console.log(parseResult.api.title);
 ```

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -152,7 +152,7 @@ class Fury {
 
       if (done) {
         promise.then(result => done(null, result), done);
-        return;
+        return null;
       }
 
       return promise;
@@ -169,14 +169,14 @@ class Fury {
       .then((parseResult) => {
         if (parseResult && !(parseResult instanceof this.minim.Element)) {
           return this.load(parseResult);
-        } else {
-          return parseResult;
         }
+
+        return parseResult;
       });
 
     if (done) {
       promise.then(result => done(null, result), done);
-      return;
+      return null;
     }
 
     return promise;
@@ -205,7 +205,7 @@ class Fury {
 
       if (done) {
         done(error);
-        return;
+        return null;
       }
 
       return Promise.reject(error);
@@ -223,14 +223,14 @@ class Fury {
       .then((parseResult) => {
         if (parseResult instanceof this.minim.Element) {
           return parseResult;
-        } else {
-          return this.load(parseResult);
         }
+
+        return this.load(parseResult);
       });
 
     if (done) {
       promise.then(result => done(null, result), done);
-      return;
+      return null;
     }
 
     return promise;
@@ -259,17 +259,17 @@ class Fury {
 
       if (done) {
         done(error);
-        return;
+        return null;
       }
 
       return Promise.reject(error);
     }
 
-    const promise = adapter.serialize({ api, namespace: this.minim, mediaType })
+    const promise = adapter.serialize({ api, namespace: this.minim, mediaType });
 
     if (done) {
       promise.then(result => done(null, result), done);
-      return;
+      return null;
     }
 
     return promise;

--- a/packages/fury/lib/fury.js
+++ b/packages/fury/lib/fury.js
@@ -231,13 +231,24 @@ class Fury {
     const adapter = findAdapter(this.adapters, mediaType, 'serialize');
 
     if (!adapter) {
-      done(new Error('Media type did not match any registered serializer!'));
+      const error = new Error('Media type did not match any registered serializer!');
+
+      if (done) {
+        done(error);
+        return;
+      }
+
+      return Promise.reject(error);
+    }
+
+    const promise = adapter.serialize({ api, namespace: this.minim, mediaType })
+
+    if (done) {
+      promise.then(result => done(null, result), done);
       return;
     }
 
-    adapter
-      .serialize({ api, namespace: this.minim, mediaType })
-      .then(result => done(null, result), done);
+    return promise;
   }
 }
 

--- a/packages/fury/test/assert.js
+++ b/packages/fury/test/assert.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+
+// Nearly API Compatible version of assert.rejects from Node 10
+// https://nodejs.org/api/assert.html#assert_assert_rejects_asyncfn_error_message
+// We're only supporting errorMessage as input
+async function rejects(asyncFn, errorMessage) {
+  let didThrow = false;
+
+  try {
+    await asyncFn();
+  } catch (error) {
+    didThrow = true;
+
+    assert.equal(error.message, errorMessage);
+  }
+
+  if (!didThrow) {
+    assert.fail('asyncFn did not throw');
+  }
+}
+
+module.exports = {
+  rejects,
+};

--- a/packages/fury/test/parse-test.js
+++ b/packages/fury/test/parse-test.js
@@ -1,10 +1,11 @@
 const { assert } = require('chai');
 const { Fury } = require('../lib/fury');
+const { rejects } = require('./assert');
 
 describe('Parser', () => {
   let fury;
 
-  before(() => {
+  beforeEach(() => {
     fury = new Fury();
     const adapter = {
       name: 'passthrough',
@@ -17,64 +18,99 @@ describe('Parser', () => {
     fury.use(adapter);
   });
 
-  it('should parse through mediatype', (done) => {
-    fury.parse({ source: 'dummy', mediaType: 'text/vnd.passthrough' }, (err, result) => {
-      assert.equal(result.content, 'dummy');
-      done(err);
+  describe('using callback', () => {
+    it('should parse through mediatype', (done) => {
+      fury.parse({ source: 'dummy', mediaType: 'text/vnd.passthrough' }, (err, result) => {
+        assert.equal(result.content, 'dummy');
+        done(err);
+      });
+    });
+
+    it('should parse through autodetect', (done) => {
+      fury.parse({ source: 'dummy' }, (err, result) => {
+        assert.equal(result.content, 'dummy');
+        done(err);
+      });
+    });
+
+    it('should parse when returning element instances', (done) => {
+      // Modify the parse method to return an element instance
+      fury.adapters[fury.adapters.length - 1].parse = ({ namespace, source }) => {
+        const { ParseResult } = namespace.elements;
+        return Promise.resolve(new ParseResult(source));
+      };
+
+      fury.parse({ source: 'dummy' }, (err, result) => {
+        assert.equal(result.toValue(), 'dummy');
+        done(err);
+      });
+    });
+
+    it('should pass adapter options during parsing', (done) => {
+      const { length } = fury.adapters;
+
+      fury.adapters[length - 1].parse = ({ namespace, testOption = false }) => {
+        const BooleanElement = namespace.getElementClass('boolean');
+        return Promise.resolve(new BooleanElement(testOption));
+      };
+
+      fury.parse({ source: 'dummy', adapterOptions: { testOption: true } }, (err, result) => {
+        assert.isNull(err);
+        assert.isTrue(result.content);
+        done();
+      });
+    });
+
+    it('should error on parser error', (done) => {
+      const expectedError = new Error();
+      fury.adapters[fury.adapters.length - 1].parse = () => Promise.reject(expectedError);
+
+      fury.parse({ source: 'dummy' }, (err, parseResult) => {
+        assert.equal(err, expectedError);
+        assert.isUndefined(parseResult);
+        done();
+      });
+    });
+
+    it('should error on missing parser', (done) => {
+      fury.adapters[fury.adapters.length - 1].parse = undefined;
+      fury.parse({ source: 'dummy' }, (err) => {
+        assert.instanceOf(err, Error);
+        done();
+      });
     });
   });
 
-  it('should parse through autodetect', (done) => {
-    fury.parse({ source: 'dummy' }, (err, result) => {
-      assert.equal(result.content, 'dummy');
-      done(err);
+  describe('using async/await', () => {
+    it('errors with unknown mediaType', async () => {
+      const fury = new Fury();
+      const source = '';
+
+      await rejects(
+        async () => {
+          await fury.parse({ source, mediaType: 'application/unregistered' });
+        },
+        'Document did not match any registered parsers!'
+      );
     });
-  });
 
-  it('should parse when returning element instances', (done) => {
-    // Modify the parse method to return an element instance
-    fury.adapters[fury.adapters.length - 1].parse = ({ namespace, source }) => {
-      const { ParseResult } = namespace.elements;
-      return Promise.resolve(new ParseResult(source));
-    };
+    it('errors with matching erroring adapter', async () => {
+      const expectedError = new Error('failed to parse');
+      fury.adapters[fury.adapters.length - 1].parse = () => Promise.reject(expectedError);
 
-    fury.parse({ source: 'dummy' }, (err, result) => {
-      assert.equal(result.toValue(), 'dummy');
-      done(err);
+      await rejects(
+        async () => {
+          await fury.parse({ source: '' });
+        },
+        'failed to parse'
+      );
     });
-  });
 
-  it('should pass adapter options during parsing', (done) => {
-    const { length } = fury.adapters;
+    it('can parse with matching adapter', async () => {
+      const result = await fury.parse({ source: 'doc' });
 
-    fury.adapters[length - 1].parse = ({ namespace, testOption = false }) => {
-      const BooleanElement = namespace.getElementClass('boolean');
-      return Promise.resolve(new BooleanElement(testOption));
-    };
-
-    fury.parse({ source: 'dummy', adapterOptions: { testOption: true } }, (err, result) => {
-      assert.isNull(err);
-      assert.isTrue(result.content);
-      done();
-    });
-  });
-
-  it('should error on parser error', (done) => {
-    const expectedError = new Error();
-    fury.adapters[fury.adapters.length - 1].parse = () => Promise.reject(expectedError);
-
-    fury.parse({ source: 'dummy' }, (err, parseResult) => {
-      assert.equal(err, expectedError);
-      assert.isUndefined(parseResult);
-      done();
-    });
-  });
-
-  it('should error on missing parser', (done) => {
-    fury.adapters[fury.adapters.length - 1].parse = undefined;
-    fury.parse({ source: 'dummy' }, (err) => {
-      assert.instanceOf(err, Error);
-      done();
+      assert.instanceOf(result, fury.minim.elements.String);
+      assert.equal(result.toValue(), 'doc');
     });
   });
 });

--- a/packages/fury/test/serialize-test.js
+++ b/packages/fury/test/serialize-test.js
@@ -1,49 +1,98 @@
 const { expect } = require('chai');
 const { Fury } = require('../lib/fury');
+const assert = require('./assert');
 
 describe('Serialize', () => {
-  it('errors with unknown mediaType', (done) => {
-    const fury = new Fury();
-    const api = new fury.minim.elements.Category();
+  describe('using callback', () => {
+    it('errors with unknown mediaType', (done) => {
+      const fury = new Fury();
+      const api = new fury.minim.elements.Category();
 
-    fury.serialize({ api, mediaType: 'application/unregistered' }, (error, result) => {
-      expect(error.message).to.equal('Media type did not match any registered serializer!');
-      expect(result).to.be.undefined;
-      done();
+      fury.serialize({ api, mediaType: 'application/unregistered' }, (error, result) => {
+        expect(error.message).to.equal('Media type did not match any registered serializer!');
+        expect(result).to.be.undefined;
+        done();
+      });
+    });
+
+    it('errors with matching erroring adapter', (done) => {
+      const fury = new Fury();
+      fury.use({
+        name: 'json',
+        mediaTypes: ['application/json'],
+        serialize: () => Promise.reject(new Error('failed to serialize')),
+      });
+
+      const api = new fury.minim.elements.Category();
+
+      fury.serialize({ api, mediaType: 'application/json' }, (error, result) => {
+        expect(error.message).to.equal('failed to serialize');
+        expect(result).to.be.undefined;
+        done();
+      });
+    });
+
+    it('can serialize with matching adapter', (done) => {
+      const fury = new Fury();
+      fury.use({
+        name: 'json',
+        mediaTypes: ['application/json'],
+        serialize: ({ api, namespace }) => Promise.resolve(JSON.stringify(namespace.serialiser.serialise(api))),
+      });
+
+      const api = new fury.minim.elements.Category();
+
+      fury.serialize({ api, mediaType: 'application/json' }, (error, result) => {
+        expect(error).to.be.null;
+        expect(result).to.equal('{"element":"category"}');
+        done();
+      });
     });
   });
 
-  it('errors with matching erroring adapter', (done) => {
-    const fury = new Fury();
-    fury.use({
-      name: 'json',
-      mediaTypes: ['application/json'],
-      serialize: () => Promise.reject(new Error('failed to serialize')),
+  describe('using async/await', () => {
+    it('errors with unknown mediaType', async () => {
+      const fury = new Fury();
+      const api = new fury.minim.elements.Category();
+
+      await assert.rejects(
+        async () => {
+          await fury.serialize({ api, mediaType: 'application/unregistered' });
+        },
+        'Media type did not match any registered serializer!'
+      );
     });
 
-    const api = new fury.minim.elements.Category();
+    it('errors with matching erroring adapter', async () => {
+      const fury = new Fury();
+      fury.use({
+        name: 'json',
+        mediaTypes: ['application/json'],
+        serialize: () => Promise.reject(new Error('failed to serialize')),
+      });
 
-    fury.serialize({ api, mediaType: 'application/json' }, (error, result) => {
-      expect(error.message).to.equal('failed to serialize');
-      expect(result).to.be.undefined;
-      done();
+      const api = new fury.minim.elements.Category();
+
+      await assert.rejects(
+        async () => {
+          await fury.serialize({ api, mediaType: 'application/json' });
+        },
+        'failed to serialize'
+      );
     });
-  });
 
-  it('can serialize with matching adapter', (done) => {
-    const fury = new Fury();
-    fury.use({
-      name: 'json',
-      mediaTypes: ['application/json'],
-      serialize: ({ api, namespace }) => Promise.resolve(JSON.stringify(namespace.serialiser.serialise(api))),
-    });
+    it('can serialize with matching adapter', async () => {
+      const fury = new Fury();
+      fury.use({
+        name: 'json',
+        mediaTypes: ['application/json'],
+        serialize: ({ api, namespace }) => Promise.resolve(JSON.stringify(namespace.serialiser.serialise(api))),
+      });
 
-    const api = new fury.minim.elements.Category();
+      const api = new fury.minim.elements.Category();
 
-    fury.serialize({ api, mediaType: 'application/json' }, (error, result) => {
-      expect(error).to.be.null;
+      const result = await fury.serialize({ api, mediaType: 'application/json' });
       expect(result).to.equal('{"element":"category"}');
-      done();
     });
   });
 });


### PR DESCRIPTION
Implements support for async/await (and promises) under https://github.com/apiaryio/api-elements.js/issues/37.

Effectively, the following work:

```js
const parseResult = await fury.parse({ source });
console.log(parseResult.api.title.toValue());
```

```js
fury
  .parse({ source })
  .then((parseResult) => {
    console.log(parseResult.api.title.toValue());
  });
```

```js
// existing behaviour with callbacks
fury.parse({ source }, (err, parseResult) => {
  console.log(parseResult.api.title.toValue());
});
```

~This depends on https://github.com/apiaryio/api-elements.js/pull/244 as I am using async/await syntax in the tests which won't work on Node 6.~