### PR TITLE
Remove object.values dependency

### DIFF
--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -1,10 +1,4 @@
 const _ = require('lodash');
-const values = require('object.values');
-
-// Polyfill Object.values for node 6
-if (!Object.values) {
-  values.shim();
-}
 
 class ReferenceError extends Error {}
 

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -22,7 +22,6 @@
     "json-schema-faker": "0.5.0-rc17",
     "lodash": "^4.17.0",
     "media-typer": "^1.0.1",
-    "object.values": "^1.1.0",
     "swagger-parser": "^6.0.2",
     "yaml-js": "^0.2.3",
     "z-schema": "^3.24.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4432,16 +4432,6 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-object.values@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
-  integrity sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.12.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"


### PR DESCRIPTION
This dependency was used to bring Object.value to Node 6, which is not needed as we support Node >= 8.