### PR TITLE
Handle required schema object keys which are not in properties

### DIFF
--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -21,6 +21,9 @@
   values of the array to be a string type. Instead provided an example that the
   value of the array MAY be a string.
 
+- Support required keys in a Schema Object which are not found in the
+  properties list.
+
 ## 0.30.0 (2020-04-29)
 
 The package has been renamed to `@apielements/openapi2-parser`.

--- a/packages/openapi2-parser/lib/schema.js
+++ b/packages/openapi2-parser/lib/schema.js
@@ -111,6 +111,15 @@ class DataStructureGenerator {
       return member;
     }));
 
+    // Create member elements for required keys which are not defined in properties
+    const missingRequiredProperties = required.filter(name => properties[name] === undefined);
+    const requiredMembers = missingRequiredProperties.map((name) => {
+      const member = new this.minim.elements.Member(name);
+      member.attributes.set('typeAttributes', ['required']);
+      return member;
+    });
+    element.content = element.content.concat(requiredMembers);
+
     return element;
   }
 

--- a/packages/openapi2-parser/lib/schema.js
+++ b/packages/openapi2-parser/lib/schema.js
@@ -96,11 +96,11 @@ class DataStructureGenerator {
       } else if (refs.length > 1) {
         const { Ref: RefElement } = this.minim.elements;
         const refElements = refs.map(ref => new RefElement(ref));
-        element.content = element.content.concat(refElements);
+        element.content.push(...refElements);
       }
     }
 
-    element.content = element.content.concat(_.map(properties, (subschema, property) => {
+    element.content.push(..._.map(properties, (subschema, property) => {
       const member = this.generateMember(property, subschema);
 
       const isRequired = required.includes(property);
@@ -118,7 +118,7 @@ class DataStructureGenerator {
       member.attributes.set('typeAttributes', ['required']);
       return member;
     });
-    element.content = element.content.concat(requiredMembers);
+    element.content.push(...requiredMembers);
 
     return element;
   }

--- a/packages/openapi2-parser/test/schema-test.js
+++ b/packages/openapi2-parser/test/schema-test.js
@@ -460,6 +460,21 @@ describe('JSON Schema to Data Structure', () => {
       expect(member.attributes.getValue('typeAttributes')).to.deep.equal(['required']);
     });
 
+    it('produces object members from required which are not found in properties', () => {
+      const schema = {
+        type: 'object',
+        required: ['name'],
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+
+      const name = dataStructure.content.getMember('name');
+      expect(name.attributes.getValue('typeAttributes')).to.deep.equal(['required']);
+    });
+
     it('produces object element with description of maxProperties', () => {
       const schema = {
         type: 'object',


### PR DESCRIPTION
Currently the OAS 2 parser losses information about required keys which are not found in properties. For example in the following schema:

```yaml
type: object
required: name
```

Would produce an object element with no keys. With this patch we created the member element which contains the key and the required type attribute.