### PR TITLE
Handle missing variables in Server Object url

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Fury OAS3 Parser Changelog
 
+## 0.12.1 (2020-04-30)
+
+### Bug Fixes
+
+- Prevent the parser from throwing an error when handling a Server Object with
+  variables when the URL does not contain any variables. For example:
+
+  ```yaml
+  openapi: 3.0.3
+  servers:
+    - url: https://example.com
+      variables:
+        version:
+          default: '1.0'
+  paths: {}
+  ```
+
 ## 0.12.0 (2020-04-29)
 
 The package has been renamed to `@apielements/openapi3-parser`.

--- a/packages/openapi3-parser/lib/parser/oas/parseServerObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseServerObject.js
@@ -15,14 +15,22 @@ const parseServerVariableObject = require('./parseServerVariableObject');
 const name = 'Server Object';
 const requiredKeys = ['url'];
 
+function extractURLVariables(path) {
+  const matches = path.match(/({.*?})/gm);
+
+  if (matches) {
+    return matches.map(x => x.substring(1, x.length - 1));
+  }
+
+  return [];
+}
+
 const validateVariablesInURL = (context, object) => {
   const url = object.getValue('url');
   const variables = object.get('variables');
   const parseResult = new context.namespace.elements.ParseResult();
 
-  const urlVariables = url
-    .match(/{(.*?)}/g)
-    .map(x => x.replace(/[{}]/g, ''));
+  const urlVariables = extractURLVariables(url);
 
   // if you define a variable that is not in URL it warns (and the variable is ignored).
   variables.keys().forEach((key) => {

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/openapi3-parser/test/unit/parser/oas/parseServerObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseServerObject-test.js
@@ -144,6 +144,26 @@ describe('#parseServerObject', () => {
       expect(secondHrefVariable.value.default).to.equal('1.0');
     });
 
+    it('warns when variables is defined, but no variables are in the url', () => {
+      const server = new namespace.elements.Object({
+        url: 'https://example.com/',
+        variables: {
+          version: {
+            default: '1.0',
+          },
+        },
+      });
+
+      const parseResult = parse(context)(server);
+      expect(parseResult).to.contain.warning("Server variable 'version' is not present in the URL and will be ignored");
+
+      const resource = parseResult.get(0);
+      expect(resource).to.be.instanceof(namespace.elements.Resource);
+
+      expect(resource.href.toValue()).to.equal('https://example.com/');
+      expect(resource.hrefVariables.isEmpty).to.be.true;
+    });
+
     it("warns when a URL defined variable is missing from 'variables'", () => {
       const server = new namespace.elements.Object({
         url: 'https://{username}.{server}/{version}/',


### PR DESCRIPTION
Given the following OAS document:

```yaml
openapi: 3.0.3
servers:
  - url: https://example.com
    variables:
      version:
        default: '1.0'
paths: {}
```

The parser would validate if all variables are found in the URL and warn when it is missing. In this case 'version' is validated to be in the URL. The code to handle this is throwing out when the regex has no matches as the match returns `null` and thus:

```
TypeError: Cannot read property map of null
 at validateVariablesInURL (/app/node_modules/fury-adapter-oas3-parser/lib/parser/oas/parseServerObject.js:25:5)
```