### PR TITLE
Add a JSON Serializer

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -11,6 +11,7 @@ module.exports = {
       'apiaryb',
       'remote',
       'form',
+      'json',
       'deps',
       'deps-dev',
     ]],

--- a/packages/json-serializer/README.md
+++ b/packages/json-serializer/README.md
@@ -1,0 +1,24 @@
+# API Elements: JSON Serializer
+
+## Usage
+
+Takes an API Element data structure, and returns JSON serialized data
+structures, for example:
+
+```javascript
+const { Fury } = require('@apielements/core');
+const jsonSerializer = require('@apielements/json-serializer');
+
+const fury = new Fury();
+fury.use(jsonSerializer);
+
+const name = new fury.minim.elements.String();
+name.attributes.set('default', 'Doe');
+
+const api = new fury.minim.elements.Object({ name });
+const mediaType = 'application/json';
+fury.serialize({ api, mediaType }, (error, body) => {
+  console.log(body);
+  // { "name": "Doe" }
+});
+```

--- a/packages/json-serializer/lib/adapter.js
+++ b/packages/json-serializer/lib/adapter.js
@@ -1,0 +1,12 @@
+const serializeJSON = require('./serializeJSON');
+
+const name = 'json';
+const mediaTypes = [
+  'application/json',
+];
+
+function serialize({ api }) {
+  return new Promise(resolve => resolve(serializeJSON(api)));
+}
+
+module.exports = { name, mediaTypes, serialize };

--- a/packages/json-serializer/lib/serializeJSON.js
+++ b/packages/json-serializer/lib/serializeJSON.js
@@ -1,0 +1,26 @@
+function collectElementByIDs(element) {
+  const dataStructures = {};
+
+  const { parents } = element;
+  if (parents) {
+    const rootElement = parents.get(0);
+
+    if (rootElement) {
+      rootElement.recursiveChildren.forEach((element) => {
+        if (element.id) {
+          dataStructures[element.id.toValue()] = element;
+        }
+      });
+    }
+  }
+
+  return dataStructures;
+}
+
+function serializeJSON(element) {
+  const dataStructures = collectElementByIDs(element);
+  const value = element.valueOf(undefined, dataStructures);
+  return JSON.stringify(value);
+}
+
+module.exports = serializeJSON;

--- a/packages/json-serializer/package.json
+++ b/packages/json-serializer/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@apielements/json-serializer",
+  "version": "0.1.0",
+  "description": "JSON serializer for API Elements",
+  "author": "Apiary.io <support@apiary.io>",
+  "license": "MIT",
+  "main": "./lib/adapter.js",
+  "files": [
+    "lib/adapter.js",
+    "lib/serializeJSON.js"
+  ],
+  "homepage": "https://github.com/apiaryio/api-elements.js/tree/master/packages/json-serializer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apiaryio/api-elements.js.git",
+    "directory": "packages/json-serializer"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "mocha test"
+  },
+  "peerDependencies": {
+    "@apielements/core": "^0.1.0"
+  },
+  "devDependencies": {
+    "@apielements/core": "^0.1.0",
+    "chai": "^4.2.0",
+    "eslint": "^5.16.0",
+    "mocha": "^7.1.1"
+  },
+  "engines": {
+    "node": ">=8"
+  }
+}

--- a/packages/json-serializer/test/adapter-test.js
+++ b/packages/json-serializer/test/adapter-test.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai');
+const { Fury } = require('@apielements/core');
+const adapter = require('../lib/adapter');
+
+describe('JSON Serialiser Adapter', () => {
+  let fury;
+
+  before(() => {
+    fury = new Fury();
+    fury.use(adapter);
+  });
+
+  it('has a name', () => {
+    expect(adapter.name).to.equal('json');
+  });
+
+  it('has a JSON media type', () => {
+    expect(adapter.mediaTypes).to.deep.equal(['application/json']);
+  });
+
+  it('can serialize an element', (done) => {
+    const element = new fury.minim.elements.String('hello world');
+
+    fury.serialize({ api: element, mediaType: 'application/json' }, (error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.equal('"hello world"');
+      done();
+    });
+  });
+});

--- a/packages/json-serializer/test/serializeJSON-test.js
+++ b/packages/json-serializer/test/serializeJSON-test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai');
+const { Fury } = require('@apielements/core');
+const serializeJSON = require('../lib/serializeJSON');
+
+const { minim: namespace } = new Fury();
+
+describe('#serializeJSON', () => {
+  it('can serialize a primitive element with value', () => {
+    const element = new namespace.elements.String('hello world');
+
+    expect(serializeJSON(element)).to.equal('"hello world"');
+  });
+
+  it('can serialize a primitive element with default value', () => {
+    const element = new namespace.elements.String();
+    element.attributes.set('default', 'hello world');
+
+    expect(serializeJSON(element)).to.equal('"hello world"');
+  });
+
+  it('can serialize an element with references via parent tree', () => {
+    const element = new namespace.elements.Element();
+    element.element = 'message';
+
+    new namespace.elements.Category([
+      new namespace.elements.Category([
+        new namespace.elements.String('hello world', { id: 'message' }),
+      ], { classes: ['dataStructures'] }),
+      element,
+    ]).freeze();
+
+    expect(serializeJSON(element)).to.equal('"hello world"');
+  });
+});


### PR DESCRIPTION
Takes an API Elements data structure and returns JSON serialized data structure (https://github.com/apiaryio/api-elements.js/issues/372), for example:

```js
const jsonSerializer = require('@apielements/json-serializer');
fury.use(jsonSerializer);

const mediaType = 'application/json';
fury.serialize({ api: element, mediaType }, (error, body) => {
  console.log(body);
});
```

Where element is a data structure, for example:

```js
const element = fury.minim.elements.Object({ name: "kyle" });
```

Would output:

```json
{"name": "kyle"}
```

### Remaining

- [x] Support for references