### PR TITLE
Cache body generation for allOf's with ref

### DIFF
--- a/packages/fury-cli/package.json
+++ b/packages/fury-cli/package.json
@@ -25,7 +25,7 @@
     "@apielements/apiaryb-parser": "^0.1.0",
     "@apielements/apib-parser": "^0.19.0",
     "@apielements/apib-serializer": "^0.15.0",
-    "@apielements/openapi2-parser": "^0.31.0",
+    "@apielements/openapi2-parser": "^0.31.1",
     "@apielements/openapi3-parser": "^0.12.2",
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",

--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # API Elements: OpenAPI 2 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- This release includes performance improvements to parsing documents which
+  contain the same schema re-used via a reference (`$ref`) many times in
+  request parameters and response bodies under an `allOf` key.
+
 ## 0.31.0 (2020-05-12)
 
 ### Bug Fixes

--- a/packages/openapi2-parser/lib/parser.js
+++ b/packages/openapi2-parser/lib/parser.js
@@ -1611,7 +1611,16 @@ class Parser {
     const referencedPathValue = this.referencedPathValue();
     let cacheKey;
     if (referencedPathValue && referencedPathValue.$ref) {
+      // schema object with $ref
       cacheKey = `${referencedPathValue.$ref};${contentType}`;
+    } else if (
+      referencedPathValue
+      && referencedPathValue.allOf
+      && Object.keys(referencedPathValue).length === 1
+      && referencedPathValue.allOf.length === 1
+      && referencedPathValue.allOf[0].$ref) {
+      // schema object with single ref in allOf (`allOf: [{$ref: path}]`)
+      cacheKey = `${referencedPathValue.allOf[0].$ref};${contentType}`;
     }
 
     if (this.generateMessageBody || this.generateMessageBodySchema) {

--- a/packages/openapi2-parser/package.json
+++ b/packages/openapi2-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi2-parser",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
This continues on from https://github.com/apiaryio/api-elements.js/pull/409 but includes caching the case where a schema object uses `allOf` with single $ref. This appears to be a common case with some schema generators:

```yaml
allOf:
  - $ref: x
```

That is particullary because `$ref` cannot be used alongside other keys at root, the following can be invalid:

```yaml
$ref: '#/definitions/x'
definitions:
  x: {type: string}
```

Whereas this is acceptable:

```yaml
allOf: [{$ref: '#/definitions/x'}]
definitions:
  x: {type: string}
```

In documents utilising this particular case you can see up to 4x performance improvements:

```shell
# master
$ time npx fury a.json /dev/null
       54.86 real        41.67 user         1.98 sys

$ time npx fury b.json /dev/null
       23.94 real        20.30 user         0.92 sys

# this changeset

$ time npx fury a.json /dev/null
       13.34 real        12.79 user         0.80 sys

$ time npx fury b.json /dev/null
        7.12 real         7.00 user         0.44 sys
```