### PR TITLE
Store element reference for valueOf in object

### DIFF
--- a/packages/api-elements/lib/define-value-of.js
+++ b/packages/api-elements/lib/define-value-of.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-bitwise, no-underscore-dangle */
 
+const R = require('ramda');
+
 const {
   Element,
   ArrayElement,
@@ -139,8 +141,8 @@ function mapValue(e, options, f, elements) {
 
   if (elements) {
     if (e.element === 'ref') {
-      const result = elements.find(el => el.id.equals(e.content));
-      const inheritedElements = elements.filter(el => !el.id.equals(e.content));
+      const result = elements[e.content];
+      const inheritedElements = R.filter(el => !el.id.equals(e.content), elements);
 
       if (e.path && e.path.toValue() === 'content') {
         return mapValue(result.content, opts, f, inheritedElements);
@@ -149,9 +151,9 @@ function mapValue(e, options, f, elements) {
       return mapValue(result, opts, f, inheritedElements);
     }
 
-    const result = elements.find(el => el.id.equals(e.element));
+    const result = elements[e.element];
     if (result) {
-      const inheritedElements = elements.filter(el => !el.id.equals(e.element));
+      const inheritedElements = R.filter(el => !el.id.equals(e.element), elements);
       return mapValue(result, opts, f, inheritedElements);
     }
   }

--- a/packages/api-elements/package.json
+++ b/packages/api-elements/package.json
@@ -17,7 +17,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "minim": "^0.23.4"
+    "minim": "^0.23.4",
+    "ramda": "^0.26.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/packages/api-elements/test/value-of-test.js
+++ b/packages/api-elements/test/value-of-test.js
@@ -1114,7 +1114,7 @@ describe('valueOf RefElement', () => {
     name.id = 'name';
 
     const element = name.toRef('element');
-    const value = element.valueOf(undefined, [name]);
+    const value = element.valueOf(undefined, { name });
 
     expect(value).to.equal('doe');
   });
@@ -1125,7 +1125,7 @@ describe('valueOf RefElement', () => {
     container.id = 'name';
 
     const element = container.toRef('content');
-    const value = element.valueOf(undefined, [container]);
+    const value = element.valueOf(undefined, { name: container });
 
     expect(value).to.equal('doe');
   });
@@ -1136,7 +1136,7 @@ describe('valueOf RefElement', () => {
 
     const names = new ArrayElement([name.toRef()]);
 
-    const value = names.valueOf(undefined, [name]);
+    const value = names.valueOf(undefined, { name });
 
     expect(value).to.deep.equal(['doe']);
   });
@@ -1148,7 +1148,7 @@ describe('valueOf RefElement with source', () => {
     name.id = 'name';
 
     const element = name.toRef('element');
-    const value = element.valueOf({ source: true }, [name]);
+    const value = element.valueOf({ source: true }, { name });
 
     expect(value).to.deep.equal(['doe', 'content']);
   });
@@ -1159,7 +1159,7 @@ describe('valueOf RefElement with source', () => {
     container.id = 'name';
 
     const element = container.toRef('content');
-    const value = element.valueOf({ source: true }, [container]);
+    const value = element.valueOf({ source: true }, { name: container });
 
     expect(value).to.deep.equal(['doe', 'content']);
   });
@@ -1170,7 +1170,7 @@ describe('valueOf RefElement with source', () => {
 
     const names = new ArrayElement([name.toRef()]);
 
-    const value = names.valueOf({ source: true }, [name]);
+    const value = names.valueOf({ source: true }, { name });
 
     expect(value).to.deep.equal([['doe'], 'content']);
   });
@@ -1184,7 +1184,7 @@ describe('valueOf referenced element', () => {
     const element = new Element();
     element.element = 'name';
 
-    const value = element.valueOf(undefined, [name]);
+    const value = element.valueOf(undefined, { name });
 
     expect(value).to.equal('doe');
   });
@@ -1198,7 +1198,7 @@ describe('valueOf referenced element with source', () => {
     const element = new Element();
     element.element = 'name';
 
-    const value = element.valueOf({ source: true }, [name]);
+    const value = element.valueOf({ source: true }, { name });
 
     expect(value).to.deep.equal(['doe', 'content']);
   });

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseMediaTypeObject.js
@@ -134,14 +134,17 @@ function parseMediaTypeObject(context, MessageBodyClass, element) {
       const dataStructure = mediaTypeObject.get('schema');
 
       if (!messageBody && dataStructure && isJSONMediaType(mediaType)) {
-        let elements = [];
+        const elements = {};
         const { components } = context.state;
         if (components) {
           const schemas = components.get('schemas');
           if (schemas) {
-            elements = schemas.content
+            schemas.content
               .filter(e => e.value && e.value.content)
-              .map(e => e.value.content);
+              .forEach((e) => {
+                const element = e.value.content;
+                elements[element.id.toValue()] = element;
+              });
           }
         }
 


### PR DESCRIPTION
This brings a somewhat substancial performance improvement to parsing an OpenAPI 3 document:

```
$ git checkout master
$ time npx fury oas3.json > output.json

       25.68 real        28.63 user         0.60 sys
```

```
$ git checkout kylef/perf2
$ time npx fury oas3.json > output.json

       11.15 real        14.20 user         0.55 sys
```

The reason being, is that we're looking up an element via an ID from an array *many* times during generating the JSON body of the element. This counted for a large proportion of the parse time (https://gist.github.com/kylef/d054d1191c7c880dd993e0b7a8399fb5 shows numerous benchmarks of object lookup). This changes the interface of `valueOf` reference elements from being an array of elements with an `id` to being a JS Object with the key of the id as a string.