### PR TITLE
Validate OAS 2 documents contain swagger key

### DIFF
--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # API Elements: OpenAPI 2 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Returns a validation error while trying to parse a YAML or JSON object which
+  does not contain the `swagger` key, in prior versions the parser may have
+  crashed under some inputs.
+
 ## 0.32.0 (2020-06-12)
 
 The package has been updated for compatibility with `@apielements/core`.

--- a/packages/openapi2-parser/lib/parser.js
+++ b/packages/openapi2-parser/lib/parser.js
@@ -103,6 +103,15 @@ class Parser {
       return done(null, this.result);
     }
 
+    if (loaded.swagger === undefined) {
+      this.createAnnotation(
+        annotations.VALIDATION_ERROR, null,
+        ('Missing required key "swagger"')
+      );
+
+      return done(null, this.result);
+    }
+
     // Some sane defaults since these are sometimes left out completely
     if (loaded.info === undefined) {
       loaded.info = {};

--- a/packages/openapi2-parser/test/adapter-test.js
+++ b/packages/openapi2-parser/test/adapter-test.js
@@ -155,6 +155,50 @@ describe('Swagger 2.0 adapter', () => {
     });
   });
 
+  describe('parsing the swagger key', () => {
+    it('returns error parse result for object without swagger key', (done) => {
+      const source = 'openapi: 3.0.0\ninfo: {title: hi, version: 0.1.0}\npaths: {}\n';
+
+      fury.parse({ source, mediaType: 'application/swagger+yaml' }, (err, parseResult) => {
+        expect(err).to.be.null;
+        expect(parseResult).to.exist;
+        expect(parseResult.api).to.be.undefined;
+        expect(parseResult.errors.toValue()).to.deep.equal([
+          'Missing required key "swagger"',
+        ]);
+        done();
+      });
+    });
+
+    it('returns error parse result when swagger key is number', (done) => {
+      const source = 'swagger: 2.0\ninfo: {title: hi, version: 0.1.0}\npaths: {}\n';
+
+      fury.parse({ source, mediaType: 'application/swagger+yaml' }, (err, parseResult) => {
+        expect(err).to.be.null;
+        expect(parseResult).to.exist;
+        expect(parseResult.api).to.be.undefined;
+        expect(parseResult.errors.toValue()).to.deep.equal([
+          'Swagger version number must be a string (e.g. "2.0") not a number.',
+        ]);
+        done();
+      });
+    });
+
+    it('returns error parse result when swagger key is not 2.0 version', (done) => {
+      const source = 'swagger: "1.0"\ninfo: {title: hi, version: 0.1.0}\npaths: {}\n';
+
+      fury.parse({ source, mediaType: 'application/swagger+yaml' }, (err, parseResult) => {
+        expect(err).to.be.null;
+        expect(parseResult).to.exist;
+        expect(parseResult.api).to.be.undefined;
+        expect(parseResult.errors.toValue()).to.deep.equal([
+          'Unrecognized Swagger version: 1.0. Expected 2.0',
+        ]);
+        done();
+      });
+    });
+  });
+
   describe('can parse fixtures', () => {
     const fixtures = swaggerZoo.features();
     fixtures.forEach((fixture) => {


### PR DESCRIPTION
In some cases, the document could be OpenAPI 3 and pass the swagger-parser validation. We should ensure the document is swagger 2.