### PR TITLE
Prevent API Blueprint serializer from returning double trailing new lines

### DIFF
--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury API Blueprint Serializer
 
+## Master
+
+### Bug Fixes
+
+- Prevent double new lines being appended to the end of serialized API
+  Blueprints.
+
 ## 0.12.0 (2019-07-02)
 
 ### Enhancements

--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury API Blueprint Serializer
 
-## Master
+## 0.12.1 (2019-07-12)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-apib-serializer/lib/adapter.js
+++ b/packages/fury-adapter-apib-serializer/lib/adapter.js
@@ -37,7 +37,8 @@ function serialize({ api }) {
       }
 
       // Attempt to filter out extra spacing
-      return resolve(apib.replace(/\n\s*\n\s*\n/g, '\n\n'));
+      const result = apib.trim().replace(/\n\s*\n\s*\n/g, '\n\n');
+      return resolve(`${result}\n`);
     });
   });
 }

--- a/packages/fury-adapter-apib-serializer/package.json
+++ b/packages/fury-adapter-apib-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-serializer",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "API Blueprint serializer for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-apib-serializer/test/adapter-test.js
+++ b/packages/fury-adapter-apib-serializer/test/adapter-test.js
@@ -43,7 +43,7 @@ describe('API Blueprint serializer adapter', () => {
           return done(serializeErr);
         }
 
-        expect(serialized.trim()).to.deep.equal(expectedBlueprint.trim());
+        expect(serialized).to.deep.equal(expectedBlueprint);
         return done();
       });
     });


### PR DESCRIPTION
The parsing service shows that two newlines are present in the response for serialising to API Blueprint:

![Screenshot 2019-07-12 at 18 12 59](https://user-images.githubusercontent.com/44164/61146201-5bfdf180-a4d1-11e9-9f58-771acecca196.png)

There is an incorrect Dredd hook preventing this being tested properly (the blueprint is correct, the comment here is incorrect): 

```js
const { beforeEachValidation } = require('hooks');

beforeEachValidation(function (transaction) {
  if (transaction.fullPath.includes('/composer')) {
    // Message body in API Blueprint has newlines appended
    transaction.expected.body = transaction.expected.body.trim();
    transaction.real.body = transaction.real.body.trim();
  }
});
```

The following patch in the service can validate this:

```diff
diff --git a/functions/transform/lib/compose.js b/functions/transform/lib/compose.js
index 72e8e84..8078110 100644
--- a/functions/transform/lib/compose.js
+++ b/functions/transform/lib/compose.js
@@ -116,7 +116,7 @@ async function compose(request) {
     headers: {
       'Content-Type': mediaType,
     },
-    body: output,
+    body: output.trim() + '\n',
   };
 }
```

Digging into the adapter, I saw that the tests are also trimming the files so that the presence of additional new lines won't cause failing test. I've trimmed the result (to remove occurances of trailing double new lines) and then added a single training new line.

Once propergated to parsing service, we can remove the Dredd hook for composer.