### PR TITLE
Use Protagonist / drafter.js directly

### DIFF
--- a/packages/fury-adapter-apib-parser/lib/adapter.js
+++ b/packages/fury-adapter-apib-parser/lib/adapter.js
@@ -1,7 +1,16 @@
 // API Blueprint parser for Fury.js
 
 const deckardcain = require('deckardcain');
-const drafter = require('drafter');
+
+let drafter;
+
+try {
+  // eslint-disable-next-line import/no-unresolved, global-require
+  drafter = require('protagonist');
+} catch (error) {
+  // eslint-disable-next-line global-require
+  drafter = require('drafter.js');
+}
 
 const name = 'api-blueprint';
 const mediaTypes = [

--- a/packages/fury-adapter-apib-parser/package.json
+++ b/packages/fury-adapter-apib-parser/package.json
@@ -21,7 +21,10 @@
   },
   "dependencies": {
     "deckardcain": "^1.0.0",
-    "drafter": "2.0.0"
+    "drafter.js": "^3.2.0"
+  },
+  "optionalDependencies": {
+    "protagonist": "^2.1.0"
   },
   "peerDependencies": {
     "fury": "3.0.0-beta.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,19 +2372,10 @@ dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-drafter.js@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/drafter.js/-/drafter.js-3.1.0.tgz#f810f63be3464bbaf1cf689b3f2721ce9c5a6ba0"
-  integrity sha512-05E5x8oVPSq0WqYHv2VQ16uNnF9gP10FrFwZgBFimRm+72baLSuOUSH4C2R26phaVCnoZj62ohyE7CdpNthsaA==
-
-drafter@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/drafter/-/drafter-2.0.0.tgz#a3c66e242775732405179f568f493086038ce9d9"
-  integrity sha512-dguGHbBkCRaan26eyGb0eEaCYdO6wtA7I+EuUVzte5EU46j9x0W98GThUBxsKzUfbvPaS6TR8wcPymfZUoeplg==
-  dependencies:
-    drafter.js "^3.0.2"
-  optionalDependencies:
-    protagonist "^2.0.2"
+drafter.js@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/drafter.js/-/drafter.js-3.2.0.tgz#3403b31cac84b2e7c8ee93fac12cd82c5ba538a3"
+  integrity sha512-ThDDh8bTK0p9JJsP2TqqmiOKLqTkdnOF205hc1MF+axfCjXWyRzrNNiPLEUXQrHJJ+bPbkevWjjn5e9x0g0tqA==
 
 drange@^1.0.2:
   version "1.1.1"
@@ -5282,10 +5273,10 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-protagonist@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/protagonist/-/protagonist-2.1.0.tgz#15815dfd3574e466e92d5a1780dec29b54625e9b"
-  integrity sha512-NZMBG7S/5r44b9q8IDcYxAzvRCiOxd2VLZsCjuOfeZ6bNlc+U9WDoba9lHt6BJJRh77iaBb4WIRLKR55gcHgLw==
+protagonist@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/protagonist/-/protagonist-2.2.0.tgz#28036c57ae85a3936e6d3442da1059f4472e381d"
+  integrity sha512-oqHVxpjMZgOk4J99MYfTDrgHM6N5m4ATnKlgxJS3wd8aGFkYat9lakB1VEEr5Kb+rDSZUFmr2yp5o2xRfYG2YQ==
   dependencies:
     nan "^2.13.2"
 


### PR DESCRIPTION
Using protagonist/drafter.js directly, this helps us strip out some layers of dependencies and complexity.

I would consider deprecating and/or getting rid of drafter-npm and suggest users use fury-adapter-apib-parser instead, and if they must go to parser's directly then drafter.js and/or protagonist.