### PR TITLE
Warn for unsupported scheme

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury OAS3 Parser Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Prevents the parser from throwing an error when encountering an unsupported
+  scheme in a http Security Scheme Object.
+
 ## 0.10.0 (2019-12-06)
 
 ### Enhancements

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js
@@ -57,8 +57,20 @@ function validateApiKeyScheme(context, securityScheme) {
 function validateHttpScheme(context, securityScheme) {
   const { namespace } = context;
 
+  const schemes = ['bearer', 'basic'];
+  const isValidScheme = R.anyPass(R.map(hasValue, schemes));
+  const createInvalidSchemeWarning = scheme => createWarning(
+    namespace,
+    `'${name}' 'http' contains unsupported scheme '${scheme.value.toValue()}', supported schemes ${schemes.join(', ')}`,
+    scheme.value
+  );
+
+  const parseScheme = pipeParseResult(namespace,
+    parseString(context, name, false),
+    R.unless(isValidScheme, createInvalidSchemeWarning));
+
   const parseMember = R.cond([
-    [hasKey('scheme'), parseString(context, name, false)],
+    [hasKey('scheme'), parseScheme],
 
     [innerPassThrough, e => e],
     [isUnsupportedKey, e => e],

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseSecuritySchemeObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseSecuritySchemeObject-test.js
@@ -413,6 +413,20 @@ describe('Security Scheme Object', () => {
       expect(parseResult.length).to.equal(2);
       expect(parseResult).to.contain.warning("'Security Scheme Object' 'http' contains invalid key 'flows'");
     });
+
+    it('provides warning for invalid scheme', () => {
+      const securityScheme = new namespace.elements.Object({
+        type: 'http',
+        scheme: 'basic[',
+      });
+
+      const parseResult = parse(context, securityScheme);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.warning(
+        "'Security Scheme Object' 'http' contains unsupported scheme 'basic[', supported schemes bearer, basic"
+      );
+    });
   });
 
   describe('warnings for unsupported properties', () => {


### PR DESCRIPTION
Previously if you define a Security Scheme Object with unknown scheme we throw an error:

```
Error: Invalid security Scheme 'http' 'basic]'
 at pipeParseResult (/app/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js:161:15)
 at run (/app/node_modules/fury-adapter-oas3-parser/lib/pipeParseResult.js:60:25)
 at XWrap.f (/app/node_modules/ramda/src/reduceWhile.js:40:27)
 at XWrap.@@transducer/step (/app/node_modules/ramda/src/internal/_xwrap.js:12:17)
 at _arrayReduce (/app/node_modules/ramda/src/internal/_reduce.js:11:34)
 at _reduce (/app/node_modules/ramda/src/internal/_reduce.js:45:12)
 at Object._reduceWhile (/app/node_modules/ramda/src/reduceWhile.js:39:10)
 at Object.reduceWhile (/app/node_modules/ramda/src/internal/_curryN.js:37:27)
 at /app/node_modules/fury-adapter-oas3-parser/lib/pipeParseResult.js:71:14
 at parseSecuritySchemeObject (/app/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseSecuritySchemeObject.js:186:10)
```

This PR adds validation of the scheme to show an appropriate warning when using unsupported schemes.