### PR TITLE
Handle negative boolean values as false

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -8,6 +8,10 @@
   invalid: `style`, `explode`, `allowReserved`, `schema`, `content`, `example`,
   and `examples`. These will now return an unsupported warning instead.
 
+- Negative boolean YAML values was previously treated as true and thus
+  Parameter Object's with `required: false` would have been incorrectly treated
+  as required.
+
 ## 0.13.0 (2020-06-12)
 
 The package has been updated for compatibility with `@apielements/core`.

--- a/packages/openapi3-parser/lib/parser/parseYAML.js
+++ b/packages/openapi3-parser/lib/parser/parseYAML.js
@@ -61,7 +61,7 @@ function convert(node, annotations, context) {
   } else if (node.tag === 'tag:yaml.org,2002:int' || node.tag === 'tag:yaml.org,2002:float') {
     element = new namespace.elements.Number(Number(node.value));
   } else if (node.tag === 'tag:yaml.org,2002:bool') {
-    element = new namespace.elements.Boolean(Boolean(node.value));
+    element = new namespace.elements.Boolean(node.value === 'true' || node.value === 'yes' || node.value === 'on');
   } else if (node.tag === 'tag:yaml.org,2002:null') {
     element = new namespace.elements.Null();
   } else if (node.tag === 'tag:yaml.org,2002:binary') {

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.json
@@ -122,17 +122,6 @@
                           "content": "How many items to return at one time (max 100)"
                         }
                       },
-                      "attributes": {
-                        "typeAttributes": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "string",
-                              "content": "required"
-                            }
-                          ]
-                        }
-                      },
                       "content": {
                         "key": {
                           "element": "string",

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -347,17 +347,6 @@
                           "content": "How many items to return at one time (max 100)"
                         }
                       },
-                      "attributes": {
-                        "typeAttributes": {
-                          "element": "array",
-                          "content": [
-                            {
-                              "element": "string",
-                              "content": "required"
-                            }
-                          ]
-                        }
-                      },
                       "content": {
                         "key": {
                           "element": "string",

--- a/packages/openapi3-parser/test/unit/parser/parseYAML-test.js
+++ b/packages/openapi3-parser/test/unit/parser/parseYAML-test.js
@@ -93,7 +93,7 @@ describe('#parseYAML', () => {
     expect(element.first).to.have.sourceMapEndColumn(4);
   });
 
-  it('can parse an boolean value into a boolean element', () => {
+  it('can parse an boolean yes value into a boolean element', () => {
     const element = parseYAML('yes', context);
 
     expect(element).to.be.instanceof(namespace.elements.ParseResult);
@@ -101,6 +101,86 @@ describe('#parseYAML', () => {
 
     expect(element.first).to.be.instanceof(namespace.elements.Boolean);
     expect(element.first.toValue()).to.deep.equal(true);
+    expect(element.first).to.have.sourceMapStart(0);
+    expect(element.first).to.have.sourceMapOffset(3);
+    expect(element.first).to.have.sourceMapStartLine(1);
+    expect(element.first).to.have.sourceMapStartColumn(1);
+    expect(element.first).to.have.sourceMapEndLine(1);
+    expect(element.first).to.have.sourceMapEndColumn(4);
+  });
+
+  it('can parse an boolean on value into a boolean element', () => {
+    const element = parseYAML('on', context);
+
+    expect(element).to.be.instanceof(namespace.elements.ParseResult);
+    expect(element.length).to.equal(1);
+
+    expect(element.first).to.be.instanceof(namespace.elements.Boolean);
+    expect(element.first.toValue()).to.deep.equal(true);
+    expect(element.first).to.have.sourceMapStart(0);
+    expect(element.first).to.have.sourceMapOffset(2);
+    expect(element.first).to.have.sourceMapStartLine(1);
+    expect(element.first).to.have.sourceMapStartColumn(1);
+    expect(element.first).to.have.sourceMapEndLine(1);
+    expect(element.first).to.have.sourceMapEndColumn(3);
+  });
+
+  it('can parse an boolean true value into a boolean element', () => {
+    const element = parseYAML('true', context);
+
+    expect(element).to.be.instanceof(namespace.elements.ParseResult);
+    expect(element.length).to.equal(1);
+
+    expect(element.first).to.be.instanceof(namespace.elements.Boolean);
+    expect(element.first.toValue()).to.deep.equal(true);
+    expect(element.first).to.have.sourceMapStart(0);
+    expect(element.first).to.have.sourceMapOffset(4);
+    expect(element.first).to.have.sourceMapStartLine(1);
+    expect(element.first).to.have.sourceMapStartColumn(1);
+    expect(element.first).to.have.sourceMapEndLine(1);
+    expect(element.first).to.have.sourceMapEndColumn(5);
+  });
+
+  it('can parse an boolean false value into a boolean element', () => {
+    const element = parseYAML('false', context);
+
+    expect(element).to.be.instanceof(namespace.elements.ParseResult);
+    expect(element.length).to.equal(1);
+
+    expect(element.first).to.be.instanceof(namespace.elements.Boolean);
+    expect(element.first.toValue()).to.deep.equal(false);
+    expect(element.first).to.have.sourceMapStart(0);
+    expect(element.first).to.have.sourceMapOffset(5);
+    expect(element.first).to.have.sourceMapStartLine(1);
+    expect(element.first).to.have.sourceMapStartColumn(1);
+    expect(element.first).to.have.sourceMapEndLine(1);
+    expect(element.first).to.have.sourceMapEndColumn(6);
+  });
+
+  it('can parse an boolean no value into a boolean element', () => {
+    const element = parseYAML('no', context);
+
+    expect(element).to.be.instanceof(namespace.elements.ParseResult);
+    expect(element.length).to.equal(1);
+
+    expect(element.first).to.be.instanceof(namespace.elements.Boolean);
+    expect(element.first.toValue()).to.deep.equal(false);
+    expect(element.first).to.have.sourceMapStart(0);
+    expect(element.first).to.have.sourceMapOffset(2);
+    expect(element.first).to.have.sourceMapStartLine(1);
+    expect(element.first).to.have.sourceMapStartColumn(1);
+    expect(element.first).to.have.sourceMapEndLine(1);
+    expect(element.first).to.have.sourceMapEndColumn(3);
+  });
+
+  it('can parse an boolean off value into a boolean element', () => {
+    const element = parseYAML('off', context);
+
+    expect(element).to.be.instanceof(namespace.elements.ParseResult);
+    expect(element.length).to.equal(1);
+
+    expect(element.first).to.be.instanceof(namespace.elements.Boolean);
+    expect(element.first.toValue()).to.deep.equal(false);
     expect(element.first).to.have.sourceMapStart(0);
     expect(element.first).to.have.sourceMapOffset(3);
     expect(element.first).to.have.sourceMapStartLine(1);


### PR DESCRIPTION
This is a pretty big bug 😱, all boolean YAML values have been parsed as true because `Boolean('false')` returns true....

Discovered in https://github.com/apiaryio/dredd/issues/1686