### PR TITLE
Allow --adapter in fury-cli to have precedence

### DIFF
--- a/packages/fury-cli/CHANGELOG.md
+++ b/packages/fury-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+- Any adapter added via the `--adapter` option will be preferred for parsing
+  when there are multiple adapters loaded for the same media types. For example
+  if you want to use `--adapter fury-adapter-remote` and there is already a
+  conflicting adapter such as `fury-adapter-apib-parser` which previously took
+  precedence.
+
 ## 0.9.1 (2019-07-02)
 
 This update incorporates changes from Fury Adapters:

--- a/packages/fury-cli/lib/fury.js
+++ b/packages/fury-cli/lib/fury.js
@@ -228,7 +228,8 @@ if (require.main === module) {
 
   if (commander.adapter) {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    fury.use(require(commander.adapter));
+    const adapter = require(commander.adapter);
+    fury.adapters.unshift(adapter);
   }
 
   const furyCLI = new FuryCLI(input, output, commander.format,


### PR DESCRIPTION
If I was to run `fury --adapter fury-adapter-remote helo.apib` or similiar it would prefer parsing with the built-in adapters such as fury-adapter-apib-parser. Since i've explicitly enabled the remote adapter, it should take precedence so that it is used.

I've solved this by addign the adatper to start of "adapters" array instead of the end.