### PR TITLE
Add optional typeAttribute for optional parameters

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Prevents a 'Path Item Object' from being included in a Resource Group created
   by an 'Operation Object' in a previously defined 'Path Item Object'.
 
+- Optional parameters will now include an optional typeAttribute in the parse
+  result. This will fix conversion to API Blueprint with fury-cli where
+  optional parameters have shown up as required in the generated API Blueprint.
+
 ## 0.27.1 (2019-06-03)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/lib/parser.js
+++ b/packages/fury-adapter-swagger/lib/parser.js
@@ -1445,6 +1445,8 @@ class Parser {
 
     if (parameter.required) {
       member.attributes.set('typeAttributes', ['required']);
+    } else {
+      member.attributes.set('typeAttributes', ['optional']);
     }
 
     return member;

--- a/packages/fury-adapter-swagger/test/fixtures/parameter-array-default-warning.json
+++ b/packages/fury-adapter-swagger/test/fixtures/parameter-array-default-warning.json
@@ -52,6 +52,17 @@
                           "content": "Query argument"
                         }
                       },
+                      "attributes": {
+                        "typeAttributes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "optional"
+                            }
+                          ]
+                        }
+                      },
                       "content": {
                         "key": {
                           "element": "string",

--- a/packages/fury-adapter-swagger/test/parameter-test.js
+++ b/packages/fury-adapter-swagger/test/parameter-test.js
@@ -3,7 +3,7 @@ const { Fury } = require('fury');
 const Parser = require('../lib/parser');
 
 const { minim: namespace } = new Fury();
-const { Annotation } = namespace.elements;
+const { Annotation, Member } = namespace.elements;
 
 describe('Parameter to Member converter', () => {
   it('can convert a parameter to a member with x-example', () => {
@@ -227,5 +227,35 @@ describe('Parameter to Member converter', () => {
 
     expect(parser.result.get(0)).to.be.instanceof(Annotation);
     expect(parameter.toValue()).to.equal('true');
+  });
+
+  describe('#typeAttributes', () => {
+    it('adds required typeAttribute for required as truthy', () => {
+      const parser = new Parser({ namespace, source: '' });
+      parser.result = new namespace.elements.ParseResult();
+      const parameter = parser.convertParameterToMember({
+        type: 'string',
+        required: true,
+      });
+
+      expect(parameter).to.be.instanceof(Member);
+
+      const typeAttributes = parameter.attributes.getValue('typeAttributes');
+      expect(typeAttributes).to.deep.equal(['required']);
+    });
+
+    it('adds required typeAttribute for required as truthy', () => {
+      const parser = new Parser({ namespace, source: '' });
+      parser.result = new namespace.elements.ParseResult();
+      const parameter = parser.convertParameterToMember({
+        type: 'string',
+        required: false,
+      });
+
+      expect(parameter).to.be.instanceof(Member);
+
+      const typeAttributes = parameter.attributes.getValue('typeAttributes');
+      expect(typeAttributes).to.deep.equal(['optional']);
+    });
   });
 });

--- a/packages/swagger-zoo/fixtures/features/api-elements/param-with-enum-default.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/param-with-enum-default.json
@@ -52,6 +52,17 @@
                           "content": "Query argument"
                         }
                       },
+                      "attributes": {
+                        "typeAttributes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "optional"
+                            }
+                          ]
+                        }
+                      },
                       "content": {
                         "key": {
                           "element": "string",
@@ -123,6 +134,17 @@
                         "description": {
                           "element": "string",
                           "content": "Query argument 2"
+                        }
+                      },
+                      "attributes": {
+                        "typeAttributes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "optional"
+                            }
+                          ]
                         }
                       },
                       "content": {

--- a/packages/swagger-zoo/fixtures/features/api-elements/param-with-enum-default.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/param-with-enum-default.sourcemap.json
@@ -175,6 +175,15 @@
                               ]
                             }
                           ]
+                        },
+                        "typeAttributes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "optional"
+                            }
+                          ]
                         }
                       },
                       "content": {
@@ -388,6 +397,15 @@
                                   ]
                                 }
                               ]
+                            }
+                          ]
+                        },
+                        "typeAttributes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "optional"
                             }
                           ]
                         }

--- a/packages/swagger-zoo/fixtures/features/api-elements/recursion.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/recursion.json
@@ -113,6 +113,17 @@
                               "content": "Test 1 2"
                             }
                           },
+                          "attributes": {
+                            "typeAttributes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "optional"
+                                }
+                              ]
+                            }
+                          },
                           "content": {
                             "key": {
                               "element": "string",

--- a/packages/swagger-zoo/fixtures/features/api-elements/recursion.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/recursion.sourcemap.json
@@ -311,6 +311,15 @@
                                   ]
                                 }
                               ]
+                            },
+                            "typeAttributes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "optional"
+                                }
+                              ]
                             }
                           },
                           "content": {

--- a/packages/swagger-zoo/fixtures/features/api-elements/x-example.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/x-example.json
@@ -57,6 +57,17 @@
                 },
                 {
                   "element": "member",
+                  "attributes": {
+                    "typeAttributes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "optional"
+                        }
+                      ]
+                    }
+                  },
                   "content": {
                     "key": {
                       "element": "string",

--- a/packages/swagger-zoo/fixtures/features/api-elements/x-example.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/x-example.sourcemap.json
@@ -178,6 +178,15 @@
                           ]
                         }
                       ]
+                    },
+                    "typeAttributes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "optional"
+                        }
+                      ]
                     }
                   },
                   "content": {


### PR DESCRIPTION
Converting an OAS 2 with optional parameters to API Blueprint would convert the parameter to required. In, API Blueprint parameters are required by default.

The following diff is from these changes on the generated API Blueprint below:

```diff
-     + title - optional title
+     + title (optional) - optional title
```

Now:

```yaml
swagger: '2.0'
info:
  title: Optional Parameters
  version: '1.0'
paths:
  '/test':
    get:
      parameters:
        - name: title
          in: query
          description: optional title
          required: false
          type: string
      responses:
        200:
          description: ok
```

```shell
$ npx fury 6018.yaml --format text/vnd.apiblueprint
```

```apib
FORMAT: 1A

# Optional Parameters

### /test

#### GET /test{?title}

+ Parameters

    + title (optional) - optional title

+ Response 200

    ok
```