### PR TITLE
Required schema object keys which are not in properties

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fury OAS3 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Support required keys in a Schema Object which are not found in the
+  properties list.
+
 ## 0.12.1 (2020-04-30)
 
 ### Bug Fixes

--- a/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
@@ -39,13 +39,13 @@ function constructObjectStructure(namespace, schema) {
 
   const required = schema.get('required');
   if (required) {
+    const attachMember = element.push.bind(element);
+    const findMember = element.getMember.bind(element);
+
+    const createMember = R.constructN(1, namespace.elements.Member);
     const findOrCreateMember = R.either(
-      element.getMember.bind(element),
-      (key) => {
-        const member = new namespace.elements.Member(key);
-        element.push(member);
-        return member;
-      }
+      findMember,
+      R.pipe(createMember, R.tap(attachMember))
     );
 
     required

--- a/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
@@ -39,13 +39,19 @@ function constructObjectStructure(namespace, schema) {
 
   const required = schema.get('required');
   if (required) {
-    required.forEach((key) => {
-      const member = element.getMember(key.toValue());
-
-      if (member) {
-        member.attributes.set('typeAttributes', ['required']);
+    const findOrCreateMember = R.either(
+      element.getMember.bind(element),
+      (key) => {
+        const member = new namespace.elements.Member(key);
+        element.push(member);
+        return member;
       }
-    });
+    );
+
+    required
+      .toValue()
+      .map(findOrCreateMember)
+      .forEach(member => member.attributes.set('typeAttributes', ['required']));
   }
 
   return element;

--- a/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
@@ -315,7 +315,25 @@ describe('Schema Object', () => {
         ]);
       });
 
-      it('returns an object with required properties', () => {
+      it('returns an object with members from required keys', () => {
+        const schema = new namespace.elements.Object({
+          type: 'object',
+          required: ['name'],
+        });
+        const parseResult = parse(context, schema);
+
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+        expect(parseResult).to.not.contain.annotations;
+
+        const object = parseResult.get(0).content;
+        expect(object).to.be.instanceof(namespace.elements.Object);
+
+        const name = object.getMember('name');
+        expect(name.attributes.getValue('typeAttributes')).to.deep.equal(['required']);
+      });
+
+      it('returns an object with required properties by merging properties', () => {
         const schema = new namespace.elements.Object({
           type: 'object',
           properties: {


### PR DESCRIPTION
This is the same bug that existed in the OAS 2 parser at https://github.com/apiaryio/api-elements.js/pull/462, see the related PR for description.