### PR TITLE
Ensure we place copy of request headers in tree

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 - Adds support for `contact` in 'Info Object'.
 
+### Bug Fixes
+
+- Prevents an exception being raised when using `freeze()` on the parse result
+  returned by the parser when the OpenAPI document uses a request header with
+  multiple request/response pairs.
+
 ## 0.10.1 (2020-01-30)
 
 ### Bug Fixes

--- a/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathItemObject.js
+++ b/packages/fury-adapter-oas3-parser/lib/parser/oas/parsePathItemObject.js
@@ -178,7 +178,7 @@ function parsePathItemObject(context, member) {
             R.reject(member => !headers.include(member.key.toValue()).isEmpty, headerParameters.content)
           );
 
-          request.headers = headers;
+          request.headers = headers.clone();
         });
       }
 

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/regression/dredd-1685.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/regression/dredd-1685.json
@@ -1,0 +1,142 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "sample OpenAPIv3 file"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "0.0.1"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/endpoint"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "id"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "foo"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "a"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "id"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "foo"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "400"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "b"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/regression/dredd-1685.yaml
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/regression/dredd-1685.yaml
@@ -1,0 +1,16 @@
+openapi: '3.0.0'
+info:
+  title: sample OpenAPIv3 file
+  version: '0.0.1'
+paths:
+  /endpoint:
+    parameters:
+    - name: id
+      in: header
+      example: 'foo'
+    get:
+      responses:
+        '200':
+          description: a
+        '400':
+          description: b

--- a/packages/fury-adapter-oas3-parser/test/integration/parse-test.js
+++ b/packages/fury-adapter-oas3-parser/test/integration/parse-test.js
@@ -41,4 +41,11 @@ describe('#parse', () => {
     const file = path.join(__dirname, 'fixtures', 'auth-scheme-does-not-exist');
     return testParseFixture(file, true);
   });
+
+  describe('regression fixtures', () => {
+    it('can parse Dredd #1685', () => {
+      const file = path.join(__dirname, 'fixtures', 'regression', 'dredd-1685');
+      return testParseFixture(file);
+    });
+  });
 });


### PR DESCRIPTION
Prevents an exception being raised when using `freeze()` on the parse result returned by the parser when the OpenAPI document uses a request header with multiple request/response pairs.

@marcofriso btw, this is the problem I was mentioning in https://github.com/apiaryio/api-elements.js/pull/415#discussion_r386376996 due to lack of cloning. Since when you have two requests here, the "headers" are copied to each one so they must be cloned first.

This was discovered in https://github.com/apiaryio/dredd/issues/1685.