### PR TITLE
refactor(apiaryb): include apiary-blueprint-parser in lib

### DIFF
--- a/packages/fury-adapter-apiary-blueprint-parser/.eslintignore
+++ b/packages/fury-adapter-apiary-blueprint-parser/.eslintignore
@@ -1,0 +1,1 @@
+lib/apiary-blueprint-parser.js

--- a/packages/fury-adapter-apiary-blueprint-parser/.gitignore
+++ b/packages/fury-adapter-apiary-blueprint-parser/.gitignore
@@ -1,0 +1,1 @@
+lib/apiary-blueprint-parser.js

--- a/packages/fury-adapter-apiary-blueprint-parser/.npmignore
+++ b/packages/fury-adapter-apiary-blueprint-parser/.npmignore
@@ -1,1 +1,4 @@
 test
+lib/apiary-blueprint-parser.pegjs
+.gitignore
+.eslintignore

--- a/packages/fury-adapter-apiary-blueprint-parser/lib/apiary-blueprint-parser.pegjs
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/apiary-blueprint-parser.pegjs
@@ -1,0 +1,375 @@
+{
+  /*
+   * Converts headers from format like this:
+   *
+   *   [
+   *     { name: "Content-Type",   value: "application/json" },
+   *     { name: "Content-Length", value: "153"              }
+   *   ]
+   *
+   * into format like this:
+   *
+   *   {
+   *     "Content-Type":   "application/json",
+   *     "Content-Length": "153"
+   *   }
+   */
+  function convertHeaders(headers) {
+    var result = {}, i;
+
+    for (i = 0; i < headers.length; i++) {
+      result[headers[i].name] = headers[i].value;
+    }
+
+    return result;
+  }
+
+  function nullIfEmpty(s) {
+    return s !== "" ? s : null;
+  }
+
+  function combineHeadTail(head, tail) {
+    if (head !== "") {
+      tail.unshift(head);
+    }
+
+    return tail;
+  }
+
+  /*
+   * We must save these because |this| doesn't refer to the parser in actions.
+   */
+  var Blueprint            = this.ast.Blueprint,
+      Section              = this.ast.Section,
+      Resource             = this.ast.Resource,
+      Request              = this.ast.Request,
+      Response             = this.ast.Response,
+      JsonSchemaValidation = this.ast.JsonSchemaValidation;
+
+  var urlPrefix = "", bodyTerminator;
+}
+
+/* ===== Primary Rules ===== */
+
+API
+  = EmptyLine*
+    location:Location?
+    EmptyLine*
+    name:APIName
+    EmptyLine*
+    description:APIDescription?
+    EmptyLine*
+    resources:Resources
+    EmptyLine*
+    sections:Sections
+    EmptyLine*
+    validations:JsonSchemaValidations?
+    EmptyLine*
+    {
+      /* Wrap free-standing resources into an anonymnous section. */
+      if (resources.length > 0) {
+        sections.unshift(new Section({
+          name:        null,
+          description: null,
+          resources:   resources
+        }));
+      }
+
+      return new Blueprint({
+        location:    nullIfEmpty(location),
+        name:        nullIfEmpty(name),
+        description: nullIfEmpty(description),
+        sections:    sections,
+        validations: validations !== "" ? validations : []
+      });
+    }
+
+Location
+  = "HOST:" S* url:Text0 EOLF {
+      var urlWithoutProtocol = url.replace(/^https?:\/\//, ""),
+          slashIndex         = urlWithoutProtocol.indexOf("/");
+
+      if (slashIndex > 0) {
+        urlPrefix = urlWithoutProtocol.slice(slashIndex + 1);
+      }
+
+      return url;
+    }
+
+APIName
+  = "---" S+ name:Text1 EOLF {
+      return name.replace(/\s+---$/, "");
+    }
+
+APIDescription
+  = "---" S* EOL lines:APIDescriptionLine* "---" S* EOLF {
+    return lines.join("\n");
+  }
+
+APIDescriptionLine
+  = !("---" S* EOLF) text:Text0 EOL { return text; }
+
+Sections
+  = head:Section?
+    tail:(EmptyLine* section:Section { return section; })*
+    {
+      return combineHeadTail(head, tail);
+    }
+
+Section
+  = header:SectionHeader EmptyLine* resources:Resources {
+      return new Section({
+        name:        nullIfEmpty(header.name),
+        description: nullIfEmpty(header.description),
+        resources:   resources
+      });
+    }
+
+SectionHeader
+  = SectionHeaderLong
+  / SectionHeaderShort
+
+SectionHeaderShort
+  = !JsonSchemaValidationsHeader "--" S+ name:Text1 EOLF {
+      return {
+        name:        name.replace(/\s+--$/, ""),
+        description: ""
+      };
+    }
+
+SectionHeaderLong
+  = !JsonSchemaValidationsHeader "--" S* EOL lines:SectionHeaderLongLine* "--" S* EOLF {
+    return {
+      name:        lines.length > 0 ? lines[0] : "",
+      description: lines.slice(1).join("\n")
+    };
+  }
+
+SectionHeaderLongLine
+  = !("--" S* EOLF) text:Text0 EOL { return text; }
+
+Resources
+  = head:Resource?
+    tail:(EmptyLine* resource:Resource { return resource; })*
+    {
+      return combineHeadTail(head, tail);
+    }
+
+Resource
+  /*
+   * Initial !Section and !JsonSchemaValidations are needed so that parsing of
+   * sectionless resources (which are placed before resources in sections and
+   * validations) terminates correctly.
+   */
+  = !SectionHeader !JsonSchemaValidationsHeader
+    description:ResourceDescription?
+    signature:Signature
+    request:Request
+    responses:Responses
+    {
+      /* For the "HEAD" method every response body must be empty */
+      if (signature.method === "HEAD") {
+        for (var i = 0; i < responses.length; i++) {
+          if (responses[i].body !== null)
+            return null; /* Error, body must be null */
+        };
+      }
+
+      var url = urlPrefix !== ""
+        ? "/" + urlPrefix.replace(/\/$/, "") + "/" + signature.url.replace(/^\//, "")
+        : signature.url;
+
+      return new Resource({
+        description: nullIfEmpty(description),
+        method:      signature.method,
+        url:         url,
+        request:     request,
+        responses:   responses
+      });
+    }
+
+ResourceDescription "resource description"
+  = lines:ResourceDescriptionLine+ { return lines.join("\n"); }
+
+ResourceDescriptionLine
+  = !HttpMethod text:Text0 EOL { return text; }
+
+/* Assembled from RFC 2616, 5323, 5789. */
+HttpMethod
+  = "GET"
+  / "POST"
+  / "PUT"
+  / "DELETE"
+  / "OPTIONS"
+  / "PATCH"
+  / "PROPPATCH"
+  / "LOCK"
+  / "UNLOCK"
+  / "COPY"
+  / "MOVE"
+  / "MKCOL"
+  / "HEAD"
+
+Request
+  = headers:RequestHeaders body:Body? {
+      return new Request({
+        headers: headers,
+        body:    nullIfEmpty(body)
+      });
+    }
+
+RequestHeaders
+  = headers:RequestHeader* { return convertHeaders(headers); }
+
+RequestHeader
+  = In header:HttpHeader { return header; }
+
+Responses
+  = head:Response
+    tail:(ResponseSeparator response:Response { return response; })*
+    {
+      return combineHeadTail(head, tail);
+    }
+
+Response
+  = status:ResponseStatus headers:ResponseHeaders body:Body? {
+      return new Response({
+        status:  status,
+        headers: headers,
+        body:    nullIfEmpty(body)
+      });
+    }
+
+ResponseStatus
+  = Out status:HttpStatus S* EOLF { return status; }
+
+ResponseHeaders
+  = headers:ResponseHeader* { return convertHeaders(headers); }
+
+ResponseHeader
+  = Out header:HttpHeader { return header; }
+
+ResponseSeparator
+  = "+++++" S* EOL
+
+HttpStatus "HTTP status code"
+  = digits:[0-9]+ { return parseInt(digits.join(""), 10); }
+
+HttpHeader
+  = name:HttpHeaderName ":" S* value:HttpHeaderValue EOLF {
+      return {
+        name:  name,
+        value: value
+      };
+    }
+
+/*
+ * See RFC 822, 3.1.2: "The field-name must be composed of printable ASCII
+ * characters (i.e., characters that have values between 33. and 126., decimal,
+ * except colon)."
+ */
+HttpHeaderName "HTTP header name"
+  = chars:[\x21-\x39\x3B-\x7E]+ { return chars.join(""); }
+
+HttpHeaderValue "HTTP header value"
+  = Text0
+
+JsonSchemaValidationsHeader
+  = "-- JSON Schema Validations --" EOLF
+
+JsonSchemaValidations
+  = JsonSchemaValidationsHeader
+    head:JsonSchemaValidation?
+    tail:(EmptyLine* validation:JsonSchemaValidation { return validation; })*
+    {
+      return combineHeadTail(head, tail);
+    }
+
+JsonSchemaValidation
+  = signature:Signature body:Body {
+      return new JsonSchemaValidation({
+        method: signature.method,
+        url:    signature.url,
+        body:   body
+      });
+    }
+
+Signature
+  = method:HttpMethod S+ url:Text1 EOL {
+      return {
+        method: method,
+        url:    url
+      };
+    }
+
+Body
+  = DelimitedBodyFixed
+  / DelimitedBodyVariable
+  / SimpleBody
+
+DelimitedBodyFixed
+  = "<<<" S* EOL
+    lines:DelimitedBodyFixedLine*
+    ">>>" S* EOLF
+    {
+      return lines.join("\n");
+    }
+
+DelimitedBodyFixedLine
+  = !(">>>" S* EOLF) text:Text0 EOL { return text; }
+
+DelimitedBodyVariable
+  = "<<<" terminator:Text1 EOL
+    &{ bodyTerminator = terminator; return true; }
+    lines:DelimitedBodyVariableLine*
+    DelimitedBodyVariableTerminator
+    {
+      return lines.join("\n");
+    }
+
+DelimitedBodyVariableLine
+  = !DelimitedBodyVariableTerminator text:Text0 EOL { return text; }
+
+DelimitedBodyVariableTerminator
+  = terminator:Text1 EOLF &{ return terminator === bodyTerminator }
+
+SimpleBody
+  = !"<<<" lines:SimpleBodyLine+ { return lines.join("\n"); }
+
+SimpleBodyLine
+  = !In !Out !ResponseSeparator !EmptyLine text:Text1 EOLF { return text; }
+
+In
+  = ">" S+
+
+Out
+  = "<" S+
+
+/* ===== Helper Rules ===== */
+
+Text0 "zero or more characters"
+  = chars:[^\n\r]* { return chars.join(""); }
+
+Text1 "one or more characters"
+  = chars:[^\n\r]+ { return chars.join(""); }
+
+EmptyLine "empty line"
+  = S* EOL
+
+EOLF "end of line or file"
+  = EOL / EOF
+
+EOL "end of line"
+  = "\n"
+  / "\r\n"
+  / "\r"
+
+EOF "end of file"
+  = !. { return ""; }
+
+/*
+ * What "\s" matches in JavaScript regexps, sans "\r", "\n", "\u2028" and
+ * "\u2029". See ECMA-262, 5.1 ed., 15.10.2.12.
+ */
+S "whitespace"
+  = [\t\v\f \u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\uFEFF]

--- a/packages/fury-adapter-apiary-blueprint-parser/lib/ast.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/ast.js
@@ -1,0 +1,312 @@
+const combineParts = (separator, builder) => {
+  const parts = [];
+
+  builder(parts);
+
+  return parts.join(separator);
+};
+
+const escapeBody = (body) => {
+  if (/^>\s+|^<\s+|^\s*$/m.test(body)) {
+    if (/^>>>\s*$/m.test(body)) {
+      if (/^EOT$/m.test(body)) {
+        let i = 1;
+
+        while (/^EOT#{i}$/m.test(body)) {
+          i += 1;
+        }
+
+        return `<<<EOT${i}\n${body}\nEOT${i}`;
+      }
+
+      return `<<<EOT\n${body}\nEOT`;
+    }
+
+    return `<<<\n${body}\n>>>`;
+  }
+
+  return body;
+};
+
+// Represents a JSON schema validation.
+class JsonSchemaValidation {
+  static fromJSON(json) {
+    return new (this)({
+      method: json.method,
+      url: json.url,
+      body: json.body,
+    });
+  }
+
+  constructor(props = {}) {
+    this.method = props.method || 'GET';
+    this.url = props.url || '/';
+    this.body = props.body || null;
+  }
+
+  toJSON() {
+    return {
+      method: this.method,
+      url: this.url,
+      body: this.body,
+    };
+  }
+
+  toBlueprint() {
+    return combineParts('\n', (parts) => {
+      parts.push(`${this.method} ${this.url}`);
+
+      if (this.body) {
+        parts.push(escapeBody(this.body));
+      }
+    });
+  }
+}
+
+// Represents a request of a resource.
+class Request {
+  static fromJSON(json) {
+    return new (this)({
+      headers: json.headers,
+      body: json.body,
+    });
+  }
+
+  constructor(props = {}) {
+    this.headers = props.headers || {};
+    this.body = props.body || null;
+  }
+
+  toJSON() {
+    return {
+      headers: this.headers,
+      body: this.body,
+    };
+  }
+
+  toBlueprint() {
+    return combineParts('\n', (parts) => {
+      Object.entries(this.headers).forEach(([name, value]) => {
+        parts.push(`> ${name}: ${value}`);
+      });
+
+      if (this.body) {
+        parts.push(escapeBody(this.body));
+      }
+    });
+  }
+}
+
+// Represents a response of a resource.
+class Response {
+  static fromJSON(json) {
+    return new (this)({
+      status: json.status,
+      headers: json.headers,
+      body: json.body,
+    });
+  }
+
+  constructor(props = {}) {
+    this.status = props.status || 200;
+    this.headers = props.headers || {};
+    this.body = props.body || null;
+  }
+
+  toJSON() {
+    return {
+      status: this.status,
+      headers: this.headers,
+      body: this.body,
+    };
+  }
+
+  toBlueprint() {
+    return combineParts('\n', (parts) => {
+      parts.push(`< ${this.status}`);
+
+      Object.entries(this.headers).forEach(([name, value]) => {
+        parts.push(`< ${name}: ${value}`);
+      });
+
+      if (this.body) {
+        parts.push(escapeBody(this.body));
+      }
+    });
+  }
+}
+
+// Represents a resource of an Apiary blueprint.
+class Resource {
+  static fromJSON(json) {
+    return new (this)({
+      description: json.description,
+      method: json.method,
+      url: json.url,
+      request: Request.fromJSON(json.request),
+      responses: json.responses.map(r => Response.fromJSON(r)),
+    });
+  }
+
+  constructor(props = {}) {
+    this.description = props.description || null;
+    this.method = props.method || 'GET';
+    this.url = props.url || '/';
+    this.request = props.request || new Request();
+    this.responses = props.responses || [new Response()];
+  }
+
+  getUrlFragment() {
+    return `${this.method.toLowerCase()}-${encodeURIComponent(this.url)}`;
+  }
+
+  toJSON() {
+    return {
+      description: this.description,
+      method: this.method,
+      url: this.url,
+      request: this.request.toJSON(),
+      responses: this.responses.map(r => r.toJSON()),
+    };
+  }
+
+  toBlueprint() {
+    return combineParts('\n', (parts) => {
+      if (this.description) {
+        parts.push(this.description);
+      }
+
+      parts.push(`${this.method} ${this.url}`);
+
+      const requestBlueprint = this.request.toBlueprint();
+
+      if (requestBlueprint !== '') {
+        parts.push(requestBlueprint);
+      }
+
+      const responsesBlueprint = combineParts('\n+++++\n', (parts) => {
+        this.responses.map(r => parts.push(r.toBlueprint()));
+      });
+
+      parts.push(responsesBlueprint);
+    });
+  }
+}
+
+// Represents a section of an Apiary blueprint.
+class Section {
+  static fromJSON(json) {
+    return new (this)({
+      name: json.name,
+      description: json.description,
+      resources: json.resources.map(r => Resource.fromJSON(r)),
+    });
+  }
+
+  constructor(props = {}) {
+    this.name = props.name || null;
+    this.description = props.description || null;
+    this.resources = props.resources || [];
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      description: this.description,
+      resources: this.resources.map(r => r.toJSON()),
+    };
+  }
+
+  toBlueprint() {
+    return combineParts('\n', (parts) => {
+      if (this.name) {
+        if (this.description) {
+          parts.push(`--\n${this.name}\n${this.description}\n--`);
+        } else {
+          parts.push(`-- ${this.name} --`);
+        }
+      }
+
+      this.resources.map(r => parts.push(r.toBlueprint()));
+    });
+  }
+}
+
+
+// Represents an Apiary blueprint.
+class Blueprint {
+  static fromJSON(json) {
+    return new (this)({
+      location: json.location,
+      name: json.name,
+      description: json.description,
+      sections: json.sections.map(s => Section.fromJSON(s)),
+      validations: json.validations.map(v => JsonSchemaValidation.fromJSON(v)),
+    });
+  }
+
+  constructor(props = {}) {
+    this.location = props.location || null;
+    this.name = props.name || null;
+    this.description = props.description || null;
+    this.sections = props.sections || [];
+    this.validations = props.validations || [];
+  }
+
+  resources(opts) {
+    const resources = [];
+
+    this.sections.forEach((section) => {
+      section.resources.forEach((r) => {
+        if ((opts != null ? opts.method : undefined) && (opts.method !== r.method)) { return; }
+        if ((opts != null ? opts.url : undefined) && (opts.url !== r.url)) { return; }
+        resources.push(r);
+      });
+    });
+
+    return resources;
+  }
+
+  toJSON() {
+    return {
+      location: this.location,
+      name: this.name,
+      description: this.description,
+      sections: this.sections.map(s => s.toJSON()),
+      validations: this.validations.map(v => v.toJSON()),
+    };
+  }
+
+  toBlueprint() {
+    return combineParts('\n', (parts) => {
+      if (this.location) {
+        parts.push(`HOST: ${this.location}`);
+      }
+
+      if (this.name) {
+        parts.push(`--- ${this.name} ---`);
+      }
+
+      if (this.description) {
+        parts.push(`---\n${this.description}\n---`);
+      }
+
+      this.sections.forEach(s => parts.push(s.toBlueprint()));
+
+      if (this.validations.length > 0) {
+        parts.push('-- JSON Schema Validations --');
+      }
+
+      this.validations.forEach(v => parts.push(v.toBlueprint()));
+    });
+  }
+}
+
+module.exports = {
+  Blueprint,
+  Section,
+  Resource,
+  Request,
+  Response,
+  JsonSchemaValidation,
+};

--- a/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
@@ -1,5 +1,8 @@
 const url = require('url');
-const ApiaryBlueprintParser = require('apiary-blueprint-parser');
+// eslint-disable-next-line import/no-unresolved
+const ApiaryBlueprintParser = require('./apiary-blueprint-parser');
+
+ApiaryBlueprintParser.ast = require('./ast');
 
 class Parser {
   constructor({ namespace, source }) {

--- a/packages/fury-adapter-apiary-blueprint-parser/package.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/package.json
@@ -14,10 +14,12 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "pegjs": "pegjs lib/apiary-blueprint-parser.pegjs lib/apiary-blueprint-parser.js",
+    "prepublishOnly": "npm run pegjs",
+    "pretest": "npm run pegjs",
     "test": "mocha"
   },
   "dependencies": {
-    "apiary-blueprint-parser": "^0.5.3",
     "deckardcain": "^0.4.0"
   },
   "peerDependencies": {
@@ -28,6 +30,7 @@
     "eslint": "^5.9.0",
     "fury": "3.0.0-beta.11",
     "glob": "^7.1.2",
+    "pegjs": "git://github.com/dmajda/pegjs.git#02af83f9b416778878e52e2cbbc22d96e312164e",
     "mocha": "^5.0.2"
   },
   "engines": {

--- a/packages/fury-adapter-apiary-blueprint-parser/test/ast-test.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/ast-test.js
@@ -1,0 +1,706 @@
+/* eslint-disable key-spacing, no-multi-spaces */
+const assert = require('assert');
+const {
+  Blueprint, Section, Resource, Request, Response, JsonSchemaValidation,
+} = require('../lib/ast');
+
+// AST nodes
+
+const filledRequest = new Request({
+  headers: { 'Content-Type': 'application/json' },
+  body:    '{ "status": "ok" }',
+});
+
+const filledResponses = [
+  new Response({
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+    body:    '{ "id": 1 }',
+  }),
+  new Response({
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+    body:    '{ "id": 2 }',
+  }),
+  new Response({
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+    body:    '{ "id": 3 }',
+  }),
+];
+
+const filledResources = [
+  new Resource({
+    description: 'Post resource 1',
+    method:      'POST',
+    url:         '/post-1',
+    request:     filledRequest,
+    responses:   filledResponses,
+  }),
+  new Resource({
+    description: 'Post resource 2',
+    method:      'POST',
+    url:         '/post-2',
+    request:     filledRequest,
+    responses:   filledResponses,
+  }),
+  new Resource({
+    description: 'Post resource 3',
+    method:      'POST',
+    url:         '/post-3',
+    request:     filledRequest,
+    responses:   filledResponses,
+  }),
+];
+
+const filledSections = [
+  new Section({
+    name:        'Section 1',
+    description: 'Test section 1',
+    resources:    filledResources,
+  }),
+  new Section({
+    name:        'Section 2',
+    description: 'Test section 2',
+    resources:    filledResources,
+  }),
+  new Section({
+    name:        'Section 3',
+    description: 'Test section 3',
+    resources:    filledResources,
+  }),
+];
+
+const filledValidations = [
+  new JsonSchemaValidation({
+    method: 'POST',
+    url:    '/post-1',
+    body:   '{ "type": "object" }',
+  }),
+  new JsonSchemaValidation({
+    method: 'POST',
+    url:    '/post-2',
+    body:   '{ "type": "object" }',
+  }),
+  new JsonSchemaValidation({
+    method: 'POST',
+    url:    '/post-3',
+    body:   '{ "type": "object" }',
+  }),
+];
+
+const filledBlueprint = new Blueprint({
+  location:    'http://example.com/',
+  name:        'API',
+  description: 'Test API',
+  sections:    filledSections,
+  validations: filledValidations,
+});
+
+// JSONs
+
+const filledRequestJson = {
+  headers: { 'Content-Type': 'application/json' },
+  body:    '{ "status": "ok" }',
+};
+
+const filledResponseJsons = [
+  {
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+    body:    '{ "id": 1 }',
+  },
+  {
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+    body:    '{ "id": 2 }',
+  },
+  {
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+    body:    '{ "id": 3 }',
+  },
+];
+
+const filledResourceJsons = [
+  {
+    description: 'Post resource 1',
+    method:      'POST',
+    url:         '/post-1',
+    request:     filledRequestJson,
+    responses:   filledResponseJsons,
+  },
+  {
+    description: 'Post resource 2',
+    method:      'POST',
+    url:         '/post-2',
+    request:     filledRequestJson,
+    responses:   filledResponseJsons,
+  },
+  {
+    description: 'Post resource 3',
+    method:      'POST',
+    url:         '/post-3',
+    request:     filledRequestJson,
+    responses:   filledResponseJsons,
+  },
+];
+
+const filledSectionJsons = [
+  {
+    name:        'Section 1',
+    description: 'Test section 1',
+    resources:    filledResourceJsons,
+  },
+  {
+    name:        'Section 2',
+    description: 'Test section 2',
+    resources:    filledResourceJsons,
+  },
+  {
+    name:        'Section 3',
+    description: 'Test section 3',
+    resources:    filledResourceJsons,
+  },
+];
+
+const filledValidationJsons = [
+  {
+    method: 'POST',
+    url:    '/post-1',
+    body:   '{ "type": "object" }',
+  },
+  {
+    method: 'POST',
+    url:    '/post-2',
+    body:   '{ "type": "object" }',
+  },
+  {
+    method: 'POST',
+    url:    '/post-3',
+    body:   '{ "type": "object" }',
+  },
+];
+
+const filledBlueprintJson = {
+  location:    'http://example.com/',
+  name:        'API',
+  description: 'Test API',
+  sections:    filledSectionJsons,
+  validations: filledValidationJsons,
+};
+
+// Blueprints
+
+const filledRequestBlueprint = `\
+> Content-Type: application/json
+{ "status": "ok" }\
+`;
+
+const filledResponseBlueprints = [
+  `\
+< 200
+< Content-Type: application/json
+{ "id": 1 }\
+`,
+  `\
+< 200
+< Content-Type: application/json
+{ "id": 2 }\
+`,
+  `\
+< 200
+< Content-Type: application/json
+{ "id": 3 }\
+`,
+];
+
+const filledResourceBlueprints = [
+  `\
+Post resource 1
+POST /post-1
+${filledRequestBlueprint}
+${filledResponseBlueprints[0]}
++++++
+${filledResponseBlueprints[1]}
++++++
+${filledResponseBlueprints[2]}\
+`,
+  `\
+Post resource 2
+POST /post-2
+${filledRequestBlueprint}
+${filledResponseBlueprints[0]}
++++++
+${filledResponseBlueprints[1]}
++++++
+${filledResponseBlueprints[2]}\
+`,
+  `\
+Post resource 3
+POST /post-3
+${filledRequestBlueprint}
+${filledResponseBlueprints[0]}
++++++
+${filledResponseBlueprints[1]}
++++++
+${filledResponseBlueprints[2]}\
+`,
+];
+
+const filledSectionBlueprints = [
+  `\
+--
+Section 1
+Test section 1
+--
+${filledResourceBlueprints[0]}
+${filledResourceBlueprints[1]}
+${filledResourceBlueprints[2]}\
+`,
+  `\
+--
+Section 2
+Test section 2
+--
+${filledResourceBlueprints[0]}
+${filledResourceBlueprints[1]}
+${filledResourceBlueprints[2]}\
+`,
+  `\
+--
+Section 3
+Test section 3
+--
+${filledResourceBlueprints[0]}
+${filledResourceBlueprints[1]}
+${filledResourceBlueprints[2]}\
+`,
+];
+
+const filledValidationBlueprints = [
+  `\
+POST /post-1
+{ "type": "object" }\
+`,
+  `\
+POST /post-2
+{ "type": "object" }\
+`,
+  `\
+POST /post-3
+{ "type": "object" }\
+`,
+];
+
+const filledBlueprintBlueprint = `\
+HOST: http://example.com/
+--- API ---
+---
+Test API
+---
+${filledSectionBlueprints[0]}
+${filledSectionBlueprints[1]}
+${filledSectionBlueprints[2]}
+-- JSON Schema Validations --
+${filledValidationBlueprints[0]}
+${filledValidationBlueprints[1]}
+${filledValidationBlueprints[2]}\
+`;
+
+const bodyTestcases = [
+  { body: '> ',           blueprint: '<<<\n> \n>>>'                },
+  { body: '>   ',         blueprint: '<<<\n>   \n>>>'              },
+  { body: 'line\n> ',     blueprint: '<<<\nline\n> \n>>>'          },
+  { body: '> \nline',     blueprint: '<<<\n> \nline\n>>>'          },
+  { body: 'a> ',          blueprint: 'a> '                         },
+
+  { body: '< ',           blueprint: '<<<\n< \n>>>'                },
+  { body: '<   ',         blueprint: '<<<\n<   \n>>>'              },
+  { body: 'line\n< ',     blueprint: '<<<\nline\n< \n>>>'          },
+  { body: '< \nline',     blueprint: '<<<\n< \nline\n>>>'          },
+  { body: 'a< ',          blueprint: 'a< '                         },
+
+  { body: ' ',            blueprint: '<<<\n \n>>>'                 },
+  { body: '   ',          blueprint: '<<<\n   \n>>>'               },
+  { body: 'line\n',       blueprint: '<<<\nline\n\n>>>'            },
+  { body: '\nline',       blueprint: '<<<\n\nline\n>>>'            },
+  { body: 'a ',           blueprint: 'a '                          },
+  { body: ' a',           blueprint: ' a'                          },
+
+  { body: '\n>>>',        blueprint: '<<<EOT\n\n>>>\nEOT'          },
+  { body: '\n>>> ',       blueprint: '<<<EOT\n\n>>> \nEOT'         },
+  { body: '\n>>>   ',     blueprint: '<<<EOT\n\n>>>   \nEOT'       },
+  { body: '\n\n>>>',      blueprint: '<<<EOT\n\n\n>>>\nEOT'        },
+  { body: '\n>>>\n',      blueprint: '<<<EOT\n\n>>>\n\nEOT'        },
+  { body: '\na>>>',       blueprint: '<<<\n\na>>>\n>>>'            },
+  { body: '\n>>>a',       blueprint: '<<<\n\n>>>a\n>>>'            },
+
+  { body: '\n>>>\nEOT',   blueprint: '<<<EOT1\n\n>>>\nEOT\nEOT1'   },
+  { body: '\n>>>\n\nEOT', blueprint: '<<<EOT1\n\n>>>\n\nEOT\nEOT1' },
+  { body: '\n>>>\nEOT\n', blueprint: '<<<EOT1\n\n>>>\nEOT\n\nEOT1' },
+  { body: '\n>>>\naEOT',  blueprint: '<<<EOT\n\n>>>\naEOT\nEOT'    },
+  { body: '\n>>>\nEOTa',  blueprint: '<<<EOT\n\n>>>\nEOTa\nEOT'    },
+];
+
+describe('Blueprint', () => {
+  const emptyBlueprint = new Blueprint();
+
+  describe('@fromJSON', () => {
+    it('creates a new blueprint from a JSON-serializable object', () => {
+      assert.deepEqual(Blueprint.fromJSON(filledBlueprintJson), filledBlueprint);
+    });
+  });
+
+  describe('#constructor', () => {
+    describe('when passed property values', () => {
+      it('initializes properties correctly', () => {
+        const blueprint = filledBlueprint;
+
+        assert.deepEqual(blueprint.location,    'http://example.com/');
+        assert.deepEqual(blueprint.name,        'API');
+        assert.deepEqual(blueprint.description, 'Test API');
+        assert.deepEqual(blueprint.sections,    filledSections);
+        assert.deepEqual(blueprint.validations, filledValidations);
+      });
+    });
+
+    describe('when not passed property values', () => {
+      it('uses correct defaults', () => {
+        assert.deepEqual(emptyBlueprint.location,    null);
+        assert.deepEqual(emptyBlueprint.name,        null);
+        assert.deepEqual(emptyBlueprint.description, null);
+        assert.deepEqual(emptyBlueprint.sections,    []);
+        assert.deepEqual(emptyBlueprint.validations, []);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('on a filled-in blueprint', () => {
+      it('returns a correct JSON-serializable object', () => {
+        assert.deepEqual(filledBlueprint.toJSON(), filledBlueprintJson);
+      });
+    });
+  });
+
+  describe('#toBlueprint', () => {
+    describe('on an empty blueprint', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(emptyBlueprint.toBlueprint(), '');
+      });
+    });
+
+    describe('on a filled-in blueprint', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(filledBlueprint.toBlueprint(), filledBlueprintBlueprint);
+      });
+    });
+  });
+});
+
+describe('Section', () => {
+  const emptySection = new Section();
+
+  describe('@fromJSON', () => {
+    it('creates a new section from a JSON-serializable object', () => {
+      assert.deepEqual(Section.fromJSON(filledSectionJsons[0]), filledSections[0]);
+    });
+  });
+
+  describe('#constructor', () => {
+    describe('when passed property values', () => {
+      it('initializes properties correctly', () => {
+        const section = filledSections[0];
+
+        assert.deepEqual(section.name,        'Section 1');
+        assert.deepEqual(section.description, 'Test section 1');
+        assert.deepEqual(section.resources,   filledResources);
+      });
+    });
+
+    describe('when not passed property values', () => {
+      it('uses correct defaults', () => {
+        assert.deepEqual(emptySection.name,        null);
+        assert.deepEqual(emptySection.description, null);
+        assert.deepEqual(emptySection.resources,   []);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('on a filled-in section', () => {
+      it('returns a correct JSON-serializable object', () => {
+        assert.deepEqual(filledSections[0].toJSON(), filledSectionJsons[0]);
+      });
+    });
+  });
+
+  describe('#toBlueprint', () => {
+    describe('on an empty section', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(emptySection.toBlueprint(), '');
+      });
+    });
+
+    describe('on a section with a name but with no description', () => {
+      it('returns a correct blueprint', () => {
+        const section = new Section({ name: 'Section 1' });
+
+        assert.deepEqual(section.toBlueprint(), '-- Section 1 --');
+      });
+    });
+
+    describe('on a section with no name but with a description', () => {
+      it('returns a correct blueprint', () => {
+        const section = new Section({ description: 'Test section 1' });
+
+        assert.deepEqual(section.toBlueprint(), '');
+      });
+    });
+
+    describe('on a filled-in section', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(filledSections[0].toBlueprint(), filledSectionBlueprints[0]);
+      });
+    });
+  });
+});
+
+describe('Resource', () => {
+  const emptyResource = new Resource();
+
+  describe('@fromJSON', () => {
+    it('creates a new resource from a JSON-serializable object', () => {
+      assert.deepEqual(Resource.fromJSON(filledResourceJsons[0]), filledResources[0]);
+    });
+  });
+
+  describe('#constructor', () => {
+    describe('when passed property values', () => {
+      it('initializes properties correctly', () => {
+        const resource = filledResources[0];
+
+        assert.deepEqual(resource.description, 'Post resource 1');
+        assert.deepEqual(resource.method,      'POST');
+        assert.deepEqual(resource.url,         '/post-1');
+        assert.deepEqual(resource.request,     filledRequest);
+        assert.deepEqual(resource.responses,   filledResponses);
+      });
+    });
+
+    describe('when not passed property values', () => {
+      it('uses correct defaults', () => {
+        assert.deepEqual(emptyResource.description, null);
+        assert.deepEqual(emptyResource.method,      'GET');
+        assert.deepEqual(emptyResource.url,         '/');
+        assert.deepEqual(emptyResource.request,     new Request());
+        assert.deepEqual(emptyResource.responses,   [new Response()]);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('on a filled-in resource', () => {
+      it('returns a correct JSON-serializable object', () => {
+        assert.deepEqual(filledResources[0].toJSON(), filledResourceJsons[0]);
+      });
+    });
+  });
+
+  describe('#toBlueprint', () => {
+    describe('on an empty resource', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(emptyResource.toBlueprint(), 'GET /\n< 200');
+      });
+    });
+
+    describe('on a filled-in resource', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(filledResources[0].toBlueprint(), filledResourceBlueprints[0]);
+      });
+    });
+  });
+});
+
+describe('Request', () => {
+  const emptyRequest = new Request();
+
+  describe('@fromJSON', () => {
+    it('creates a new request from a JSON-serializable object', () => {
+      assert.deepEqual(Request.fromJSON(filledRequestJson), filledRequest);
+    });
+  });
+
+  describe('#constructor', () => {
+    describe('when passed property values', () => {
+      it('initializes properties correctly', () => {
+        assert.deepEqual(filledRequest.headers, { 'Content-Type': 'application/json' });
+        assert.deepEqual(filledRequest.body,    '{ "status": "ok" }');
+      });
+    });
+
+    describe('when not passed property values', () => {
+      it('uses correct defaults', () => {
+        assert.deepEqual(emptyRequest.headers, {});
+        assert.deepEqual(emptyRequest.body,    null);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('on a filled-in request', () => {
+      it('returns a correct JSON-serializable object', () => {
+        assert.deepEqual(filledRequest.toJSON(), filledRequestJson);
+      });
+    });
+  });
+
+  describe('#toBlueprint', () => {
+    describe('on an empty request', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(emptyRequest.toBlueprint(), '');
+      });
+    });
+
+    describe('on a filled-in request', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(filledRequest.toBlueprint(), filledRequestBlueprint);
+      });
+    });
+
+    describe('on requests with weird bodies', () => {
+      it('uses suitable body syntax', () => {
+        bodyTestcases.forEach((testcase) => {
+          const request = new Request({ body: testcase.body });
+
+          assert.deepEqual(request.toBlueprint(), testcase.blueprint);
+        });
+      });
+    });
+  });
+});
+
+describe('Response', () => {
+  const emptyResponse = new Response();
+
+  describe('@fromJSON', () => {
+    it('creates a new response from a JSON-serializable object', () => {
+      assert.deepEqual(Response.fromJSON(filledResponseJsons[0]), filledResponses[0]);
+    });
+  });
+
+  describe('#constructor', () => {
+    describe('when passed property values', () => {
+      it('initializes properties correctly', () => {
+        const response = filledResponses[0];
+
+        assert.deepEqual(response.status,  200);
+        assert.deepEqual(response.headers, { 'Content-Type': 'application/json' });
+        assert.deepEqual(response.body,    '{ "id": 1 }');
+      });
+    });
+
+    describe('when not passed property values', () => {
+      it('uses correct defaults', () => {
+        assert.deepEqual(emptyResponse.status,  200);
+        assert.deepEqual(emptyResponse.headers, {});
+        assert.deepEqual(emptyResponse.body,    null);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('on a filled-in response', () => {
+      it('returns a correct JSON-serializable object', () => {
+        assert.deepEqual(filledResponses[0].toJSON(), filledResponseJsons[0]);
+      });
+    });
+  });
+
+  describe('#toBlueprint', () => {
+    describe('on an empty response', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(emptyResponse.toBlueprint(), '< 200');
+      });
+    });
+
+    describe('on a filled-in response', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(filledResponses[0].toBlueprint(), filledResponseBlueprints[0]);
+      });
+    });
+
+    describe('on responses with weird bodies', () => {
+      it('uses suitable body syntax', () => {
+        bodyTestcases.forEach((testcase) => {
+          const response = new Response({ body: testcase.body });
+
+          assert.deepEqual(response.toBlueprint(), `< 200\n${testcase.blueprint}`);
+        });
+      });
+    });
+  });
+});
+
+describe('JsonSchemaValidation', () => {
+  const emptyValidation = new JsonSchemaValidation();
+
+  describe('@fromJSON', () => {
+    it('creates a new validation from a JSON-serializable object', () => {
+      assert.deepEqual(JsonSchemaValidation.fromJSON(filledValidationJsons[0]), filledValidations[0]);
+    });
+  });
+
+  describe('#constructor', () => {
+    describe('when passed property values', () => {
+      it('initializes properties correctly', () => {
+        const validation = filledValidations[0];
+
+        assert.deepEqual(validation.method, 'POST');
+        assert.deepEqual(validation.url,    '/post-1');
+        assert.deepEqual(validation.body,   '{ "type": "object" }');
+      });
+    });
+
+    describe('when not passed property values', () => {
+      it('uses correct defaults', () => {
+        assert.deepEqual(emptyValidation.method, 'GET');
+        assert.deepEqual(emptyValidation.url,    '/');
+        assert.deepEqual(emptyValidation.body,   null);
+      });
+    });
+  });
+
+  describe('#toJSON', () => {
+    describe('on a filled-in validation', () => {
+      it('returns a correct JSON-serializable object', () => {
+        assert.deepEqual(filledValidations[0].toJSON(), filledValidationJsons[0]);
+      });
+    });
+  });
+
+  describe('#toBlueprint', () => {
+    describe('on an empty validation', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(emptyValidation.toBlueprint(), 'GET /');
+      });
+    });
+
+    describe('on a filled-in validation', () => {
+      it('returns a correct blueprint', () => {
+        assert.deepEqual(filledValidations[0].toBlueprint(), filledValidationBlueprints[0]);
+      });
+    });
+
+    describe('on validations with weird bodies', () => {
+      it('uses suitable body syntax', () => {
+        bodyTestcases.forEach((testcase) => {
+          const validation = new JsonSchemaValidation({ body: testcase.body });
+
+          assert.deepEqual(validation.toBlueprint(), `GET /\n${testcase.blueprint}`);
+        });
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,13 +933,6 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-apiary-blueprint-parser@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/apiary-blueprint-parser/-/apiary-blueprint-parser-0.5.3.tgz#f97a2cf89a9fa8bdc6f5b7a5edc2cb58c8dd34af"
-  integrity sha1-+Xos+JqfqL3G9bel7cLLWMjdNK8=
-  dependencies:
-    commander "2.0.0"
-
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1521,11 +1514,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.0.0.tgz#d1b86f901f8b64bd941bdeadaf924530393be928"
-  integrity sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=
 
 commander@2.15.1:
   version "2.15.1"
@@ -4791,6 +4779,10 @@ pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
+"pegjs@git://github.com/dmajda/pegjs.git#02af83f9b416778878e52e2cbbc22d96e312164e":
+  version "0.7.0"
+  resolved "git://github.com/dmajda/pegjs.git#02af83f9b416778878e52e2cbbc22d96e312164e"
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
I added the `.pegjs` and `ast.js` for lib and `ast-test.js` for tests. Also, added the hooks to convert the pegjs file. And then finally removed apiary-blueprint-parser package.

I diffed the generated file here and the one from apiary-blueprint-parser package and confirmed that there are no changes.