### PR TITLE
Support adapters which have constructor

### DIFF
--- a/packages/fury-cli/lib/fury.js
+++ b/packages/fury-cli/lib/fury.js
@@ -228,7 +228,13 @@ if (require.main === module) {
 
   if (commander.adapter) {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    const adapter = require(commander.adapter);
+    let adapter = require(commander.adapter);
+
+    if (adapter.constructor) {
+      // eslint-disable-next-line new-cap
+      adapter = new adapter();
+    }
+
     fury.adapters.unshift(adapter);
   }
 


### PR DESCRIPTION
Some adapters like the fury remote adapter require initialisation, we can detect that the adapter has a `constructor` method and then create a new instance. This allows the following to work:

```
$ npx fury --adapter fury-adapter-remote test.apib
```