### PR TITLE
Minor OAS 3 documentation fixes

### DIFF
--- a/packages/openapi3-parser/STATUS.md
+++ b/packages/openapi3-parser/STATUS.md
@@ -195,7 +195,6 @@ support.
 |:--|:--|
 | type | ✓ |
 | enum | ✓ |
-| examples | ✕ |
 | encoding | ✕ |
 | title | ✕ |
 | multipleOf | ✕ |

--- a/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
@@ -20,7 +20,7 @@ const unsupportedKeys = [
   // JSON Schema
   'title', 'multipleOf', 'maximum', 'exclusiveMaximum', 'minimum',
   'exclusiveMinimum', 'maxLength', 'minLength', 'pattern', 'maxItems',
-  'minItems', 'uniqueItems', 'maxProperties', 'minProperties', 'required',
+  'minItems', 'uniqueItems', 'maxProperties', 'minProperties',
 
   // JSON Schema + OAS 3 specific rules
   'allOf', 'anyOf', 'not', 'additionalProperties', 'format',


### PR DESCRIPTION
- remove required keyword in unsupported list - this keyword is actually supported
- remove 'examples' from STATUS.md, `examples` was mistakenly added as it comes from JSON Schema, although is not part of OpenAPI 3.0 as per the following clause in spec:

> Additional properties defined by the JSON Schema specification that are not mentioned here are strictly unsupported.