### PR TITLE
Handle parameters without value during serialize

### DIFF
--- a/packages/fury-adapter-apib-serializer/CHANGELOG.md
+++ b/packages/fury-adapter-apib-serializer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury API Blueprint Serializer
 
+## Master
+
+### Bug Fixes
+
+- Prevents an exception from being thrown when serializing href variables which
+  do not include a value.
+  [#357](https://github.com/apiaryio/api-elements.js/issues/357)
+
 ## 0.12.1 (2019-07-12)
 
 ### Bug Fixes

--- a/packages/fury-adapter-apib-serializer/template.nunjucks
+++ b/packages/fury-adapter-apib-serializer/template.nunjucks
@@ -50,7 +50,7 @@ FORMAT: 1A
 
   {% for item in hrefVariables.content %}
     {% set typeAttributes = item.attributes.get('typeAttributes') %}
-    + {{ item.key.toValue() }}{% if item.value.toValue() %}: {{ item.value.toValue() }}{% endif %}{% if typeAttributes %} ({{ typeAttributes.toValue() }}){% endif %}{% if item.description and item.description.toValue() %} - {{ item.description.toValue() }}{% endif %}{% endfor %}
+    + {{ item.key.toValue() }}{% if item.value and item.value.toValue() %}: {{ item.value.toValue() }}{% endif %}{% if typeAttributes %} ({{ typeAttributes.toValue() }}){% endif %}{% if item.description and item.description.toValue() %} - {{ item.description.toValue() }}{% endif %}{% endfor %}
 
 {% endmacro %}
 

--- a/packages/fury-adapter-apib-serializer/test/fixtures/parameters-no-value.apib
+++ b/packages/fury-adapter-apib-serializer/test/fixtures/parameters-no-value.apib
@@ -1,0 +1,9 @@
+FORMAT: 1A
+
+# API Documentation
+
+### /{?example}
+
++ Parameters
+
+    + example

--- a/packages/fury-adapter-apib-serializer/test/fixtures/parameters-no-value.json
+++ b/packages/fury-adapter-apib-serializer/test/fixtures/parameters-no-value.json
@@ -1,0 +1,44 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/{?example}"
+            },
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "content": [
+                {
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "example"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
When serializing a Href Variable which does not have a value (for example from an OpenAPI document) the serializer would crash because there is a call to convert the element to a value without a check if there is a value element.

Fixes https://github.com/apiaryio/api-elements.js/issues/357