### PR TITLE
Setup a smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,13 @@ jobs:
     docker:
       - image: circleci/node:12
 
+  test-smoke:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install
+      - run: ./.circleci/smoke.sh
+
   lint:
     <<: *defaults
     steps:
@@ -58,5 +65,6 @@ workflows:
       - test-node8
       - test-node10
       - test-node12
+      - test-smoke
       - lint
       - docs

--- a/.circleci/smoke.sh
+++ b/.circleci/smoke.sh
@@ -12,7 +12,7 @@ create_package() {
 install() {
   PACKAGE="$1"
 
-  TARBALL="$(cd packages/$PACKAGE && npm pack)"
+  TARBALL="$(cd packages/$PACKAGE && npm pack | tail -n1)"
   mv "packages/$PACKAGE/$TARBALL" "$TMPDIR"
 
   cd "$TMPDIR" && npm install "$TARBALL" && cd "$API_ELEMENTS"

--- a/.circleci/smoke.sh
+++ b/.circleci/smoke.sh
@@ -34,7 +34,7 @@ npx fury --version
 
 # Parse Apiary Blueprint
 cat << EOF | npx fury -
-HOST: http://www.google.com/
+HOST: http://example.com/
 
 --- Sample API v2 ---
 ---

--- a/.circleci/smoke.sh
+++ b/.circleci/smoke.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'apiejs-smoketest')"
-API_ELEMENTS="$(pwd)"
+TMPDIR="$(mktemp -d)"
+PROJECT_DIR="$(pwd)"
 
 create_package() {
-  cd "$TMPDIR" && npm init --yes && cd "$API_ELEMENTS"
+  cd "$TMPDIR" && npm init --yes && cd "$PROJECT_DIR"
 }
 
 install() {
@@ -15,7 +15,7 @@ install() {
   TARBALL="$(cd packages/$PACKAGE && npm pack | tail -n1)"
   mv "packages/$PACKAGE/$TARBALL" "$TMPDIR"
 
-  cd "$TMPDIR" && npm install "$TARBALL" && cd "$API_ELEMENTS"
+  cd "$TMPDIR" && npm install "$TARBALL" && cd "$PROJECT_DIR"
 }
 
 echo "Setting up Fury in $TMPDIR"

--- a/.circleci/smoke.sh
+++ b/.circleci/smoke.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -e
+
+TMPDIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'apiejs-smoketest')"
+API_ELEMENTS="$(pwd)"
+
+create_package() {
+  cd "$TMPDIR" && npm init --yes && cd "$API_ELEMENTS"
+}
+
+install() {
+  PACKAGE="$1"
+
+  TARBALL="$(cd packages/$PACKAGE && npm pack)"
+  mv "packages/$PACKAGE/$TARBALL" "$TMPDIR"
+
+  cd "$TMPDIR" && npm install "$TARBALL" && cd "$API_ELEMENTS"
+}
+
+echo "Setting up Fury in $TMPDIR"
+
+create_package
+install fury
+install fury-adapter-apib-parser
+install fury-adapter-oas3-parser
+install fury-adapter-apiary-blueprint-parser
+install fury-adapter-apib-serializer
+install fury-cli
+
+cd "$TMPDIR"
+npx fury --help
+npx fury --version
+
+# Parse Apiary Blueprint
+cat << EOF | npx fury -
+HOST: http://www.google.com/
+
+--- Sample API v2 ---
+---
+Welcome to the our sample API documentation. All comments can be written in (support [Markdown](http://daringfireball.net/projects/markdown/syntax) syntax)
+---
+EOF
+
+# Parse API Blueprint
+cat << EOF | npx fury -
+FORMAT: 1A
+
+# GET /
+
++ Response 204
+EOF
+
+# Parse OpenAPI 2.0
+cat << EOF | npx fury -
+swagger: '2.0'
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+EOF
+
+# Parse OpenAPI 3.0
+cat << EOF | npx fury -
+openapi: 3.0.2
+info:
+  title: My API
+  version: 1.0.0
+paths: {}
+EOF
+
+rm -fr "$TMPDIR"

--- a/packages/fury-adapter-apiary-blueprint-parser/package.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "pegjs": "pegjs lib/apiary-blueprint-parser.pegjs lib/apiary-blueprint-parser.js",
-    "prepublishOnly": "npm run pegjs",
+    "prepack": "npm run pegjs",
     "pretest": "npm run pegjs",
     "test": "mocha"
   },

--- a/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/example.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/example.json
@@ -42,7 +42,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "http://www.google.com/"
+                  "content": "http://example.com/"
                 }
               }
             }

--- a/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/example.txt
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/example.txt
@@ -1,4 +1,4 @@
-HOST: http://www.google.com/
+HOST: http://example.com/
 
 --- Sample API v2 ---
 ---


### PR DESCRIPTION
This PR adds a smoke test to API Elements, which installs Fury, all of the Fury adapters and then the fury-cli. We then run a few operations on Fury such as parsinrg a document of all description formats (to test all of the adapters). I've also ran `--version`, `--help` to verify they return 0. Note `--version` outputs versions of all configured adapters.

Check out the full output of https://circleci.com/gh/apiaryio/api-elements.js/2834

This did actually help me catch a bug that `npm pack` doesn't build part of fury-adapter-apiary-blueprint-parser (fixed in 7b4dcaa).