### PR TITLE
Use provided index from forEach instead of computing ourselves

### DIFF
--- a/packages/fury-adapter-swagger/lib/parser.js
+++ b/packages/fury-adapter-swagger/lib/parser.js
@@ -1629,12 +1629,11 @@ class Parser {
   }
 
   validateContentTypes(contentTypes) {
-    contentTypes.forEach((contentType) => {
+    contentTypes.forEach((contentType, index) => {
       try {
         const { type } = contentTypeModule.parse(contentType);
         mediaTyper.parse(type);
       } catch (e) {
-        const index = contentTypes.indexOf(contentType);
         this.withPath(index, () => {
           this.createAnnotation(
             annotations.VALIDATION_WARNING, this.path,


### PR DESCRIPTION
While reviewing this part of the OAS 2 code base I realised the index of an item in an array was being computed using `indexOf` while we are already in a function which has access to the index in the arguments.

In theory, this may also fix a bug where the source maps could be wrong if you had two identical invalid content types in produces or consumes. (The source maps would reference the first one). I haven't validated if such bug exists it was just speculation, it may be more likely there is a unique requirement for content-types which is validated upfront.