### PR TITLE
Fix OpenAPI parse results to include fixedType for arrays with items

### DIFF
--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -7,6 +7,20 @@
 - The parser will now produce a data structure for Schema Object's which do not
   contain a `type`.
 
+- Added the `fixedType` attribute to array data structures which describe
+  arrays with fixed types in the items. For example, the following schema which
+  describes an array where the values MUST be of type string:
+
+  ```yaml
+  type: array
+  items:
+    type: string
+  ```
+
+  Previously we generated a data structure for an array which didn't fix the
+  values of the array to be a string type. Instead provided an example that the
+  value of the array MAY be a string.
+
 ## 0.30.0 (2020-04-29)
 
 The package has been renamed to `@apielements/openapi2-parser`.

--- a/packages/openapi2-parser/lib/schema.js
+++ b/packages/openapi2-parser/lib/schema.js
@@ -120,6 +120,8 @@ class DataStructureGenerator {
     const element = new ArrayElement();
 
     if (schema.items) {
+      element.attributes.set('typeAttributes', ['fixedType']);
+
       if (_.isArray(schema.items)) {
         schema.items.forEach((item) => {
           const itemElement = this.generateElement(item);

--- a/packages/openapi2-parser/test/fixtures/json-body-generation-array-object.json
+++ b/packages/openapi2-parser/test/fixtures/json-body-generation-array-object.json
@@ -208,6 +208,17 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "array",
+                            "attributes": {
+                              "typeAttributes": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string",
+                                    "content": "fixedType"
+                                  }
+                                ]
+                              }
+                            },
                             "content": [
                               {
                                 "element": "definitions/Question"
@@ -330,6 +341,17 @@
                       },
                       "value": {
                         "element": "array",
+                        "attributes": {
+                          "typeAttributes": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "content": "fixedType"
+                              }
+                            ]
+                          }
+                        },
                         "content": [
                           {
                             "element": "definitions/Choice"

--- a/packages/openapi2-parser/test/schema-test.js
+++ b/packages/openapi2-parser/test/schema-test.js
@@ -702,7 +702,7 @@ describe('JSON Schema to Data Structure', () => {
       const dataStructure = schemaToDataStructure(schema);
 
       expect(dataStructure.element).to.equal('dataStructure');
-      expect(dataStructure.content).to.be.instanceof(ArrayElement);
+      expect(dataStructure.content.attributes.getValue('typeAttributes')).to.deep.equal(['fixedType']);
       expect(dataStructure.content.get(0).element).to.equal('string');
     });
 

--- a/packages/swagger-zoo/fixtures/features/api-elements/recursion.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/recursion.json
@@ -282,6 +282,17 @@
                             "content": "A list of categories"
                           }
                         },
+                        "attributes": {
+                          "typeAttributes": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "content": "fixedType"
+                              }
+                            ]
+                          }
+                        },
                         "content": [
                           {
                             "element": "definitions/category"

--- a/packages/swagger-zoo/fixtures/features/api-elements/recursion.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/recursion.sourcemap.json
@@ -653,6 +653,17 @@
                             "content": "A list of categories"
                           }
                         },
+                        "attributes": {
+                          "typeAttributes": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "content": "fixedType"
+                              }
+                            ]
+                          }
+                        },
                         "content": [
                           {
                             "element": "definitions/category"


### PR DESCRIPTION
Added the `fixedType` attribute to array data structures which describe arrays with fixed types in the items. For example, the following schema which describes an array where the values MUST be of type string:

```yaml
type: array
items:
  type: string
```

Previously we generated a data structure for an array which didn't fix the values of the array to be a string type. Instead provided an example that the value of the array MAY be a string. This is a mismatch in how API Elements works vs how JSON Schema rules work. This PR is equivilent to the OpenAPI 3 behaviour from the line at https://github.com/apiaryio/api-elements.js/blob/9c9ffc9885ce87d9bfefc499b64dbe588535ac94/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js#L59