### PR TITLE
feat(oas3): support parameters in media types

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+### Enhancements
+
+- support parameters in media types
+
 ### Breaking
 
 - Support for NodeJS 6 has been removed, upgrading to NodeJS 8 or newer is

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
@@ -1,5 +1,5 @@
 const R = require('ramda');
-const mediaTyper = require('media-typer');
+const contentType = require('content-type');
 const pipeParseResult = require('../../pipeParseResult');
 const {
   isExtension, hasKey, getKey, getValue,
@@ -19,11 +19,9 @@ const unsupportedKeys = ['encoding'];
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 
 function isJSONMediaType(mediaType) {
-  const type = mediaTyper.parse(mediaType);
-  return (
-    type.type === 'application'
-    && (type.subtype === 'json' || type.suffix === 'json')
-  );
+  const type = contentType.parse(mediaType);
+  const jsonMediaType = /^application\/\S*json$/i;
+  return jsonMediaType.test(type.type);
 }
 
 const createJSONMessageBodyAsset = R.curry((namespace, mediaType, value) => {
@@ -48,7 +46,7 @@ const parseExampleObjectOrRef = parseReference('examples', parseExampleObject);
 
 const isValidMediaType = (mediaType) => {
   try {
-    mediaTyper.parse(mediaType.toValue());
+    contentType.parse(mediaType.toValue());
   } catch (error) {
     return false;
   }

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -5,7 +5,9 @@
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
   "main": "./lib/adapter.js",
-  "files": ["lib/"],
+  "files": [
+    "lib/"
+  ],
   "homepage": "https://github.com/apiaryio/api-elements.js/tree/master/packages/fury-adapter-oas3-parser",
   "repository": {
     "type": "git",
@@ -21,7 +23,7 @@
     "test:integration:fix": "env GENERATE=1 mocha test/integration"
   },
   "dependencies": {
-    "media-typer": "^1.0.1",
+    "content-type": "^1.0.4",
     "ramda": "0.26.1",
     "yaml-js": "^0.2.3"
   },

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
@@ -29,6 +29,16 @@ describe('Media Type Object', () => {
     expect(parseResult).to.contain.warning("'Media Type Object' media type 'foo' is invalid");
   });
 
+  it('permits media type with parameters', () => {
+    const mediaType = new namespace.elements.Member('application/json; charset=utf-8', {});
+
+    const parseResult = parse(context, messageBodyClass, mediaType);
+
+    const message = parseResult.get(0);
+    expect(message).to.be.instanceof(messageBodyClass);
+    expect(message.contentType.toValue()).to.equal('application/json; charset=utf-8');
+  });
+
   it('returns a HTTP message body', () => {
     const mediaType = new namespace.elements.Member('application/json', {});
 


### PR DESCRIPTION
closes #246

Solved by replacing `media-typer` by `content-type` as sugested in #246