### PR TITLE
Add sourcemaps to some swagger validation errors

### DIFF
--- a/packages/openapi2-parser/lib/parser.js
+++ b/packages/openapi2-parser/lib/parser.js
@@ -188,6 +188,15 @@ class Parser {
           annotation.attributes.set('sourceMap', [
             new SourceMap([location]),
           ]);
+        } else {
+          // Some validation errors contain `in '/some/path'`,
+          // we can extract path to get source map
+          const matchesPath = message.match(/in '\/(.*?)'/);
+
+          if (matchesPath) {
+            const path = matchesPath[1].split('/');
+            this.createSourceMap(annotation, path, true);
+          }
         }
 
         return done(null, this.result);

--- a/packages/openapi2-parser/test/fixtures/swagger-error.json
+++ b/packages/openapi2-parser/test/fixtures/swagger-error.json
@@ -1,0 +1,87 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#swagger-validation"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 4
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 6
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 2
+                        }
+                      },
+                      "content": 98
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 9
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 0
+                        }
+                      },
+                      "content": 43
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Validation failed. Property 'foo' listed as required but does not exist in '/definitions/test'"
+    }
+  ]
+}

--- a/packages/openapi2-parser/test/fixtures/swagger-error.sourcemap.json
+++ b/packages/openapi2-parser/test/fixtures/swagger-error.sourcemap.json
@@ -1,0 +1,87 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#swagger-validation"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 4
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 6
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 2
+                        }
+                      },
+                      "content": 98
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 9
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 0
+                        }
+                      },
+                      "content": 43
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "Validation failed. Property 'foo' listed as required but does not exist in '/definitions/test'"
+    }
+  ]
+}

--- a/packages/openapi2-parser/test/fixtures/swagger-error.yaml
+++ b/packages/openapi2-parser/test/fixtures/swagger-error.yaml
@@ -1,0 +1,9 @@
+swagger: '2.0'
+info:
+  title: Swagger Validation Errors
+  version: 1.0.0
+paths: {}
+definitions:
+  test:
+    type: object
+    required: [foo]


### PR DESCRIPTION
I noticed source map was missing for one particular error message:

> error: (4) Validation failed. Property 'authorizerId' listed as required but does not exist in '/definitions/authorizerInfoType'

The error was as follows:

```
{
  stack: "SyntaxError: Validation failed. Property 'authorizerId' listed as required but does not exist in '/definitions/authorizerInfoType'\n" +
    '    at validateRequiredPropertiesExist (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/swagger-parser/lib/validators/spec.js:338:19)\n' +
    '    at validateSpec (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/swagger-parser/lib/validators/spec.js:37:5)\n' +
    '    at SwaggerParser.validate (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/swagger-parser/lib/index.js:172:7)',
  message: "Validation failed. Property 'authorizerId' listed as required but does not exist in '/definitions/authorizerInfoType'",
  toJSON: [Function: toJSON],
  name: 'SyntaxError',
  toString: [Function: toString]
}
```

Given the JSON path is in the error message I was able to extract it out and attach sourcemaps via it.