### PR TITLE
Prevent installing yarn on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 aliases:
   - &install
-    run: sudo npm install -g yarn && yarn install --frozen-lockfile --ignore-optional
+    run: yarn install --frozen-lockfile --ignore-optional
   - &defaults
     working_directory: ~/repo
     docker:


### PR DESCRIPTION
CI is failing because Yarn is already installed in newer CircleCI images. This can be seen in the PR at https://github.com/apiaryio/api-elements.js/pull/394