### PR TITLE
Work around infinite loop bug when using pattern and minLength in OAS 2

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.27.1 (2019-06-03)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a problem while parsing a document which contains a Swagger Schema for
+  a string which contains both a `minLength` and a `pattern` property which are
+  incompatible. For example, the following pattern: `^[A-z]*$` which is making
+  use of `*` which means that it allows strings that are zero length or more.
+  If there is a property `minLength` which is incompatible with the pattern
+  such as if `minLength` is set to 1. Previously this would cause the parser to
+  get into an infinite loop.
+
 ## 0.26.0 (2019-06-11)
 
 ### Breaking

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -166,6 +166,15 @@ const convertSubSchema = (schema, references, swagger) => {
     actualSchema.type = 'string';
   }
 
+  if (schema.pattern && schema.minLength && schema.pattern.startsWith('^[') && schema.pattern.endsWith(']*$')) {
+    // If a schema has a minimal length (minLength) > 0 AND there is a regex
+    // such as: `^[A-z]*$`, the schema can resolve to an empty string which
+    // doesn't match minLength.
+    //
+    // JSON Schema Faker will fail in that case and get into an infinite loop.
+    actualSchema.pattern = schema.pattern.replace('*$', '+$');
+  }
+
   if (schema.example) {
     actualSchema.examples = [dereference(schema.example, swagger)];
   }

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-swagger/test/fixtures/json-body-generation-bad-pattern.json
+++ b/packages/fury-adapter-swagger/test/fixtures/json-body-generation-bad-pattern.json
@@ -1,0 +1,224 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Produces JSON with pattern"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "links": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "link",
+                                      "attributes": {
+                                        "relation": {
+                                          "element": "string",
+                                          "content": "inferred"
+                                        },
+                                        "href": {
+                                          "element": "string",
+                                          "content": "http://docs.apiary.io/validations/swagger#produces-accept"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "links": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "link",
+                                      "attributes": {
+                                        "relation": {
+                                          "element": "string",
+                                          "content": "inferred"
+                                        },
+                                        "href": {
+                                          "element": "string",
+                                          "content": "http://docs.apiary.io/validations/swagger#produces-content-type"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "My Response"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            },
+                            "links": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "link",
+                                  "attributes": {
+                                    "relation": {
+                                      "element": "string",
+                                      "content": "inferred"
+                                    },
+                                    "href": {
+                                      "element": "string",
+                                      "content": "http://docs.apiary.io/validations/swagger#message-body-generation"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "A"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\"type\":\"string\",\"minLength\":1,\"maxLength\":255,\"pattern\":\"^[A-z]+$\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "string",
+                            "meta": {
+                              "description": {
+                                "element": "string",
+                                "content": "- Matches regex pattern: `^[A-z]*$`\n- Length of string must be less than, or equal to 255\n- Length of string must be greater than, or equal to 1"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/fury-adapter-swagger/test/fixtures/json-body-generation-bad-pattern.yaml
+++ b/packages/fury-adapter-swagger/test/fixtures/json-body-generation-bad-pattern.yaml
@@ -1,0 +1,17 @@
+swagger: '2.0'
+info:
+  title: Produces JSON with pattern
+  version: '1.0'
+produces:
+  - application/json
+paths:
+  '/test':
+    get:
+      responses:
+        200:
+          description: 'My Response'
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 255
+            pattern: ^[A-z]*$

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -26,7 +26,7 @@
     "fury-adapter-apib-parser": "^0.16.0",
     "fury-adapter-apib-serializer": "^0.12.0",
     "fury-adapter-oas3-parser": "^0.9.0",
-    "fury-adapter-swagger": "^0.27.0",
+    "fury-adapter-swagger": "^0.27.1",
     "js-yaml": "^3.12.0",
     "minim": "^0.23.4"
   },


### PR DESCRIPTION
The changelog entry in diff explains the problem that I am working around. Effectively, if you have a pattern `^[A-z]*$` and a `minLength` of `1` then the pattern with `*` can resolve to an empty string which doesn't match validation. I'm working around it by detecting this particular issue and "patching" the regex to use `+` instead of `*` so that it is a "one or more" not "zero or more".

This is due to the current behaviour with JSON Schema Faker which gets into an infinite loop in this state. I think it is seeing that the pattern string doesn't generate the correct length and then it tries again, and again (forever). As we've seeded our "randomness" to produce consistent results it gets stuck.

This is a short-sighted solution, there are likely other cases this can happen which I am not counting for. This particular fix is to solve a majority problem that I am seeing a small amount of our customers hit (and subsequent platform instability). A proper fix should be made in json-schema-faker, that's more time consuming (and involves waiting for a fix to be released which given JSF release cycles can be months or more). So I've made this interim fix to solve platform instablity and customers not being able to use their OAS 2 document in our products. I've created APIARY-5932 to track this going forward (and for us to solve the problem in JSON Schema Faker).

I did consider providing a warning annotation to the user, but given how this part of the code base is architected, it wouldn't be possible to have source maps for the annotation without larger refactoring (which may in turn slow the parser down).