### PR TITLE
Pin to Python 3.6.8 for building docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
   docs:
     <<: *defaults
     docker:
-      - image: circleci/python:3.6-node-browsers
+      - image: circleci/python:3.6.8-node-browsers
     steps:
       - checkout
       - <<: *install


### PR DESCRIPTION
CircleCIs Python 3.6.9 image contains Node 12 which is incompatible with JSDoc 3.5. JSDoc 3.6 supports Node 12 but it brings other problems and incompatibilies with the jsdoc comments in minim causing documentation to fail (see master branch has failing CI). While we should strive to get onto latest JSDoc and Node 12, I wouldn't leave master broken while we do that.