### PR TITLE
Return unsupported warnings in header object instead of invalid

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Fury OAS3 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Prior versions of the adapter reported the following 'Header Object' keys as
+  invalid: `style`, `explode`, `allowReserved`, `schema`, `content`, `example`,
+  and `examples`. These will now return an unsupported warning instead.
+
 ## 0.13.0 (2020-06-12)
 
 The package has been updated for compatibility with `@apielements/core`.

--- a/packages/openapi3-parser/lib/parser/oas/parseHeaderObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseHeaderObject.js
@@ -10,6 +10,8 @@ const parseObject = require('../parseObject');
 const name = 'Header Object';
 const unsupportedKeys = [
   'description', 'required', 'deprecated', 'allowEmptyValue',
+  'style', 'explode', 'allowReserved', 'schema', 'content', 'example',
+  'examples',
 ];
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
 

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.json
@@ -1035,7 +1035,7 @@
           ]
         }
       },
-      "content": "'Header Object' contains invalid key 'schema'"
+      "content": "'Header Object' contains unsupported key 'schema'"
     },
     {
       "element": "annotation",

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -1985,7 +1985,7 @@
           ]
         }
       },
-      "content": "'Header Object' contains invalid key 'schema'"
+      "content": "'Header Object' contains unsupported key 'schema'"
     },
     {
       "element": "annotation",


### PR DESCRIPTION
I saw the following warning when parsing a document:

> 'Header Object' contains invalid key 'schema'

`schema` is a valid header object key, but it is unsupported. This changeset makes that the case in the warning message

As per the spec https://spec.openapis.org/oas/v3.0.2#header-object:

> The Header Object follows the structure of the Parameter Object with the following changes

All these keys from Parameter Object have been missing in unsupported keys.