### PR TITLE
Prevent resource ending up in previous resource group

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Prevents a 'Path Item Object' from being included in a Resource Group created
+  by an 'Operation Object' in a previously defined 'Path Item Object'.
+
 ## 0.27.1 (2019-06-03)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/lib/parser.js
+++ b/packages/fury-adapter-swagger/lib/parser.js
@@ -689,12 +689,6 @@ class Parser {
         });
       }
 
-      if (this.useResourceGroups()) {
-        this.updateResourceGroup(pathValue['x-group-name']);
-      }
-
-      this.group.content.push(resource);
-
       const pathObjectParameters = pathValue.parameters || [];
       const resourceHrefVariables = this.createHrefVariables(pathObjectParameters);
 
@@ -723,6 +717,17 @@ class Parser {
       });
 
       this.handleSwaggerVendorExtensions(resource, pathValue);
+
+      const operationsHaveTags = Object.values(relevantMethods).some(method => method.tags !== undefined && method.tags.length > 0);
+      if (operationsHaveTags) {
+        if (this.useResourceGroups()) {
+          this.updateResourceGroup(pathValue['x-group-name']);
+        }
+
+        this.group.content.push(resource);
+      } else {
+        this.api.push(resource);
+      }
 
       return resource;
     });

--- a/packages/fury-adapter-swagger/test/fixtures/tags.json
+++ b/packages/fury-adapter-swagger/test/fixtures/tags.json
@@ -1,0 +1,296 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Tags on some of the operations"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "v1"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": "MyRG1"
+            },
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/one"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": "first resource"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          }
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "string",
+                              "content": "200"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "element": "resource",
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/three"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": "third resource"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          }
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "string",
+                              "content": "200"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/two"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "second resource"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": "MyRG2"
+            },
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/four"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": "fourth resource"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          }
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "string",
+                              "content": "200"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/five"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "fith resource"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/fury-adapter-swagger/test/fixtures/tags.yaml
+++ b/packages/fury-adapter-swagger/test/fixtures/tags.yaml
@@ -1,0 +1,42 @@
+swagger: '2.0'
+info:
+  version: v1
+  title: Tags on some of the operations
+paths:
+  /one:
+    get:
+      summary: first resource
+      tags:
+      - MyRG1
+      responses:
+        200:
+          description: ""
+  /two:
+    get:
+      summary: second resource
+      responses:
+        200:
+          description: ""
+  /three:
+    get:
+      summary: third resource
+      tags:
+      - MyRG1
+      responses:
+        200:
+          description: ""
+  /four:
+    get:
+      summary: fourth resource
+      tags:
+      - MyRG2
+      responses:
+        200:
+          description: ""
+  /five:
+    get:
+      summary: fith resource
+      tags: []
+      responses:
+        200:
+          description: ""


### PR DESCRIPTION
See the following OAS 2 document which defines two resources where the first Operation Object is part of a tag "MyRG", the parser is incorrectly treated the subsequent Operation Object in the MyRG tag.

```yaml
swagger: '2.0'
info:
  version: v1
  title: marcotestswagger1
paths:
  /resource3:
    get:
      summary: Description of the resource
      tags:
      - MyRG
      responses:
        200:
          description: ""
  /resource4:
    get:
      summary: Description of the resource
      responses:
        200:
          description: ""
```

```json
{
  "element": "parseResult",
  "content": [
    {
      "element": "category",
      "meta": {
        "classes": {
          "element": "array",
          "content": [
            {
              "element": "string",
              "content": "api"
            }
          ]
        },
        "title": {
          "element": "string",
          "content": "marcotestswagger1"
        }
      },
      "attributes": {
        "version": {
          "element": "string",
          "content": "v1"
        }
      },
      "content": [
        {
          "element": "category",
          "meta": {
            "title": {
              "element": "string",
              "content": "MyRG"
            },
            "classes": {
              "element": "array",
              "content": [
                {
                  "element": "string",
                  "content": "resourceGroup"
                }
              ]
            }
          },
          "content": [
            {
              "element": "resource",
              "attributes": {
                "href": {
                  "element": "string",
                  "content": "/resource3"
                }
              },
              "content": [
                {
                  "element": "transition",
                  "meta": {
                    "title": {
                      "element": "string",
                      "content": "Description of the resource"
                    }
                  },
                  "content": [
                    {
                      "element": "httpTransaction",
                      "content": [
                        {
                          "element": "httpRequest",
                          "attributes": {
                            "method": {
                              "element": "string",
                              "content": "GET"
                            }
                          }
                        },
                        {
                          "element": "httpResponse",
                          "attributes": {
                            "statusCode": {
                              "element": "string",
                              "content": "200"
                            }
                          }
                        }
                      ]
                    }
                  ]
                }
              ]
            },
            {
              "element": "resource",
              "attributes": {
                "href": {
                  "element": "string",
                  "content": "/resource4"
                }
              },
              "content": [
                {
                  "element": "transition",
                  "meta": {
                    "title": {
                      "element": "string",
                      "content": "Description of the resource"
                    }
                  },
                  "content": [
                    {
                      "element": "httpTransaction",
                      "content": [
                        {
                          "element": "httpRequest",
                          "attributes": {
                            "method": {
                              "element": "string",
                              "content": "GET"
                            }
                          }
                        },
                        {
                          "element": "httpResponse",
                          "attributes": {
                            "statusCode": {
                              "element": "string",
                              "content": "200"
                            }
                          }
                        }
                      ]
                    }
                  ]
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```

This changeset guards against this bug by ensuring we only use the existing logic for resource groups iff any of the 'Operation Object' contains tags.