### PR TITLE
Handle internal YAML parser error

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
@@ -111,8 +111,10 @@ function parse(source, context) {
     if (error.problem) {
       const problem = error.problem.replace('\t', '\\t');
       message = `${problem}, ${error.context}`;
-    } else {
+    } else if (error.context) {
       message = error.context;
+    } else {
+      ({ message } = error);
     }
 
     const annotation = new namespace.elements.Annotation(
@@ -121,12 +123,14 @@ function parse(source, context) {
     );
 
     const marker = error.context_mark || error.problem_mark;
-    copySourceMap(
-      marker,
-      marker,
-      annotation,
-      namespace
-    );
+    if (marker) {
+      copySourceMap(
+        marker,
+        marker,
+        annotation,
+        namespace
+      );
+    }
 
     parseResult.push(annotation);
     return parseResult;

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/parseYAML-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/parseYAML-test.js
@@ -31,6 +31,18 @@ describe('#parseYAML', () => {
 
       expect(parseResult).contain.error('YAML Syntax: found character \\t that cannot start any token, while scanning for the next token').with.sourceMap([[14, 0]]);
     });
+
+    it('can handle internal YAML parser error', () => {
+      // Protection against YAML parser bug where source map information isn't available
+      // Particular case: https://github.com/connec/yaml-js/issues/46
+
+      const parseResult = parseYAML("key:\n  key:\n      key: 'x\nkey: 'string'", context);
+
+      expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
+      expect(parseResult.errors.length).to.equal(1);
+
+      expect(parseResult).contain.error('YAML Syntax: logic failure');
+    });
   });
 
   it('can parse a string into a string element', () => {


### PR DESCRIPTION
The following YAML document causes yaml parser to throw an internal error:

```yaml
openapi: 3.0.0
key:
  key:
      key: 'x
key: 'string'
```

This is due to a combination of the incorrect YAML string missing the terminating `'` and the key on the next line at a very different indentation level.

```
Error: logic failure
    at Loader.Scanner.Scanner.save_possible_simple_key (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/scanner.js:302:15)
    at Loader.Scanner.Scanner.fetch_plain (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/scanner.js:566:12)
    at Loader.Scanner.Scanner.fetch_more_tokens (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/scanner.js:238:21)
    at Loader.Scanner.Scanner.check_token (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/scanner.js:115:14)
    at Loader.Parser.Parser.parse_block_mapping_key (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/parser.js:421:16)
    at Loader.Parser.Parser.check_event (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/parser.js:61:48)
    at Loader.Composer.Composer.compose_mapping_node (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/composer.js:248:20)
    at Loader.Composer.Composer.compose_node (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/composer.js:160:21)
    at Loader.Composer.Composer.compose_mapping_node (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/composer.js:250:27)
    at Loader.Composer.Composer.compose_node (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/yaml-js/lib/composer.js:160:21)
```

Which inturn causes the OAS 3 parser to throw an error while trying to copy source maps from the error to the annotation. This changeset makes it so that we handle errors without "marks" (the Yaml parser node structure for source maps and show the error message when there isn't other human readable messages. It's not perfect behaviour, solving the upstream bug https://github.com/connec/yaml-js/issues/46 would be the best route, but that doesn't seem to be as simple so I've made protection against it so that atleast the parser shows an error instead of crashing.