### PR TITLE
Restore accidentally disabled tests

### DIFF
--- a/packages/openapi2-parser/test/adapter-test.js
+++ b/packages/openapi2-parser/test/adapter-test.js
@@ -242,7 +242,7 @@ describe('Swagger 2.0 adapter', () => {
       });
 
       testFixture(`Parses ${name}`, options);
-      testFixture(`Parses ${name} with source maps`, options, true);
+      testFixture(`Parses ${name} with source maps`, options, { generateSourceMap: true });
       testFixture(`Parses ${name}`, testFixtureOptions(swaggerPath, apiElementsPath));
     });
   });

--- a/packages/openapi2-parser/test/fixtures/circular-example.sourcemap.json
+++ b/packages/openapi2-parser/test/fixtures/circular-example.sourcemap.json
@@ -653,28 +653,25 @@
                         "content": "company"
                       },
                       "value": {
-                        "element": "object",
-                        "content": [
-                          {
-                            "element": "member",
-                            "attributes": {
-                              "typeAttributes": {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "string",
-                                    "content": "optional"
-                                  }
-                                ]
-                              }
-                            },
-                            "content": {
-                              "key": {
-                                "element": "string",
-                                "content": "data"
+                        "element": "enum",
+                        "attributes": {
+                          "enumerations": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string"
                               },
-                              "value": {
-                                "element": "definitions/Company",
+                              {
+                                "element": "number"
+                              },
+                              {
+                                "element": "boolean"
+                              },
+                              {
+                                "element": "array"
+                              },
+                              {
+                                "element": "object",
                                 "content": [
                                   {
                                     "element": "member",
@@ -692,24 +689,49 @@
                                     "content": {
                                       "key": {
                                         "element": "string",
-                                        "content": "is_owner"
+                                        "content": "data"
                                       },
                                       "value": {
-                                        "element": "boolean",
-                                        "attributes": {
-                                          "default": {
-                                            "element": "boolean",
-                                            "content": false
+                                        "element": "definitions/Company",
+                                        "content": [
+                                          {
+                                            "element": "member",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "optional"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "content": {
+                                              "key": {
+                                                "element": "string",
+                                                "content": "is_owner"
+                                              },
+                                              "value": {
+                                                "element": "boolean",
+                                                "attributes": {
+                                                  "default": {
+                                                    "element": "boolean",
+                                                    "content": false
+                                                  }
+                                                }
+                                              }
+                                            }
                                           }
-                                        }
+                                        ]
                                       }
                                     }
                                   }
                                 ]
                               }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     }
                   }

--- a/packages/openapi2-parser/test/fixtures/json-body-generation-array-object.sourcemap.json
+++ b/packages/openapi2-parser/test/fixtures/json-body-generation-array-object.sourcemap.json
@@ -406,6 +406,17 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "array",
+                            "attributes": {
+                              "typeAttributes": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string",
+                                    "content": "fixedType"
+                                  }
+                                ]
+                              }
+                            },
                             "content": [
                               {
                                 "element": "definitions/Question"
@@ -553,6 +564,17 @@
                       },
                       "value": {
                         "element": "array",
+                        "attributes": {
+                          "typeAttributes": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "content": "fixedType"
+                              }
+                            ]
+                          }
+                        },
                         "content": [
                           {
                             "element": "definitions/Choice"


### PR DESCRIPTION
Source map tests have been disabled in 1e323408067379177966287598b6cf226a46061f by mistake during refactoring. Adapter options is an object, and not a boolean value and thus didn't work as intended. As per the code that handles adapter options:

```js
function testFixture(description, fixture, adapterOptions) {
    ...

    if (adapterOptions && adapterOptions.generateSourceMap) {
      expected = fixture.apiElementsSourceMap;
    } else {
      expected = fixture.apiElements;
    }
```