### PR TITLE
Performance optimisation for valueOf

### DIFF
--- a/packages/api-elements/CHANGELOG.md
+++ b/packages/api-elements/CHANGELOG.md
@@ -1,6 +1,6 @@
 # API Elements (JavaScript) CHANGELOG
 
-## Master
+## 0.2.1 (2019-06-19)
 
 ### Enhancements
 

--- a/packages/api-elements/CHANGELOG.md
+++ b/packages/api-elements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API Elements (JavaScript) CHANGELOG
 
+## Master
+
+### Enhancements
+
+- Performance of the `valueOf` has been improved under certain cases.
+
 ## 0.2.0 (2019-06-11)
 
 ### Breaking

--- a/packages/api-elements/lib/define-value-of.js
+++ b/packages/api-elements/lib/define-value-of.js
@@ -22,7 +22,7 @@ function hasTypeAttribute(e, attribute) {
   if (undefined !== e._attributes) {
     const attrs = e.attributes.get('typeAttributes');
     if (undefined !== attrs && undefined !== attrs.content) {
-      return undefined !== attrs.content.find(attr => attr.content === attribute);
+      return attrs.content.some(attr => attr.content === attribute);
     }
   }
   return false;
@@ -93,10 +93,8 @@ module.exports = (namespace) => {
     return undefined;
   }
 
-  // TODO e instanceof EnumElement fails because of dependency injection
-  // checking for e.element === 'enum' as a temporary  walkaround
-  const isEnumElement = e => (e.element === 'enum' || e instanceof EnumElement);
-  const isPlural = e => (e instanceof ArrayElement) || (e instanceof ObjectElement);
+  const isEnumElement = e => e instanceof EnumElement;
+  const isPlural = e => e instanceof ArrayElement;
 
   function mapValue(e, options, f, elements) {
     const opts = updateTypeAttributes(e, options);

--- a/packages/api-elements/lib/define-value-of.js
+++ b/packages/api-elements/lib/define-value-of.js
@@ -129,7 +129,7 @@ module.exports = (namespace) => {
 
     if (elements) {
       if (e.element === 'ref') {
-        const result = elements.filter(el => el.id.equals(e.content))[0];
+        const result = elements.find(el => el.id.equals(e.content));
         const inheritedElements = elements.filter(el => !el.id.equals(e.content));
 
         if (e.path && e.path.toValue() === 'content') {
@@ -139,7 +139,7 @@ module.exports = (namespace) => {
         return mapValue(result, opts, f, inheritedElements);
       }
 
-      const result = elements.filter(el => el.id.equals(e.element))[0];
+      const result = elements.find(el => el.id.equals(e.element));
       if (result) {
         const inheritedElements = elements.filter(el => !el.id.equals(e.element));
         return mapValue(result, opts, f, inheritedElements);

--- a/packages/api-elements/package.json
+++ b/packages/api-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-elements",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "API Elements JavaScript",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
This PR brings a performance optimisation for `valueOf`, there was a use of `filter()[0]` which can be replaced for `find()` which prevents looping over the entire collection unnessecerily. This brings a decent performance improvement when you are running `valueOf` a bunch of times while parsing a very large OpenAPI 3 document which is generating data structures for hundreads of data structures. Seeing around a 7-10 seconds improvement for the particular document I have been testing.

Subsequently I've made minor changes to remove unnessecery work (see below)