### PR TITLE
Update minim to 0.23.8

### DIFF
--- a/packages/api-elements/lib/define-value-of.js
+++ b/packages/api-elements/lib/define-value-of.js
@@ -36,7 +36,7 @@ function hasTypeAttribute(e, attribute) {
   if (undefined !== e._attributes) {
     const typeAttributes = e.attributes.get('typeAttributes');
     if (typeAttributes) {
-      return typeAttributes.contains(attribute);
+      return typeAttributes.includes(attribute);
     }
   }
 

--- a/packages/api-elements/lib/elements/Category.js
+++ b/packages/api-elements/lib/elements/Category.js
@@ -21,7 +21,7 @@ class Category extends ArrayElement {
    * @memberof Category.prototype
    */
   get resourceGroups() {
-    return this.children.filter(item => item.classes.contains('resourceGroup'));
+    return this.children.filter(item => item.classes.includes('resourceGroup'));
   }
 
   /**
@@ -30,15 +30,15 @@ class Category extends ArrayElement {
    * @memberof Category.prototype
    */
   get dataStructures() {
-    return this.children.filter(item => item.classes.contains('dataStructures'));
+    return this.children.filter(item => item.classes.includes('dataStructures'));
   }
 
   get scenarios() {
-    return this.children.filter(item => item.classes.contains('scenario'));
+    return this.children.filter(item => item.classes.includes('scenario'));
   }
 
   get transitionGroups() {
-    return this.children.filter(item => item.classes.contains('transitions'));
+    return this.children.filter(item => item.classes.includes('transitions'));
   }
 
   /**
@@ -47,7 +47,7 @@ class Category extends ArrayElement {
    * @memberof Category.prototype
    */
   get authSchemeGroups() {
-    return this.children.filter(item => item.classes.contains('authSchemes'));
+    return this.children.filter(item => item.classes.includes('authSchemes'));
   }
 
   /**

--- a/packages/api-elements/lib/elements/HttpMessagePayload.js
+++ b/packages/api-elements/lib/elements/HttpMessagePayload.js
@@ -66,7 +66,7 @@ class HttpMessagePayload extends ArrayElement {
   get messageBody() {
     // Returns the *first* message body. Only one should be defined according
     // to the spec, but it's possible to include more.
-    return this.filter(item => item.element === 'asset' && item.classes.contains('messageBody')).first;
+    return this.filter(item => item.element === 'asset' && item.classes.includes('messageBody')).first;
   }
 
   /**
@@ -77,7 +77,7 @@ class HttpMessagePayload extends ArrayElement {
   get messageBodySchema() {
     // Returns the *first* message body schema. Only one should be defined
     // according to the spec, but it's possible to include more.
-    return this.filter(item => item.element === 'asset' && item.classes.contains('messageBodySchema')).first;
+    return this.filter(item => item.element === 'asset' && item.classes.includes('messageBodySchema')).first;
   }
 }
 

--- a/packages/api-elements/lib/elements/ParseResult.js
+++ b/packages/api-elements/lib/elements/ParseResult.js
@@ -21,7 +21,7 @@ class ParseResult extends ArrayElement {
    * @memberof ParseResult.prototype
    */
   get api() {
-    return this.children.filter(item => item.classes.contains('api')).first;
+    return this.children.filter(item => item.classes.includes('api')).first;
   }
 
   /**
@@ -40,7 +40,7 @@ class ParseResult extends ArrayElement {
    */
   get warnings() {
     return this.children
-      .filter(item => item.element === 'annotation' && item.classes.contains('warning'));
+      .filter(item => item.element === 'annotation' && item.classes.includes('warning'));
   }
 
   /**
@@ -50,7 +50,7 @@ class ParseResult extends ArrayElement {
    */
   get errors() {
     return this.children
-      .filter(item => item.element === 'annotation' && item.classes.contains('error'));
+      .filter(item => item.element === 'annotation' && item.classes.includes('error'));
   }
 }
 

--- a/packages/api-elements/package.json
+++ b/packages/api-elements/package.json
@@ -21,7 +21,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "minim": "^0.23.5",
+    "minim": "^0.23.8",
     "ramda": "^0.27.0"
   },
   "devDependencies": {

--- a/packages/api-elements/test/api-description-test.js
+++ b/packages/api-elements/test/api-description-test.js
@@ -35,7 +35,7 @@ chai.use((_chai, utils) => {
     const obj = this._obj;
 
     this.assert(
-      obj.classes.contains(name),
+      obj.classes.includes(name),
       'Expected class list #{act} to contain #{exp}',
       'Expected class list #{act} to not contain #{exp}',
       name,

--- a/packages/api-elements/test/parse-result-test.js
+++ b/packages/api-elements/test/parse-result-test.js
@@ -21,7 +21,7 @@ chai.use((_chai, utils) => {
     const obj = this._obj;
 
     this.assert(
-      obj.classes.contains(name),
+      obj.classes.includes(name),
       'Expected class list #{act} to contain #{exp}',
       'Expected class list #{act} to not contain #{exp}',
       name,

--- a/packages/apiaryb-parser/test/adapter-test.js
+++ b/packages/apiaryb-parser/test/adapter-test.js
@@ -45,7 +45,7 @@ describe('Apiary Blueprint Parser Adapter', () => {
     });
 
     it('has API category inside parse result', () => {
-      const filtered = result.filter(item => item.element === 'category' && item.classes.contains('api'));
+      const filtered = result.filter(item => item.element === 'category' && item.classes.includes('api'));
 
       expect(filtered).to.have.length(1);
       expect(filtered.first).to.be.an('object');

--- a/packages/apib-parser/test/adapter-test.js
+++ b/packages/apib-parser/test/adapter-test.js
@@ -44,7 +44,7 @@ describe('API Blueprint parser adapter', () => {
     });
 
     it('has API category inside parse result', () => {
-      const filtered = result.children.filter(item => item.element === 'category' && item.classes.contains('api'));
+      const filtered = result.children.filter(item => item.element === 'category' && item.classes.includes('api'));
 
       expect(filtered).to.have.length(1);
       expect(filtered.first).to.be.an('object');

--- a/packages/apib-serializer/template.nunjucks
+++ b/packages/apib-serializer/template.nunjucks
@@ -169,10 +169,10 @@ FORMAT: 1A
     {% if item.element == 'copy' %}
 {{ item.toValue() }}
     {% endif %}
-    {% if item.element == 'category' and item.classes.contains('resourceGroup') %}
+    {% if item.element == 'category' and item.classes.includes('resourceGroup') %}
       {{ renderGroup(item) }}
     {% endif %}
-    {% if item.element == 'category' and item.classes.contains('dataStructures') %}
+    {% if item.element == 'category' and item.classes.includes('dataStructures') %}
       {{ renderDataStructures(item) }}
     {% endif %}
     {% if item.element == 'resource' %}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",
     "js-yaml": "^3.12.0",
-    "minim": "^0.23.4"
+    "minim": "^0.23.8"
   },
   "devDependencies": {
     "eslint": "^5.16.0"

--- a/packages/openapi2-parser/lib/parser.js
+++ b/packages/openapi2-parser/lib/parser.js
@@ -1320,7 +1320,7 @@ class Parser {
     const { Category, Copy } = this.namespace.elements;
 
     if (name) {
-      this.group = this.api.find(el => el.element === 'category' && el.classes.contains('resourceGroup') && el.title.toValue() === name).first;
+      this.group = this.api.find(el => el.element === 'category' && el.classes.includes('resourceGroup') && el.title.toValue() === name).first;
 
       if (!this.group) {
         // TODO: Source maps for these groups. The problem is that the location

--- a/packages/openapi2-parser/test/adapter-test.js
+++ b/packages/openapi2-parser/test/adapter-test.js
@@ -124,7 +124,7 @@ describe('Swagger 2.0 adapter', () => {
     });
 
     it('has API category inside parse result', () => {
-      const filtered = result.filter(item => item.element === 'category' && item.classes.contains('api'));
+      const filtered = result.filter(item => item.element === 'category' && item.classes.includes('api'));
 
       expect(filtered).to.have.length(1);
       expect(filtered.first).to.be.an('object');

--- a/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -373,7 +373,7 @@ describe('Parameter Object', () => {
 
       expect(typeAttributes).to.be.instanceof(namespace.elements.Array);
       expect(typeAttributes.length).to.be.equal(1);
-      expect(typeAttributes.contains('required')).to.be.true;
+      expect(typeAttributes.includes('required')).to.be.true;
     });
 
     it('ignore required param if it is `false`', () => {
@@ -421,7 +421,7 @@ describe('Parameter Object', () => {
 
       expect(typeAttributes).to.be.instanceof(namespace.elements.Array);
       expect(typeAttributes.length).to.be.equal(1);
-      expect(typeAttributes.contains('required')).to.be.true;
+      expect(typeAttributes.includes('required')).to.be.true;
 
       expect(parseResult).to.contain.warning("'Parameter Object' 'required' must exist when 'in' is set to 'path'");
     });
@@ -442,7 +442,7 @@ describe('Parameter Object', () => {
 
       expect(typeAttributes).to.be.instanceof(namespace.elements.Array);
       expect(typeAttributes.length).to.be.equal(1);
-      expect(typeAttributes.contains('required')).to.be.true;
+      expect(typeAttributes.includes('required')).to.be.true;
 
       expect(parseResult).to.contain.warning("'Parameter Object' 'required' must be 'true' when 'in' is set to 'path'");
     });
@@ -463,7 +463,7 @@ describe('Parameter Object', () => {
 
       expect(typeAttributes).to.be.instanceof(namespace.elements.Array);
       expect(typeAttributes.length).to.be.equal(1);
-      expect(typeAttributes.contains('required')).to.be.true;
+      expect(typeAttributes.includes('required')).to.be.true;
 
       expect(parseResult).to.contain.warning("'Parameter Object' 'required' is not a boolean");
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4449,10 +4449,10 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-minim@^0.23.4, minim@^0.23.5:
-  version "0.23.7"
-  resolved "https://registry.yarnpkg.com/minim/-/minim-0.23.7.tgz#cfacc31f247193c5887f4d0b834ddb8fde84b949"
-  integrity sha512-XAp54ttzelevD/iN0U+N7I0clxrFw9n01Ou0ZGS3tuweXpzjfnFq2rDrqFeHqBoYUtpt/3vt1JFvBtPMc5KW/Q==
+minim@^0.23.8:
+  version "0.23.8"
+  resolved "https://registry.yarnpkg.com/minim/-/minim-0.23.8.tgz#a529837afe1654f119dfb68ce7487dd8d4866b9c"
+  integrity sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==
   dependencies:
     lodash "^4.15.0"
 


### PR DESCRIPTION
Includes method replaces contains (for consistency) - old method is available for compatibility, but we can upgrade here.

Hint for others doing this: `sed -i '' "s/\.contains/\.includes/g" **.js`