### PR TITLE
Add support for schema example in OAS3 parameters.

### DIFF
--- a/packages/openapi3-parser/test/integration/fixtures/petstore.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.json
@@ -885,66 +885,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 21
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 414
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 21
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 17
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 29
                         },
                         "column": {
@@ -1096,66 +1036,6 @@
         }
       },
       "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1504
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 15
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
     },
     {
       "element": "annotation",

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -1835,66 +1835,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 21
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 414
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 21
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 17
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 29
                         },
                         "column": {
@@ -2046,66 +1986,6 @@
         }
       },
       "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1504
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 15
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
     },
     {
       "element": "annotation",

--- a/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -315,6 +315,22 @@ describe('Parameter Object', () => {
         bar: 'baz',
       });
     });
+
+    it('attaches integer example to member of schema object', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'schema_example',
+        in: 'query',
+        schema: { type: 'string', example: 10 },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      console.log(parseResult.get(0));
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value.toValue()).to.equal(10);
+    });
   });
 
   describe('#explode', () => {
@@ -516,18 +532,6 @@ describe('Parameter Object', () => {
       const parseResult = parse(context, parameter);
 
       expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'allowReserved'");
-    });
-
-    it('provides warning for unsupported schema property', () => {
-      const parameter = new namespace.elements.Object({
-        name: 'example',
-        in: 'query',
-        schema: { type: 'string' },
-      });
-
-      const parseResult = parse(context, parameter);
-
-      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'schema'");
     });
 
     it('provides warning for unsupported examples property', () => {


### PR DESCRIPTION
According to OAS3 Specification, an example element can be included in a schema object.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject

I fixed to use example value under the schema object under the parameter object when it has set.

I'm using Stoplight Studio and I'm having the following problem, so I'd like you to import this pull request.

problem: When I set a example value of Query parameter in Stoplight Studio, it will output the value to parameters.schema.example in the OAS3 yaml file. If this file is read by dredd, an error will be displayed as "example" is not set. 

I referenced #156 to make this pull request.