### PR TITLE
Prevent throwing during freeze for required annotations

### DIFF
--- a/packages/openapi3-parser/lib/parser/parseObject.js
+++ b/packages/openapi3-parser/lib/parser/parseObject.js
@@ -41,7 +41,7 @@ const hasMember = R.curry((object, key) => {
 const validateObjectContainsRequiredKeys = R.curry((namespace, path, requiredKeys, sendWarning, object) => {
   const missingKeys = R.reject(hasMember(object), requiredKeys);
   const createAnnotation = sendWarning ? createWarning : createError;
-  const annotationFromKey = key => createAnnotation(namespace, `'${path}' is missing required property '${key}'`, object);
+  const annotationFromKey = key => createAnnotation(namespace, `'${path}' is missing required property '${key}'`, object.clone());
 
   if (missingKeys.length > 0) {
     return new namespace.elements.ParseResult(

--- a/packages/openapi3-parser/test/unit/parser/parseObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/parseObject-test.js
@@ -18,6 +18,9 @@ describe('#parseObject', () => {
       name: 'Doe',
       message: 'Hello',
     });
+    object.attributes.set('sourceMap', [
+      new namespace.elements.SourceMap([[0, 10]]),
+    ]);
   });
 
   it('provides warning when given element is non-object', () => {
@@ -141,6 +144,13 @@ describe('#parseObject', () => {
         "'Example Object' is missing required property 'required1'",
         "'Example Object' is missing required property 'required2'",
       ]);
+
+      // assert errors can be frozen (we're testing that the source map
+      // for object was cloned instead of referenced)
+      parseResult.freeze();
+
+      expect(parseResult.errors.get(0)).to.have.sourceMap([[0, 10]]);
+      expect(parseResult.errors.get(1)).to.have.sourceMap([[0, 10]]);
     });
 
     it('fails object parsing when member parse cannot parse required key', () => {


### PR DESCRIPTION
The parser can create multiple errors from an object which contain the exact same instance of a source map element. Thus creating integration problems using the parse result as the same element instance is re-used and thus a modification to one causes modification to others. This can be demonstrated by using `.freeze()` method as that requires each element to only be used a single time within the tree.

Prevents the error from being throw to users as per https://github.com/apiaryio/dredd/issues/1762