### PR TITLE
Allow circular references in allOf

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -11,6 +11,11 @@
   result. This will fix conversion to API Blueprint with fury-cli where
   optional parameters have shown up as required in the generated API Blueprint.
 
+- Allows generating of JSON bodies for schemas which make use of `allOf` and
+  include circular references. Under some circumstances this would previously
+  fail, and a warning may have been emitted "Unable to generate
+  application/json example message body out of JSON Schema"
+
 ## 0.27.1 (2019-06-03)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -112,7 +112,7 @@ const dereference = (example, root, paths, path) => {
     const currentPath = (path || []).join('/');
 
     if (path && pathHasCircularReference(paths, path, example.$ref)) {
-      return null;
+      return {};
     }
 
     let ref;

--- a/packages/fury-adapter-swagger/test/fixtures/circular-example.json
+++ b/packages/fury-adapter-swagger/test/fixtures/circular-example.json
@@ -204,7 +204,7 @@
                               "content": "application/json"
                             }
                           },
-                          "content": "{\n  \"id\": \"ORCL\"\n}"
+                          "content": "{\n  \"id\": \"ORCL\",\n  \"user\": {\n    \"data\": {\n      \"name\": \"doe\",\n      \"company\": {\n        \"data\": {\n          \"is_owner\": false\n        }\n      }\n    }\n  }\n}"
                         },
                         {
                           "element": "asset",
@@ -225,7 +225,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"allOf\":[{\"$ref\":\"#/definitions/Company\"}],\"definitions\":{\"Company\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"default\":\"ORCL\"},\"user\":{\"type\":\"object\",\"properties\":{\"data\":{\"$ref\":\"#/definitions/User\"}}}},\"default\":{\"id\":\"ORCL\"}},\"User\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"default\":\"doe\"},\"company\":{\"properties\":{\"data\":{\"$ref\":\"#/definitions/Company\"}}}}}}}"
+                          "content": "{\"allOf\":[{\"$ref\":\"#/definitions/Company\"}],\"definitions\":{\"Company\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"default\":\"ORCL\"},\"user\":{\"type\":\"object\",\"properties\":{\"data\":{\"$ref\":\"#/definitions/User\"}}}}},\"User\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"default\":\"doe\"},\"company\":{\"properties\":{\"data\":{\"allOf\":[{\"$ref\":\"#/definitions/Company\"},{\"type\":\"object\",\"properties\":{\"is_owner\":{\"type\":\"boolean\",\"default\":false}}}]}}}}}}}"
                         },
                         {
                           "element": "dataStructure",
@@ -426,7 +426,38 @@
                                 "content": "data"
                               },
                               "value": {
-                                "element": "definitions/Company"
+                                "element": "definitions/Company",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "attributes": {
+                                      "typeAttributes": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "optional"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "is_owner"
+                                      },
+                                      "value": {
+                                        "element": "boolean",
+                                        "attributes": {
+                                          "default": {
+                                            "element": "boolean",
+                                            "content": false
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           }

--- a/packages/fury-adapter-swagger/test/fixtures/circular-example.yaml
+++ b/packages/fury-adapter-swagger/test/fixtures/circular-example.yaml
@@ -26,8 +26,6 @@ definitions:
         properties:
           data:
             $ref: '#/definitions/User'
-    default:
-      id: ORCL
 
   User:
     type: object
@@ -38,5 +36,10 @@ definitions:
       company:
         properties:
           data:
-            $ref: '#/definitions/Company'
-
+            allOf:
+              - $ref: '#/definitions/Company'
+              - type: object
+                properties:
+                  is_owner:
+                    type: boolean
+                    default: false

--- a/packages/fury-adapter-swagger/test/json-schema-test.js
+++ b/packages/fury-adapter-swagger/test/json-schema-test.js
@@ -754,7 +754,7 @@ describe('Dereferencing', () => {
 
     expect(result).to.deep.equal({
       name: 'Doe',
-      parent: null,
+      parent: {},
     });
   });
 
@@ -778,7 +778,7 @@ describe('Dereferencing', () => {
     expect(result).to.deep.equal({
       name: 'Doe',
       company: {
-        owner: null,
+        owner: {},
       },
     });
   });


### PR DESCRIPTION
When dereferencing schemas, the OAS 2 parser returned `null` in the schema upon encountering a circular reference. In turn, if you have a circular reference in the right place you'd end up with a dereferenced schema such as `{"allOf": [null]}` which is invalid, allOf array may only contain schemas (not null) and thus tools like faker will throw an exception which subsequently causes JSON body generation to fail:

```
TypeError: Cannot read property 'thunk' of null
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1716:40
    at Array.forEach (<anonymous>)
    at reduce (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1712:17)
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1752:23
    at Array.forEach (<anonymous>)
    at reduce (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1750:24)
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1752:23
    at Array.forEach (<anonymous>)
    at reduce (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1750:24)
    at /Users/kyle/Projects/apiaryio/api-elements.js/node_modules/json-schema-faker/dist/index.js:1713:22
```

With the updated test fixture, this would translate to the following warning:

```
warning: (3) Unable to generate application/json example message body out of JSON Schema - line 14
```

The fix I have proposed is that we use `{}` instead of null to represent circular dereferences as an empty object is always a valid schema and may be placed anywhere in a JSON Schema where a reference may be used.

The circular test regression fixture has been updated to use allOf to reproduce this bug.

Reported via https://github.com/apiaryio/dredd/issues/1451