### PR TITLE
Treat 'Example Object' with length property as object

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -27,6 +27,23 @@
 
   [#236](https://github.com/apiaryio/api-elements.js/issues/236)
 
+- While parsing an 'Example Object' (found in a 'Schema Object') which contains
+  an object with a property `length` anywhere in the example tree. The example
+  object will be interpreted as an array of the given length. If the value of
+  `length` property of an 'Example Object' is a large number, then the parser
+  may utilise a lot of memory while producing a result and subsequently may
+  cause out of memory failures.
+
+  For example:
+
+  ```yaml
+  definitions:
+    User:
+      type: object
+      example:
+        length: 50000
+  ```
+
 ## 0.25.1 (2019-04-26)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/lib/generator.js
+++ b/packages/fury-adapter-swagger/lib/generator.js
@@ -56,7 +56,7 @@ const bodyFromSchema = (schema, payload, parser, contentType = 'application/json
         const boundary = parseBoundary(contentType);
         let content = '';
 
-        _.forEach(body, (value, key) => {
+        _.forOwn(body, (value, key) => {
           content += `--${boundary}\r\n`;
           content += `Content-Disposition: form-data; name="${key}"\r\n\r\n`;
           content += `${value}\r\n`;

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -145,7 +145,7 @@ const dereference = (example, root, paths, path) => {
   if (_.isObject(example)) {
     const result = {};
 
-    _.forEach(example, (value, key) => {
+    _.forOwn(example, (value, key) => {
       result[key] = dereference(value, root, paths, (path || []).concat([key]));
     });
 

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -379,7 +379,7 @@ const convertSchemaDefinitions = (definitions) => {
   const jsonSchemaDefinitions = {};
 
   if (definitions) {
-    _.forEach(definitions, (schema, key) => {
+    _.forOwn(definitions, (schema, key) => {
       jsonSchemaDefinitions[key] = convertSchema(schema, { definitions }, { definitions }, false);
     });
   }

--- a/packages/fury-adapter-swagger/lib/parser.js
+++ b/packages/fury-adapter-swagger/lib/parser.js
@@ -192,7 +192,7 @@ class Parser {
 
         const paths = _.omitBy(swagger.paths, isExtension);
 
-        _.forEach(paths, (pathValue, href) => {
+        _.forOwn(paths, (pathValue, href) => {
           this.handleSwaggerPath(pathValue, href);
         });
 
@@ -631,7 +631,7 @@ class Parser {
     const dataStructures = new Category();
     dataStructures.classes.push('dataStructures');
 
-    _.forEach(definitions, (schema, key) => {
+    _.forOwn(definitions, (schema, key) => {
       this.withPath(key, () => {
         try {
           const dataStructure = generator.generateDataStructure(schema);
@@ -718,7 +718,7 @@ class Parser {
         .value();
 
       // Each path is an object with methods as properties
-      _.forEach(relevantMethods, (methodValue, method) => {
+      _.forOwn(relevantMethods, (methodValue, method) => {
         this.handleSwaggerMethod(resource, href, pathObjectParameters, methodValue, method);
       });
 
@@ -839,7 +839,7 @@ class Parser {
       }
 
       // Transactions are created for each response in the document
-      _.forEach(relevantResponses, (responseValue, statusCode) => {
+      _.forOwn(relevantResponses, (responseValue, statusCode) => {
         this.handleSwaggerResponse(
           transition, method, methodValue,
           transitionParams, responseValue, statusCode,

--- a/packages/fury-adapter-swagger/test/json-schema-test.js
+++ b/packages/fury-adapter-swagger/test/json-schema-test.js
@@ -50,6 +50,17 @@ describe('Swagger Schema to JSON Schema', () => {
       });
     });
 
+    it('translates Swagger example extension to examples where example has property length', () => {
+      const schema = convertSchema({ type: 'object', example: { length: 2 } });
+
+      expect(schema).to.deep.equal({
+        type: 'object',
+        examples: [
+          { length: 2 },
+        ],
+      });
+    });
+
     it('dereferences Swagger example extension to examples', () => {
       const root = {
         definitions: {


### PR DESCRIPTION
I discovered the following abort while parsing an OAS 2 document:

```
5: serialiseContent [/app/node_modules/minim/lib...
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
1: node::Abort()
```

It turns out that if you have `length: 500000` or similiar in an Example Object, the parser would end up treating the example as an array while creating a minim ObjectElement from the array, this results in an object with 500,000 member elements for key 0 through 500,000. When serialising this as JSON you may hit out of memory errors.

For example, if you had a schema such as:

```yaml
definitions:
  User:
    type: object
    example:
      length: 500000
```

The underlying cause is a use of Lodash `forEach` function while iterating over the values during parsing the document. The lodash `forEach` method treats objects with a length property as an array. For example:

```js
> require('lodash').forEach({ length: 20 }, (value, key) => { console.log(key) })
0
1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
```