### PR TITLE
Prevent null title for unnamed section in Apiary Blueprint

### DIFF
--- a/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
+++ b/packages/fury-adapter-apiary-blueprint-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Master
+
+### Bug Fixes
+
+- Prevents placing a null title element in a resource group when the section
+  name is empty.
+
 ## 3.0.0-beta.9 (2019-07-02)
 
 ### Enhancements

--- a/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
+++ b/packages/fury-adapter-apiary-blueprint-parser/lib/parser.js
@@ -86,7 +86,9 @@ class Parser {
     const { Copy, Category, Resource } = this.namespace.elements;
 
     const group = new Category();
-    group.title = section.name;
+    if (section.name) {
+      group.title = section.name;
+    }
     group.classes.push('resourceGroup');
 
     if (section.description) {

--- a/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/unnamed-section.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/unnamed-section.json
@@ -22,10 +22,6 @@
         {
           "element": "category",
           "meta": {
-            "title": {
-              "element": "null",
-              "content": null
-            },
             "classes": {
               "element": "array",
               "content": [

--- a/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/unnamed-section.json
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/unnamed-section.json
@@ -1,0 +1,131 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Sample API"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "title": {
+              "element": "null",
+              "content": null
+            },
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/message"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": "GET"
+                    }
+                  },
+                  "attributes": {
+                    "href": {
+                      "element": "string",
+                      "content": "/message"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          }
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "number",
+                              "content": 200
+                            },
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "text/plain"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "messageBody"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": "Hello World!"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/unnamed-section.txt
+++ b/packages/fury-adapter-apiary-blueprint-parser/test/fixtures/unnamed-section.txt
@@ -1,0 +1,5 @@
+--- Sample API ---
+GET /message
+< 200
+< Content-Type: text/plain
+Hello World!


### PR DESCRIPTION
Discovered that the lack of a title in an Apiary Blueprint section causes a "null" element as the title which is unexpected (no other parser operates like this). I've added the test in the prior commit so you can see the diff that the code change causes in second commit.