### PR TITLE
Release

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury OAS3 Parser Changelog
 
-## TBD
+## 0.10.1 (2020-01-30)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-oas3-parser/package.json
+++ b/packages/fury-adapter-oas3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-oas3-parser",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-remote/CHANGELOG.md
+++ b/packages/fury-adapter-remote/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Remote Adapter Changelog
 
-## master
+## 0.4.1 (2020-01-30)
 
 ### Bug Fixes
 

--- a/packages/fury-adapter-remote/package.json
+++ b/packages/fury-adapter-remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-remote",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provide adapter for Element API based on callin remote API site",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "fury": "3.0.0-beta.13",
     "glob": "^7.1.2",
     "mocha": "^5.2.0",
-    "swagger-zoo": "^3.1.1"
+    "swagger-zoo": "^3.1.2"
   },
   "engines": {
     "node": ">=8"

--- a/packages/fury-cli/CHANGELOG.md
+++ b/packages/fury-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.3 (2020-01-30)
+
+This update incorporates bug fixes from Fury Adapters:
+
+- fury-adapter-oas3-parser 0.10.1
+- fury-adapter-swagger 0.28.1
+
 ## 0.9.2 (2019-12-06)
 
 ### Enhancements

--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "fury-adapter-apiary-blueprint-parser": "3.0.0-beta.10",
     "fury-adapter-apib-parser": "^0.17.0",
     "fury-adapter-apib-serializer": "^0.13.0",
-    "fury-adapter-oas3-parser": "^0.10.0",
-    "fury-adapter-swagger": "^0.28.0",
+    "fury-adapter-oas3-parser": "^0.10.1",
+    "fury-adapter-swagger": "^0.28.1",
     "js-yaml": "^3.12.0",
     "minim": "^0.23.4"
   },

--- a/packages/swagger-zoo/package.json
+++ b/packages/swagger-zoo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Swagger example files for testing",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
```shell
$ npx lerna version --no-push --no-git-tag-version
lerna notice cli v3.16.5
lerna info versioning independent
lerna notice FYI git repository validation has been skipped, please ensure your version bumps are correct
lerna info Looking for changed packages since fury@3.0.0-beta.13
lerna WARN version Skipping working tree validation, proceed at your own risk
? Select a new version for fury-adapter-oas3-parser (currently 0.10.0) Patch (0.10.1)
? Select a new version for fury-adapter-remote (currently 0.4.0) Patch (0.4.1)
? Select a new version for fury-adapter-swagger (currently 0.28.0) Patch (0.28.1)
? Select a new version for fury-cli (currently 0.9.2) Patch (0.9.3)
? Select a new version for swagger-zoo (currently 3.1.1) Patch (3.1.2)

Changes:
 - fury-adapter-oas3-parser: 0.10.0 => 0.10.1
 - fury-adapter-remote: 0.4.0 => 0.4.1
 - fury-adapter-swagger: 0.28.0 => 0.28.1
 - fury-cli: 0.9.2 => 0.9.3
 - swagger-zoo: 3.1.1 => 3.1.2

? Are you sure you want to create these versions? Yes
lerna info execute Skipping git tag/commit
lerna info execute Skipping git push
lerna info execute Skipping releases
lerna success version finished

# updated changelogs
$ git add -p
$ git commit -m 'chore(project): release'
```