### PR TITLE
Adds explicit "$schema" property to JSON Schema generated from Swagger

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury Swagger Parser Changelog
 
+## 0.28.1 (2020-01-30)
+
+### Bug Fixes
+
+- Sets an explicit `$schema` property on JSON Schema generated from a Swagger
+  document in `convertSchema`. Sets a JSON Schema Draft V4 as the value of the
+  `$schema` property, making generated schema implement a JSON Schema Draft V4.
+
 ## 0.28.0 (2019-12-06)
 
 ### Enhancements

--- a/packages/fury-adapter-swagger/lib/json-schema.js
+++ b/packages/fury-adapter-swagger/lib/json-schema.js
@@ -345,6 +345,8 @@ const convertSchema = (schema, root, swagger, copyDefinitions = true) => {
   const result = convertSubSchema(schema, references, swagger);
 
   if (copyDefinitions) {
+    result.$schema = 'http://json-schema.org/draft-04/schema#';
+
     if (references.length !== 0) {
       result.definitions = {};
     }

--- a/packages/fury-adapter-swagger/test/fixtures/auth-multi-consumes.json
+++ b/packages/fury-adapter-swagger/test/fixtures/auth-multi-consumes.json
@@ -169,7 +169,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -273,7 +273,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/consumes-invalid-type.json
+++ b/packages/fury-adapter-swagger/test/fixtures/consumes-invalid-type.json
@@ -68,7 +68,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/data-structure-generation-nullable-member.json
+++ b/packages/fury-adapter-swagger/test/fixtures/data-structure-generation-nullable-member.json
@@ -91,7 +91,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":[\"string\",\"null\"]}}}"
+                          "content": "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":[\"string\",\"null\"]}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/data-structure-generation-ref.json
+++ b/packages/fury-adapter-swagger/test/fixtures/data-structure-generation-ref.json
@@ -91,7 +91,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"$ref\":\"#/definitions/User\"}},\"examples\":[{\"id\":123,\"user\":{\"name\":\"Doe\"}}],\"definitions\":{\"User\":{\"type\":\"object\",\"examples\":[{\"name\":\"Doe\"}]}}}"
+                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"$ref\":\"#/definitions/User\"}},\"examples\":[{\"id\":123,\"user\":{\"name\":\"Doe\"}}],\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"definitions\":{\"User\":{\"type\":\"object\",\"examples\":[{\"name\":\"Doe\"}]}}}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/data-structure-generation.json
+++ b/packages/fury-adapter-swagger/test/fixtures/data-structure-generation.json
@@ -91,7 +91,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"type\":\"string\",\"examples\":[\"doe\"]}},\"examples\":[{\"id\":123,\"name\":\"doe\"}]}"
+                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"type\":\"string\",\"examples\":[\"doe\"]}},\"examples\":[{\"id\":123,\"name\":\"doe\"}],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/json-body-generation-array-object.json
+++ b/packages/fury-adapter-swagger/test/fixtures/json-body-generation-array-object.json
@@ -202,7 +202,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Question\"},\"definitions\":{\"Question\":{\"title\":\"Question\",\"type\":\"object\",\"properties\":{\"question\":{\"type\":\"string\",\"examples\":[\"hi\"]},\"published_at\":{\"type\":\"string\",\"examples\":[2019]},\"choices\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Choice\"}}},\"required\":[\"question\",\"published_at\",\"choices\"]},\"Choice\":{\"title\":\"Choice\",\"type\":\"object\",\"properties\":{\"votes\":{\"type\":\"integer\",\"format\":\"int32\",\"examples\":[512]},\"choice\":{\"type\":\"string\",\"examples\":[\"Swift\"]}},\"required\":[\"votes\",\"choice\"]}}}"
+                          "content": "{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Question\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"definitions\":{\"Question\":{\"title\":\"Question\",\"type\":\"object\",\"properties\":{\"question\":{\"type\":\"string\",\"examples\":[\"hi\"]},\"published_at\":{\"type\":\"string\",\"examples\":[2019]},\"choices\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Choice\"}}},\"required\":[\"question\",\"published_at\",\"choices\"]},\"Choice\":{\"title\":\"Choice\",\"type\":\"object\",\"properties\":{\"votes\":{\"type\":\"integer\",\"format\":\"int32\",\"examples\":[512]},\"choice\":{\"type\":\"string\",\"examples\":[\"Swift\"]}},\"required\":[\"votes\",\"choice\"]}}}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/json-body-generation-bad-pattern.json
+++ b/packages/fury-adapter-swagger/test/fixtures/json-body-generation-bad-pattern.json
@@ -196,7 +196,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\",\"minLength\":1,\"maxLength\":255,\"pattern\":\"^[A-z]+$\"}"
+                          "content": "{\"type\":\"string\",\"minLength\":1,\"maxLength\":255,\"pattern\":\"^[A-z]+$\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/json-body-generation.json
+++ b/packages/fury-adapter-swagger/test/fixtures/json-body-generation.json
@@ -206,7 +206,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\",\"examples\":[1]},\"name\":{\"type\":\"string\",\"examples\":[\"doe\"]}}}"
+                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\",\"examples\":[1]},\"name\":{\"type\":\"string\",\"examples\":[\"doe\"]}},\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/operation-consumes-invalid-type.json
+++ b/packages/fury-adapter-swagger/test/fixtures/operation-consumes-invalid-type.json
@@ -68,7 +68,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/operation-produces-invalid-type.json
+++ b/packages/fury-adapter-swagger/test/fixtures/operation-produces-invalid-type.json
@@ -81,7 +81,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/parameter-array-default-warning.json
+++ b/packages/fury-adapter-swagger/test/fixtures/parameter-array-default-warning.json
@@ -126,7 +126,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/produces-invalid-type.json
+++ b/packages/fury-adapter-swagger/test/fixtures/produces-invalid-type.json
@@ -81,7 +81,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/fixtures/request-body-primitive.json
+++ b/packages/fury-adapter-swagger/test/fixtures/request-body-primitive.json
@@ -151,7 +151,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\",\"examples\":[\"Http Request Body\"]}"
+                          "content": "{\"type\":\"string\",\"examples\":[\"Http Request Body\"],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -309,7 +309,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"number\",\"examples\":[1]}"
+                          "content": "{\"type\":\"number\",\"examples\":[1],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -467,7 +467,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"boolean\",\"examples\":[true]}"
+                          "content": "{\"type\":\"boolean\",\"examples\":[true],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/fury-adapter-swagger/test/inherit-parameters-test.js
+++ b/packages/fury-adapter-swagger/test/inherit-parameters-test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const cloneDeep = require('lodash/cloneDeep');
 const fury = require('fury');
 const adapter = require('../lib/adapter');
 
@@ -28,6 +29,12 @@ function doParse(source, done, expectations) {
 
     return done();
   });
+}
+
+function getJSONSchemaFromSource(sourceSchema) {
+  const parameterSchema = cloneDeep(sourceSchema);
+  parameterSchema.$schema = 'http://json-schema.org/draft-04/schema#';
+  return JSON.stringify(parameterSchema);
 }
 
 function makeParameter(aName, aIn, aValue) {
@@ -228,7 +235,7 @@ describe('Inherit Path Parameters', () => {
       source.paths['/'].parameters.push(makeParameter('test', 'body'));
 
       doParse(source, done, (result) => {
-        const schema = JSON.stringify(source.paths['/'].parameters[0].schema);
+        const schema = getJSONSchemaFromSource(source.paths['/'].parameters[0].schema);
 
         // ensure there is no warning about unsupported "Path-level Body Parameter")
         expect(result.result.annotations.toValue()).to.be.empty;
@@ -241,7 +248,7 @@ describe('Inherit Path Parameters', () => {
       source.paths['/'].get.parameters.push(makeParameter('test', 'body'));
 
       doParse(source, done, (result) => {
-        const schema = JSON.stringify(source.paths['/'].get.parameters[0].schema);
+        const schema = getJSONSchemaFromSource(source.paths['/'].get.parameters[0].schema);
 
         expect(result.request.messageBodySchema.content).to.equal(schema);
       });
@@ -268,8 +275,9 @@ describe('Inherit Path Parameters', () => {
       source.paths['/'].get.parameters.push(makeParameter('test', 'body', { type: 'number' }));
 
       doParse(source, done, (result) => {
-        expect(result.request.messageBodySchema.content).to
-          .equal(JSON.stringify(source.paths['/'].get.parameters[0].schema));
+        const schema = getJSONSchemaFromSource(source.paths['/'].get.parameters[0].schema);
+
+        expect(result.request.messageBodySchema.content).to.equal(schema);
       });
     });
   });

--- a/packages/fury-adapter-swagger/test/json-schema-test.js
+++ b/packages/fury-adapter-swagger/test/json-schema-test.js
@@ -5,44 +5,63 @@ describe('Swagger Schema to JSON Schema', () => {
   it('returns compatible schema when given valid JSON Schema', () => {
     const schema = convertSchema({ type: 'object' });
 
-    expect(schema).to.deep.equal({ type: 'object' });
+    expect(schema).to.deep.equal({
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'object',
+    });
   });
 
   describe('extension removal', () => {
     it('removes Swagger vendored extensions', () => {
       const schema = convertSchema({ type: 'object', 'x-extension': 'example' });
 
-      expect(schema).to.deep.equal({ type: 'object' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'object',
+      });
     });
 
     it('removes Swagger discriminator extension', () => {
       const schema = convertSchema({ type: 'object', discriminator: 'example' });
 
-      expect(schema).to.deep.equal({ type: 'object' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'object',
+      });
     });
 
     it('removes Swagger readOnly extension', () => {
       const schema = convertSchema({ type: 'object', readOnly: true });
 
-      expect(schema).to.deep.equal({ type: 'object' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'object',
+      });
     });
 
     it('removes Swagger xml extension', () => {
       const schema = convertSchema({ type: 'object', xml: { name: 'example' } });
 
-      expect(schema).to.deep.equal({ type: 'object' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'object',
+      });
     });
 
     it('removes Swagger externalDocs extension', () => {
       const schema = convertSchema({ type: 'object', externalDocs: { url: 'https://example.com' } });
 
-      expect(schema).to.deep.equal({ type: 'object' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'object',
+      });
     });
 
     it('translates Swagger example extension to examples', () => {
       const schema = convertSchema({ type: 'object', example: { message: 'hello' } });
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'object',
         examples: [
           { message: 'hello' },
@@ -54,6 +73,7 @@ describe('Swagger Schema to JSON Schema', () => {
       const schema = convertSchema({ type: 'object', example: { length: 2 } });
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'object',
         examples: [
           { length: 2 },
@@ -76,6 +96,7 @@ describe('Swagger Schema to JSON Schema', () => {
       const schema = convertSchema(swaggerSchema, {}, root);
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'object',
         examples: [
           { message: 'hello' },
@@ -100,6 +121,7 @@ describe('Swagger Schema to JSON Schema', () => {
       const schema = convertSchema(swaggerSchema, {}, root);
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'object',
         examples: [
           {
@@ -126,6 +148,7 @@ describe('Swagger Schema to JSON Schema', () => {
       const schema = convertSchema(swaggerSchema, {}, root);
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'object',
         examples: [
           [{ message: 'hello' }],
@@ -138,19 +161,28 @@ describe('Swagger Schema to JSON Schema', () => {
     it('ignores false x-nullable', () => {
       const schema = convertSchema({ type: 'string', 'x-nullable': false });
 
-      expect(schema).to.deep.equal({ type: 'string' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'string',
+      });
     });
 
     it('translates x-nullable to type null without existing type', () => {
       const schema = convertSchema({ 'x-nullable': true });
 
-      expect(schema).to.deep.equal({ type: 'null' });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'null',
+      });
     });
 
     it('translates x-nullable to type null with existing type', () => {
       const schema = convertSchema({ type: 'string', 'x-nullable': true });
 
-      expect(schema).to.deep.equal({ type: ['string', 'null'] });
+      expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: ['string', 'null'],
+      });
     });
   });
 
@@ -166,6 +198,7 @@ describe('Swagger Schema to JSON Schema', () => {
       });
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         allOf: [
           {
             type: 'string',
@@ -185,6 +218,7 @@ describe('Swagger Schema to JSON Schema', () => {
       });
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         anyOf: [
           {
             type: 'string',
@@ -204,6 +238,7 @@ describe('Swagger Schema to JSON Schema', () => {
       });
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         oneOf: [
           {
             type: 'string',
@@ -221,6 +256,7 @@ describe('Swagger Schema to JSON Schema', () => {
       });
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         not: {
           type: 'string',
         },
@@ -238,6 +274,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'array',
           items: {
             type: 'string',
@@ -257,6 +294,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'array',
           items: [
             {
@@ -276,6 +314,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'array',
           additionalItems: {
             type: 'string',
@@ -290,6 +329,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'array',
           additionalItems: true,
         });
@@ -309,6 +349,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'object',
           properties: {
             example: {
@@ -330,6 +371,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'object',
           patternProperties: {
             '[0-9]': {
@@ -349,6 +391,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'object',
           additionalProperties: {
             type: 'string',
@@ -363,6 +406,7 @@ describe('Swagger Schema to JSON Schema', () => {
         });
 
         expect(schema).to.deep.equal({
+          $schema: 'http://json-schema.org/draft-04/schema#',
           type: 'object',
           additionalProperties: true,
         });
@@ -482,6 +526,7 @@ describe('Swagger Schema to JSON Schema', () => {
       }, root);
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'array',
         items: {
           $ref: '#/definitions/User',
@@ -516,6 +561,7 @@ describe('Swagger Schema to JSON Schema', () => {
       }, root);
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'array',
         items: {
           $ref: '#/definitions/User/properties/name',
@@ -558,6 +604,7 @@ describe('Swagger Schema to JSON Schema', () => {
       }, root);
 
       expect(schema).to.deep.equal({
+        $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'array',
         items: {
           $ref: '#/definitions/User',

--- a/packages/fury-adapter-swagger/test/parser-test.js
+++ b/packages/fury-adapter-swagger/test/parser-test.js
@@ -82,7 +82,7 @@ describe('Parser', () => {
       const payload = new fury.minim.elements.HttpResponse();
       parser.pushAssets(schema, payload);
 
-      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object"}');
+      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object","$schema":"http://json-schema.org/draft-04/schema#"}');
     });
 
     it('strips extensions from schema', () => {
@@ -90,7 +90,7 @@ describe('Parser', () => {
       const payload = new fury.minim.elements.HttpResponse();
       parser.pushAssets(schema, payload);
 
-      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object"}');
+      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object","$schema":"http://json-schema.org/draft-04/schema#"}');
     });
 
     it('adds null to type when x-nullable is provided', () => {
@@ -98,7 +98,7 @@ describe('Parser', () => {
       const payload = new fury.minim.elements.HttpResponse();
       parser.pushAssets(schema, payload);
 
-      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":["object","null"]}');
+      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":["object","null"],"$schema":"http://json-schema.org/draft-04/schema#"}');
     });
 
     it('sets null as type when x-nullable is provided without type', () => {
@@ -106,7 +106,7 @@ describe('Parser', () => {
       const payload = new fury.minim.elements.HttpResponse();
       parser.pushAssets(schema, payload);
 
-      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"null"}');
+      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"null","$schema":"http://json-schema.org/draft-04/schema#"}');
     });
 
     it('adds null value to enum when x-nullable is provided', () => {
@@ -114,7 +114,7 @@ describe('Parser', () => {
       const payload = new fury.minim.elements.HttpResponse();
       parser.pushAssets(schema, payload);
 
-      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null]}');
+      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null],"$schema":"http://json-schema.org/draft-04/schema#"}');
     });
 
     it('does not add null value to enum when x-nullable is provided and null in enum', () => {
@@ -122,7 +122,7 @@ describe('Parser', () => {
       const payload = new fury.minim.elements.HttpResponse();
       parser.pushAssets(schema, payload);
 
-      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null]}');
+      expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null],"$schema":"http://json-schema.org/draft-04/schema#"}');
     });
   });
 });

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-basic.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-basic.json
@@ -116,7 +116,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-basic.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-basic.sourcemap.json
@@ -339,7 +339,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-does-not-exist.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-does-not-exist.json
@@ -91,7 +91,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-does-not-exist.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-does-not-exist.sourcemap.json
@@ -289,7 +289,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-double.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-double.json
@@ -143,7 +143,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-double.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-double.sourcemap.json
@@ -441,7 +441,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-global.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-global.json
@@ -140,7 +140,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -212,7 +212,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -294,7 +294,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-global.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-global.sourcemap.json
@@ -413,7 +413,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -608,7 +608,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -838,7 +838,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-access-code.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-access-code.json
@@ -215,7 +215,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-access-code.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-access-code.sourcemap.json
@@ -713,7 +713,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-application.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-application.json
@@ -202,7 +202,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-application.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-application.sourcemap.json
@@ -650,7 +650,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-implicit.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-implicit.json
@@ -202,7 +202,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-implicit.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-implicit.sourcemap.json
@@ -650,7 +650,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-password.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-password.json
@@ -202,7 +202,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-password.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-password.sourcemap.json
@@ -650,7 +650,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-scope-does-not-exist.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-scope-does-not-exist.json
@@ -202,7 +202,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-scope-does-not-exist.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-oauth2-scope-does-not-exist.sourcemap.json
@@ -650,7 +650,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-header.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-header.json
@@ -131,7 +131,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-header.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-header.sourcemap.json
@@ -379,7 +379,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-query.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-query.json
@@ -131,7 +131,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-query.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-token-in-query.sourcemap.json
@@ -379,7 +379,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-with-x-summary.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-with-x-summary.json
@@ -124,7 +124,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/auth-with-x-summary.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/auth-with-x-summary.sourcemap.json
@@ -397,7 +397,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/body-schema-example.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/body-schema-example.json
@@ -272,7 +272,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\",\"examples\":[{\"id\":123,\"name\":\"Resource 1\"}]}"
+                          "content": "{\"type\":\"object\",\"examples\":[{\"id\":123,\"name\":\"Resource 1\"}],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/body-schema-example.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/body-schema-example.sourcemap.json
@@ -520,7 +520,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\",\"examples\":[{\"id\":123,\"name\":\"Resource 1\"}]}"
+                          "content": "{\"type\":\"object\",\"examples\":[{\"id\":123,\"name\":\"Resource 1\"}],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/consumes-json-subtype.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/consumes-json-subtype.json
@@ -145,7 +145,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/consumes-json-subtype.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/consumes-json-subtype.sourcemap.json
@@ -268,7 +268,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/external-docs.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/external-docs.json
@@ -197,7 +197,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\"type\":\"string\"}"
+                              "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                             },
                             {
                               "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/external-docs.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/external-docs.sourcemap.json
@@ -520,7 +520,7 @@
                                   ]
                                 }
                               },
-                              "content": "{\"type\":\"string\"}"
+                              "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                             },
                             {
                               "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/form-data-file.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/form-data-file.json
@@ -302,7 +302,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/form-data-file.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/form-data-file.sourcemap.json
@@ -523,7 +523,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/multiple-produces-consumes.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/multiple-produces-consumes.json
@@ -178,7 +178,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -297,7 +297,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -450,7 +450,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -569,7 +569,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/multiple-produces-consumes.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/multiple-produces-consumes.sourcemap.json
@@ -301,7 +301,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -493,7 +493,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -694,7 +694,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",
@@ -886,7 +886,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/operation-consumes-json-subtype.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/operation-consumes-json-subtype.json
@@ -145,7 +145,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/operation-consumes-json-subtype.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/operation-consumes-json-subtype.sourcemap.json
@@ -268,7 +268,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/operation-produces-json-subtype.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/operation-produces-json-subtype.json
@@ -196,7 +196,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/operation-produces-json-subtype.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/operation-produces-json-subtype.sourcemap.json
@@ -369,7 +369,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/params.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/params.json
@@ -187,7 +187,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/params.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/params.sourcemap.json
@@ -581,7 +581,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/produces-file.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/produces-file.json
@@ -81,7 +81,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/produces-file.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/produces-file.sourcemap.json
@@ -254,7 +254,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/produces-json-subtype.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/produces-json-subtype.json
@@ -196,7 +196,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/produces-json-subtype.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/produces-json-subtype.sourcemap.json
@@ -369,7 +369,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"object\"}"
+                          "content": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/schema-reference.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/schema-reference.json
@@ -178,7 +178,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\",\"examples\":[\"Hello\"]}"
+                          "content": "{\"type\":\"string\",\"examples\":[\"Hello\"],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/schema-reference.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/schema-reference.sourcemap.json
@@ -301,7 +301,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\",\"examples\":[\"Hello\"]}"
+                          "content": "{\"type\":\"string\",\"examples\":[\"Hello\"],\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/warnings.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/warnings.json
@@ -115,7 +115,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{}"
+                          "content": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         }
                       ]
                     },

--- a/packages/swagger-zoo/fixtures/features/api-elements/warnings.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/warnings.sourcemap.json
@@ -288,7 +288,7 @@
                               ]
                             }
                           },
-                          "content": "{}"
+                          "content": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         }
                       ]
                     },

--- a/packages/swagger-zoo/fixtures/features/api-elements/x-example-and-request-body.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/x-example-and-request-body.json
@@ -68,7 +68,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",

--- a/packages/swagger-zoo/fixtures/features/api-elements/x-example-and-request-body.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/x-example-and-request-body.sourcemap.json
@@ -191,7 +191,7 @@
                               ]
                             }
                           },
-                          "content": "{\"type\":\"string\"}"
+                          "content": "{\"type\":\"string\",\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
                         },
                         {
                           "element": "dataStructure",


### PR DESCRIPTION
## Changes

- Adds explicit `$schema` property in JSON Schema generated by OA2 document
- Adjusts `json-schema-test.js` to assert the presence of the root-level `$schema` property

## GitHub

- Fixes #399 