### PR TITLE
Add support for OAS 3 default responses

### DIFF
--- a/packages/fury-adapter-oas3-parser/CHANGELOG.md
+++ b/packages/fury-adapter-oas3-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury OAS3 Parser Changelog
 
+## Master
+
+### Enhancements
+
+- Support for "default" response status codes.
+
 ## 0.10.2 (2020-03-16)
 
 ### Enhancements

--- a/packages/fury-adapter-oas3-parser/STATUS.md
+++ b/packages/fury-adapter-oas3-parser/STATUS.md
@@ -118,7 +118,7 @@ Key:
 
 | Field Name | Support |
 |:--|:--|
-| default | ✕ |
+| default | ✓ |
 | HTTP Status Code | [~](#response-object) |
 
 HTTP Status Code ranges are not currently supported.

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.json
@@ -229,6 +229,76 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"code\":0,\"message\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Error"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "content": "unexpected error"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             },
@@ -269,6 +339,76 @@
                         {
                           "element": "copy",
                           "content": "Null response"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "POST"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"code\":0,\"message\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Error"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "content": "unexpected error"
                         }
                       ]
                     }
@@ -400,6 +540,76 @@
                         {
                           "element": "copy",
                           "content": "Expected response to a valid request"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"code\":0,\"message\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Error"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "content": "unexpected error"
                         }
                       ]
                     }
@@ -855,66 +1065,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 36
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 838
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 36
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 16
-                        }
-                      },
-                      "content": 7
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Responses Object' default responses are unsupported"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 45
                         },
                         "column": {
@@ -946,66 +1096,6 @@
         }
       },
       "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 50
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1181
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 50
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 16
-                        }
-                      },
-                      "content": 7
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Responses Object' default responses are unsupported"
     },
     {
       "element": "annotation",
@@ -1126,66 +1216,6 @@
         }
       },
       "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 76
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1862
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 76
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 16
-                        }
-                      },
-                      "content": 7
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Responses Object' default responses are unsupported"
     },
     {
       "element": "annotation",

--- a/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/fury-adapter-oas3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -554,6 +554,126 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "content": 159
+                                        },
+                                        {
+                                          "element": "number",
+                                          "content": 3
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"code\":0,\"message\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Error"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "content": 870
+                                        },
+                                        {
+                                          "element": "number",
+                                          "content": 16
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "unexpected error"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             },
@@ -694,6 +814,126 @@
                             }
                           },
                           "content": "Null response"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "content": 1013
+                                        },
+                                        {
+                                          "element": "number",
+                                          "content": 4
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "POST"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"code\":0,\"message\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Error"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "content": 1213
+                                        },
+                                        {
+                                          "element": "number",
+                                          "content": 16
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "unexpected error"
                         }
                       ]
                     }
@@ -1000,6 +1240,126 @@
                             }
                           },
                           "content": "Expected response to a valid request"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "content": 1539
+                                        },
+                                        {
+                                          "element": "number",
+                                          "content": 3
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"code\":0,\"message\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "Error"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "attributes": {
+                            "sourceMap": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "sourceMap",
+                                  "content": [
+                                    {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "number",
+                                          "content": 1894
+                                        },
+                                        {
+                                          "element": "number",
+                                          "content": 16
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "content": "unexpected error"
                         }
                       ]
                     }
@@ -1655,66 +2015,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 36
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 838
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 36
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 16
-                        }
-                      },
-                      "content": 7
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Responses Object' default responses are unsupported"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 45
                         },
                         "column": {
@@ -1746,66 +2046,6 @@
         }
       },
       "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 50
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1181
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 50
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 16
-                        }
-                      },
-                      "content": 7
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Responses Object' default responses are unsupported"
     },
     {
       "element": "annotation",
@@ -1926,66 +2166,6 @@
         }
       },
       "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 76
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1862
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 76
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 16
-                        }
-                      },
-                      "content": 7
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Responses Object' default responses are unsupported"
     },
     {
       "element": "annotation",

--- a/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
+++ b/packages/fury-adapter-oas3-parser/test/unit/parser/oas/parseResponsesObject-test.js
@@ -82,6 +82,25 @@ describe('Responses Object', () => {
     expect(response.statusCode.toValue()).to.equal('200');
   });
 
+  it('can parse a default responses', () => {
+    const responses = new namespace.elements.Object({
+      default: {
+        description: 'dummy',
+      },
+    });
+
+    const parseResult = parse(context, responses);
+    expect(parseResult.length).to.equal(1);
+
+    const array = parseResult.get(0);
+    expect(array).to.be.instanceof(namespace.elements.Array);
+    expect(array.length).to.equal(1);
+
+    const response = array.get(0);
+    expect(response).to.be.instanceof(namespace.elements.HttpResponse);
+    expect(response.statusCode).to.be.undefined;
+  });
+
   it('can parse a number status code with warning', () => {
     const statusCode = new namespace.elements.Number(200);
     const responses = new namespace.elements.Object([
@@ -103,15 +122,6 @@ describe('Responses Object', () => {
     expect(parseResult).to.contain.warning(
       "'Responses Object' response status code must be a string and should be wrapped in quotes"
     );
-  });
-
-  it('parses default response as warning', () => {
-    const responses = new namespace.elements.Object({
-      default: {},
-    });
-
-    const parseResult = parse(context, responses);
-    expect(parseResult).to.contain.warning("'Responses Object' default responses are unsupported");
   });
 
   it('parses a status code range as warning', () => {


### PR DESCRIPTION
Default responses is an OpenAPI feature which allows you to specify a response that doesn't have a fixed status code. For example, if you want to specify a particular structure will be the response, but the status code can be anything.

This translates to no status code in the API Elements parse result, there is no example status code. Tooling such as Dredd (Gavel), ApiaryUI, Styleguides already handle cases where status code is missing. As for v3 docs and Apiary mock server, they default to 200 in this case, which is an acceptable solution. Ideally v3 docs could show no status code, but as OAS 3 support is experimental this is an acceptable comprimise to me.