### PR TITLE
Don't limit scripts to particular scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "release": "lerna publish",
     "release:force": "lerna publish --force-publish",
-    "lint": "lerna exec --scope='*' --concurrency 1 --no-bail -- npm run lint",
-    "lint:fix": "lerna exec --scope='*' --concurrency 1 --no-bail -- npm run lint:fix",
-    "test": "lerna exec --scope='*' --concurrency 1 --no-bail -- npm run test",
+    "lint": "lerna exec --concurrency 1 --no-bail -- npm run lint",
+    "lint:fix": "lerna exec --concurrency 1 --no-bail -- npm run lint:fix",
+    "test": "lerna exec --concurrency 1 --no-bail -- npm run test",
     "cover": "nyc npm test",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },


### PR DESCRIPTION
Some packages are in @apielements and this filter for `--scope '*'` seems to prevent them from being executed in test commands.

This can be quickly confirmed via comparing the test run times between master and this branch (and before I renamed some packages).

![Screenshot 2020-05-06 at 11 20 21](https://user-images.githubusercontent.com/44164/81166590-b2ba4780-8f8b-11ea-984d-44f62254a3b4.png)

![Screenshot 2020-05-06 at 11 20 32](https://user-images.githubusercontent.com/44164/81166582-b057ed80-8f8b-11ea-9283-7c1a202579f6.png)

The output can also be analysed to see that some packages like openapi3-parser were not tested.