### PR TITLE
Support generating text message body for string schemas

### DIFF
--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "content-type": "^1.0.4",
+    "media-typer": "^1.0.1",
     "ramda": "0.26.1",
     "yaml-js": "^0.2.3"
   },

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
@@ -348,5 +348,36 @@ describe('Media Type Object', () => {
       expect(message.messageBody.toValue()).to.equal('{"parents":[]}');
       expect(message.messageBody.contentType.toValue()).to.equal('application/json');
     });
+
+    it('generates an messageBody asset for text type with string schema', () => {
+      const mediaType = new namespace.elements.Member('text/plain', {
+        schema: {
+          type: 'string',
+          example: 'hello world',
+        },
+      });
+
+      const parseResult = parse(context, messageBodyClass, mediaType);
+
+      const message = parseResult.get(0);
+      expect(message).to.be.instanceof(messageBodyClass);
+      expect(message.messageBody.toValue()).to.equal('hello world');
+      expect(message.messageBody.contentType.toValue()).to.equal('text/plain');
+    });
+
+    it('does not generates an messageBody asset for text type with non string type', () => {
+      const mediaType = new namespace.elements.Member('text/plain', {
+        schema: {
+          type: 'number',
+          example: 5,
+        },
+      });
+
+      const parseResult = parse(context, messageBodyClass, mediaType);
+
+      const message = parseResult.get(0);
+      expect(message).to.be.instanceof(messageBodyClass);
+      expect(message.messageBody).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
This PR adds support for generating message body assets for text types like text/plain and text/html.

Example usage:

```yaml
responses:
  200:
    content:
      text/plain:
        schema:
          type: string
          example: The request was successful
```

To produce message body, such as if the response was:

```
Content-Type: text/plain

The request was successful
```