### PR TITLE
Fix handling of schema object's without type

### DIFF
--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # API Elements: OpenAPI 2 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- The parser will now produce a data structure for Schema Object's which do not
+  contain a `type`.
+
 ## 0.30.0 (2020-04-29)
 
 The package has been renamed to `@apielements/openapi2-parser`.

--- a/packages/openapi2-parser/lib/schema.js
+++ b/packages/openapi2-parser/lib/schema.js
@@ -203,11 +203,6 @@ class DataStructureGenerator {
           return uniqueTypes[0];
         }
       }
-
-      if (schema.properties) {
-        // Assume user meant object
-        return 'object';
-      }
     }
 
     return schema.type;
@@ -271,6 +266,15 @@ class DataStructureGenerator {
       element = new typeGeneratorMap[type]();
     } else if (type) {
       throw new Error(`Unhandled schema type '${type}'`);
+    } else {
+      element = new this.minim.elements.Enum();
+      element.enumerations = [
+        new this.minim.elements.String(),
+        new this.minim.elements.Number(),
+        new this.minim.elements.Boolean(),
+        this.generateArray(schema),
+        this.generateObject(schema),
+      ];
     }
 
     if (element) {

--- a/packages/openapi2-parser/test/fixtures/circular-example.json
+++ b/packages/openapi2-parser/test/fixtures/circular-example.json
@@ -405,28 +405,25 @@
                         "content": "company"
                       },
                       "value": {
-                        "element": "object",
-                        "content": [
-                          {
-                            "element": "member",
-                            "attributes": {
-                              "typeAttributes": {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "string",
-                                    "content": "optional"
-                                  }
-                                ]
-                              }
-                            },
-                            "content": {
-                              "key": {
-                                "element": "string",
-                                "content": "data"
+                        "element": "enum",
+                        "attributes": {
+                          "enumerations": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string"
                               },
-                              "value": {
-                                "element": "definitions/Company",
+                              {
+                                "element": "number"
+                              },
+                              {
+                                "element": "boolean"
+                              },
+                              {
+                                "element": "array"
+                              },
+                              {
+                                "element": "object",
                                 "content": [
                                   {
                                     "element": "member",
@@ -444,24 +441,49 @@
                                     "content": {
                                       "key": {
                                         "element": "string",
-                                        "content": "is_owner"
+                                        "content": "data"
                                       },
                                       "value": {
-                                        "element": "boolean",
-                                        "attributes": {
-                                          "default": {
-                                            "element": "boolean",
-                                            "content": false
+                                        "element": "definitions/Company",
+                                        "content": [
+                                          {
+                                            "element": "member",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "optional"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "content": {
+                                              "key": {
+                                                "element": "string",
+                                                "content": "is_owner"
+                                              },
+                                              "value": {
+                                                "element": "boolean",
+                                                "attributes": {
+                                                  "default": {
+                                                    "element": "boolean",
+                                                    "content": false
+                                                  }
+                                                }
+                                              }
+                                            }
                                           }
-                                        }
+                                        ]
                                       }
                                     }
                                   }
                                 ]
                               }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     }
                   }

--- a/packages/swagger-zoo/fixtures/features/api-elements/warnings.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/warnings.json
@@ -116,6 +116,34 @@
                             }
                           },
                           "content": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "enum",
+                            "attributes": {
+                              "enumerations": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string"
+                                  },
+                                  {
+                                    "element": "number"
+                                  },
+                                  {
+                                    "element": "boolean"
+                                  },
+                                  {
+                                    "element": "array"
+                                  },
+                                  {
+                                    "element": "object"
+                                  }
+                                ]
+                              }
+                            }
+                          }
                         }
                       ]
                     },

--- a/packages/swagger-zoo/fixtures/features/api-elements/warnings.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/warnings.sourcemap.json
@@ -289,6 +289,34 @@
                             }
                           },
                           "content": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "enum",
+                            "attributes": {
+                              "enumerations": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string"
+                                  },
+                                  {
+                                    "element": "number"
+                                  },
+                                  {
+                                    "element": "boolean"
+                                  },
+                                  {
+                                    "element": "array"
+                                  },
+                                  {
+                                    "element": "object"
+                                  }
+                                ]
+                              }
+                            }
+                          }
                         }
                       ]
                     },


### PR DESCRIPTION
In a schema object which does not specify a `type`, any type may be permitted as a value. API Elements doesn't have an element type that represens "any", semantically it is equivilent to an enum of any permitted types (3 primitive types of boolean, number, string and 2 collection types: object and array).

This is the same as the behaviour in the OpenAPI 3 parser (this is the OAS 2 equivilent of https://github.com/apiaryio/api-elements.js/pull/135).

For example, the following schema:

```yaml
items: { type: string }
properties:
  name: { type: string }
```

Which is semantically equivilent to the following MSON:

+ enum
  + (object)
    + name (string)
  + (array[string], fixed-type)
  + (boolean)
  + (string)
  + (number)

Would allow the following values:

```json
["a", "b"]
```

```json
"hello world"
```


```json
{
  "name": "doe"
}
```

However, the following values are not permitted:

```json
[1, true]
```

```json
{
  "name": true
}
```

There is an existing behaviour which has been altered, in the past we "coered" a schema object which contains a properties key to be of only type object. This is incorrect behaviour which goes against the above support.