### PR TITLE
Prevent storing unparsed elements in state which can lead to undefined behaviour

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## Master
+## 0.8.1 (2019-06-12)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury OAS3 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixed handling of OpenAPI 3 documents which included invalid 'Schema Object'
+  in reusable components. Under some circumstances these could cause the parser
+  to throw an exception.
+
 ## 0.8.0 (2019-06-11)
 
 ### Breaking

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseComponentsObject.js
@@ -93,7 +93,13 @@ function parseComponentsObject(context, element) {
   context.state.components = new namespace.elements.Object();
 
   if (isObject(element) && element.get('schemas') && isObject(element.get('schemas'))) {
-    const schemas = element.get('schemas');
+    // Take schemas and convert to object with members for each key (discarding value)
+    // We don't want the value making it into final parse results under any circumstance,
+    // for example if the parse errors out and we leave bad state
+    const schemas = new namespace.elements.Object(
+      element.get('schemas').map((value, key) => new namespace.elements.Member(key))
+    );
+
     context.state.components.set('schemas', schemas);
   }
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -71,6 +71,26 @@ describe('Components Object', () => {
       expect(member).to.be.instanceof(namespace.elements.Member);
       expect(member.value).to.be.undefined;
     });
+
+    it('parses invalid schema into empty member and leaves schemas state', () => {
+      const components = new namespace.elements.Object({
+        schemas: {
+          User: { type: 'array', items: { $ref: '#/foo' } },
+        },
+      });
+
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(1);
+
+      expect(parseResult).to.contain.error(
+        "Only local references to '#/components' within the same file are supported"
+      );
+
+      const schemasState = context.state.components.get('schemas');
+      const userState = schemasState.getMember('User');
+      expect(userState).to.be.instanceof(namespace.elements.Member);
+      expect(userState.value).to.be.undefined;
+    });
   });
 
   describe('#parameters', () => {

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -25,7 +25,7 @@
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.8",
     "fury-adapter-apib-parser": "^0.15.0",
     "fury-adapter-apib-serializer": "^0.11.0",
-    "fury-adapter-oas3-parser": "^0.8.0",
+    "fury-adapter-oas3-parser": "^0.8.1",
     "fury-adapter-swagger": "^0.26.0",
     "js-yaml": "^3.12.0",
     "minim": "^0.23.4"


### PR DESCRIPTION
Under some circumstances, such as if a 'Schema Object' parse errors out, we may leave invalid state in the context behind which can lead to other code causing undefined behaviour when trying to handle invalid reusable components.

For example, when parsing the following:

```yaml
openapi: 3.0.0
info:
  title: my api
  version: 0.0.1
paths:
  /:
    get:
      summary: summary
      responses:
        '200':
          description: Ok
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Bar"
components:
  schemas:
    Bar:
      type: object
    Foo:
      type: array
      items:
        $ref: "#/invalid"
```

We'd throw the following because `Foo` was stored in the context with the value of an object with property type, items etc. Thus it wouldn't have an `id` value and it is not the parsed schema:

```
minim-api-description/lib/define-value-of.js:142 
  const result = elements.filter(el => el.id.equals(e.element))[0]; 

TypeError: Cannot read property 'equals' of undefined 
```

Fixes #227