### PR TITLE
Don't generate bodies when validating

### DIFF
--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Master
 
+### Enhancements
+
+- Performance improvements to OpenAPI 2 validation, this will only apply to
+  validation only. Full OpenAPI 2 parsing is not altered.
+
 ### Bug Fixes
 
 - Returns a validation error while trying to parse a YAML or JSON object which

--- a/packages/openapi2-parser/lib/adapter.js
+++ b/packages/openapi2-parser/lib/adapter.js
@@ -29,9 +29,29 @@ function parse(options) {
   });
 }
 
+function validate(options) {
+  return new Promise((fulfil, reject) => {
+    const parser = new Parser({
+      ...options,
+      generateMessageBody: false,
+      generateMessageBodySchema: false,
+    });
+
+    parser.parse((error, parseResult) => {
+      if (error) {
+        reject(error);
+      } else if (parseResult.annotations.length > 0) {
+        fulfil(new options.namespace.elements.ParseResult(parseResult.annotations));
+      } else {
+        fulfil(null);
+      }
+    });
+  });
+}
+
 /**
  * @implements {FuryAdapter}
  */
 module.exports = {
-  name, mediaTypes, detect, parse,
+  name, mediaTypes, detect, validate, parse,
 };

--- a/packages/openapi2-parser/test/adapter-test.js
+++ b/packages/openapi2-parser/test/adapter-test.js
@@ -104,6 +104,36 @@ describe('Swagger 2.0 adapter', () => {
     });
   });
 
+  context('#validate', () => {
+    it('validates source with no annotations', (done) => {
+      const source = { swagger: '2.0', info: { title: 'Test', version: '1.0' } };
+
+      fury.validate({ source }, (err, parseResult) => {
+        expect(err).to.be.null;
+        expect(parseResult).to.be.null;
+        done();
+      });
+    });
+
+    it('validates source with warnings', (done) => {
+      const source = {
+        swagger: '2.0',
+      };
+
+      fury.validate({ source }, (err, parseResult) => {
+        expect(err).to.be.null;
+        expect(parseResult).to.be.instanceof(fury.minim.elements.ParseResult);
+        expect(parseResult.length).to.equal(3);
+        expect(parseResult.toValue()).to.deep.equal([
+          'Missing required property: title',
+          'Source maps are only available with string input',
+          'Missing required property: version',
+        ]);
+        done();
+      });
+    });
+  });
+
   context('can parse Swagger object', () => {
     const source = { swagger: '2.0', info: { title: 'Test', version: '1.0' } };
     let result;


### PR DESCRIPTION
This brings a decent performance boost when you are validating OpenAPI 2 and do not want the parse result. The behaviour should remain unchanged, however we are disabling the generation of message bodies during validation as that is the slowest part of the parser.

Before:

```
$ time npx fury hbu/rsv.json --validate
        9.59 real        10.30 user         0.28 sys
```

After:

```
$ time npx fury hbu/rsv.json --validate
        2.83 real         3.23 user         0.11 sys
```

The added tests woth on both master and the branch, they are there to demonstrate the change retains prior behavior. When a Fury adapter does not implement validate, Fury will create one on top of parse. The caveat there is that it causes all the parse logic.