### PR TITLE
Emit node tag in error for unsupported tag

### DIFF
--- a/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/parseYAML.js
@@ -90,7 +90,7 @@ function convert(node, annotations, context) {
     copySourceMap(node.start_mark, node.end_mark, warning, namespace);
     annotations.push(warning);
   } else {
-    throw new Error('Unsupported YAML node');
+    throw new Error(`Unsupported YAML node '${node.tag}'`);
   }
 
   copySourceMap(node.start_mark, node.end_mark, element, namespace);


### PR DESCRIPTION
If this error occurs, the error and stacktrace don't provide information to be able to debug the problem. Addng the `node.tag` into error message will make it easier to figure out which node was past in.