### PR TITLE
Cache body asset for $ref's with same content type

### DIFF
--- a/packages/fury-adapter-swagger/CHANGELOG.md
+++ b/packages/fury-adapter-swagger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury Swagger Parser Changelog
 
+## 0.28.2 (2020-02-07)
+
+### Bug Fixes
+
+- This release includes performance improvements to parsing documents which
+  contain the same schema re-used via a reference (`$ref`) many times in
+  request parameters and response bodies.
+
 ## 0.28.1 (2020-01-30)
 
 ### Bug Fixes

--- a/packages/fury-adapter-swagger/package.json
+++ b/packages/fury-adapter-swagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
With some larger API Description documents the parse time goes down from
~80 seconds to ~14 seconds.

When there is many references to the same Swagger Schema in a document either in a request schema or response schema; the "generation" of the example value may happen many times; by caching these assets per each content-type we can prevent a lot of duplicate computation resulting in a significant performance improvement in this particular case.