### PR TITLE
Simplify valueOf by removing dynamic nature of functions created in namespace

### DIFF
--- a/packages/api-elements/lib/api-elements.js
+++ b/packages/api-elements/lib/api-elements.js
@@ -47,7 +47,7 @@ class Namespace extends minim.Namespace {
     this.register('category', Category);
     this.register('extension', Extension);
 
-    defineValueOf(this);
+    defineValueOf();
     defineSourceMapValue(this);
   }
 }

--- a/packages/api-elements/lib/api-elements.js
+++ b/packages/api-elements/lib/api-elements.js
@@ -48,7 +48,7 @@ class Namespace extends minim.Namespace {
     this.register('extension', Extension);
 
     defineValueOf();
-    defineSourceMapValue(this);
+    defineSourceMapValue();
   }
 }
 

--- a/packages/api-elements/lib/define-source-map-value.js
+++ b/packages/api-elements/lib/define-source-map-value.js
@@ -1,6 +1,6 @@
-module.exports = (namespace) => {
-  const { Element } = namespace;
+const { Element } = require('minim');
 
+module.exports = () => {
   /**
    * @name sourceMapValue
    * @type Array


### PR DESCRIPTION
This PR is broken into separate commits, I recommend reading the respective commits and commit messages for further information.

I've removed the passing down the namespace to `defineValueOf` because it is unnessecery and can cause multiple versions of some of the functions used to exist at runtime depending on how many times you create a namespace.