### PR TITLE
Add hrefVariables property to HttpRequest

### DIFF
--- a/packages/api-elements/CHANGELOG.md
+++ b/packages/api-elements/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Support for NodeJS 6 has been removed, upgrading to NodeJS 8 or newer is
   recommended.
 
+### Enhancements
+
+- Added the `hrefVariables` property to `HttpRequest` element.
+
 ## 0.1.1 (2019-03-26)
 
 ### Enhancements

--- a/packages/api-elements/lib/elements/HttpRequest.js
+++ b/packages/api-elements/lib/elements/HttpRequest.js
@@ -40,6 +40,19 @@ class HttpRequest extends HttpMessagePayload {
   set href(value) {
     this.attributes.set('href', value);
   }
+
+  /**
+   * @name hrefVariables
+   * @type ObjectElement
+   * @memberof HttpRequest.prototype
+   */
+  get hrefVariables() {
+    return this.attributes.get('hrefVariables');
+  }
+
+  set hrefVariables(value) {
+    this.attributes.set('hrefVariables', value);
+  }
 }
 
 module.exports = HttpRequest;

--- a/packages/api-elements/test/elements/HttpRequest-test.js
+++ b/packages/api-elements/test/elements/HttpRequest-test.js
@@ -45,4 +45,32 @@ describe('HttpRequest', () => {
       assert.equal(method.toValue(), '/');
     });
   });
+
+  describe('#hrefVariables', () => {
+    it('can access hrefVariables attribute via property', () => {
+      const request = new HttpRequest();
+      request.attributes.set('hrefVariables', {
+        limit: 5,
+      });
+
+      assert(request.hrefVariables instanceof namespace.elements.Object);
+      assert.deepEqual(request.hrefVariables.valueOf(), {
+        limit: 5,
+      });
+    });
+
+    it('can set href attribute via property', () => {
+      const request = new HttpRequest();
+
+      request.hrefVariables = {
+        limit: 5,
+      };
+
+      const hrefVariables = request.attributes.get('hrefVariables');
+      assert(hrefVariables instanceof namespace.elements.Object);
+      assert.deepEqual(hrefVariables.valueOf(), {
+        limit: 5,
+      });
+    });
+  });
 });

--- a/packages/api-elements/test/elements/HttpRequest-test.js
+++ b/packages/api-elements/test/elements/HttpRequest-test.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const { Namespace } = require('../../lib/api-elements');
+
+const namespace = new Namespace();
+
+describe('HttpRequest', () => {
+  const { HttpRequest } = namespace.elements;
+
+  describe('#method', () => {
+    it('can access method attribute via property', () => {
+      const request = new HttpRequest();
+      request.attributes.set('method', 'GET');
+
+      assert(request.method instanceof namespace.elements.String);
+      assert.equal(request.method.toValue(), 'GET');
+    });
+
+    it('can set method attribute via property', () => {
+      const request = new HttpRequest();
+
+      request.method = 'GET';
+
+      const method = request.attributes.get('method');
+      assert(method instanceof namespace.elements.String);
+      assert.equal(method.toValue(), 'GET');
+    });
+  });
+
+  describe('#href', () => {
+    it('can access href attribute via property', () => {
+      const request = new HttpRequest();
+      request.attributes.set('href', '/');
+
+      assert(request.href instanceof namespace.elements.String);
+      assert.equal(request.href.toValue(), '/');
+    });
+
+    it('can set href attribute via property', () => {
+      const request = new HttpRequest();
+
+      request.href = '/';
+
+      const method = request.attributes.get('href');
+      assert(method instanceof namespace.elements.String);
+      assert.equal(method.toValue(), '/');
+    });
+  });
+});

--- a/packages/api-elements/test/mocha.opts
+++ b/packages/api-elements/test/mocha.opts
@@ -1,0 +1,1 @@
+--recursive


### PR DESCRIPTION
During https://github.com/apiaryio/Paw-APIBlueprintImporter/pull/35 I realised that `hrefVariables` property was missing on HttpRequest element so this PR brings it (the property exists on other elements which can have the hrefVariables attribute).

I've also noticed when I was looking for the relevant tests that none of the properties in this file was tested, so my first commit was adding this missing test coverage.