### PR TITLE
Fix support for using `$ref` in a component definition

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -9,6 +9,19 @@
   or any annotation.  It is not supported in the case when one of is used in
   conjunction with other constraints in the same schema object.
 
+### Bug Fixes
+
+- Supports using `$ref` in the root of a component, for example:
+
+    ```yaml
+    components:
+      schemas:
+        UserAlias:
+          $ref: '#/components/schemas/User'
+        User:
+          type: object
+    ```
+
 ## 0.13.1 (2020-06-22)
 
 ### Bug Fixes

--- a/packages/openapi3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseComponentsObject.js
@@ -71,6 +71,36 @@ const parseComponentMember = R.curry((context, parser, member) => {
   return parseResult;
 });
 
+function registerComponentStateInContext(context, components) {
+  const { namespace } = context;
+
+  // Component referencing supports recursive (and circular in some cases)
+  // references and thus we must know about all of the component IDs upfront.
+  // Below we are putting in the unparsed components so we can keep the
+  // dereferencing logic simple, these are used during parsing the components
+  // and later on the components in our context is replaced by the final parsed
+  // result.
+  // eslint-disable-next-line no-param-reassign
+  context.state.components = new namespace.elements.Object();
+
+  if (isObject(components)) {
+    components.forEach((value, key) => {
+      if (isObject(value)) {
+        // Take each component object (f.e schemas, parameters) and convert to
+        // object with members for each key (discarding value). We don't want the
+        // value making it into final parse results under any circumstance, for
+        // example if the parse errors out and we leave bad state
+
+        const componentObject = new namespace.elements.Object(
+          value.map((value, key) => new namespace.elements.Member(key))
+        );
+
+        context.state.components.set(key.toValue(), componentObject);
+      }
+    });
+  }
+}
+
 /**
  * Parse Components Object
  *
@@ -84,24 +114,7 @@ const parseComponentMember = R.curry((context, parser, member) => {
 function parseComponentsObject(context, element) {
   const { namespace } = context;
 
-  // Schema Object supports recursive (and circular) references and thus we
-  // must know about all of the schema IDs upfront. Below we are putting
-  // in the unparsed schemas so we can keep the dereferencing logic simple,
-  // these are used during parsing the schema components and later on the
-  // components in our context is replaced by the final parsed result.
-  // eslint-disable-next-line no-param-reassign
-  context.state.components = new namespace.elements.Object();
-
-  if (isObject(element) && element.get('schemas') && isObject(element.get('schemas'))) {
-    // Take schemas and convert to object with members for each key (discarding value)
-    // We don't want the value making it into final parse results under any circumstance,
-    // for example if the parse errors out and we leave bad state
-    const schemas = new namespace.elements.Object(
-      element.get('schemas').map((value, key) => new namespace.elements.Member(key))
-    );
-
-    context.state.components.set('schemas', schemas);
-  }
+  registerComponentStateInContext(context, element);
 
   const createMemberValueNotObjectWarning = member => createWarning(namespace,
     `'${name}' '${member.key.toValue()}' is not an object`, member.value);
@@ -128,8 +141,6 @@ function parseComponentsObject(context, element) {
 
         if (contextMember) {
           contextMember.value = object;
-        } else {
-          context.state.components.push(new namespace.elements.Member(member.key, object));
         }
 
         return object;

--- a/packages/openapi3-parser/lib/parser/parseReference.js
+++ b/packages/openapi3-parser/lib/parser/parseReference.js
@@ -6,9 +6,9 @@ function isReferenceObject(element) {
   return isObject(element) && element.get('$ref') !== undefined;
 }
 
-function parseReference(component, parser, context, element, isInsideSchema) {
+function parseReference(component, parser, context, element, isInsideSchema, returnReferenceElement) {
   if (isReferenceObject(element)) {
-    const parseResult = parseReferenceObject(context, component, element, component === 'schemas');
+    const parseResult = parseReferenceObject(context, component, element, component === 'schemas' || returnReferenceElement);
 
     // If we're referencing a schema object and we're not inside a schema
     // parser (subschema), then we want to wrap the object in a data structure element

--- a/packages/openapi3-parser/test/integration/components-test.js
+++ b/packages/openapi3-parser/test/integration/components-test.js
@@ -19,6 +19,11 @@ describe('components', () => {
       const file = path.join(fixtures, 'path-item-object-parameters-unsupported-parameter');
       return testParseFixture(file);
     });
+
+    it('handles parameter referencing with reference to alias', () => {
+      const file = path.join(fixtures, 'path-item-object-parameters-alias');
+      return testParseFixture(file);
+    });
   });
 
   describe('Media Type Object', () => {
@@ -72,9 +77,16 @@ describe('components', () => {
     });
   });
 
-  it("'Schema Object' circular references", () => {
-    const file = path.join(fixtures, 'schema-object-circular');
-    return testParseFixture(file);
+  describe('Schema Object', () => {
+    it('handles circular references', () => {
+      const file = path.join(fixtures, 'schema-object-circular');
+      return testParseFixture(file);
+    });
+
+    it('handles schema with reference to alias', () => {
+      const file = path.join(fixtures, 'schema-alias');
+      return testParseFixture(file);
+    });
   });
 
   it("'Operation Object' requestBody references", () => {

--- a/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters-alias.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters-alias.json
@@ -1,0 +1,54 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Parameter Component with alias"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/{?foo}"
+            },
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "content": [
+                {
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "foo"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters-alias.yaml
+++ b/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters-alias.yaml
@@ -1,0 +1,15 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Parameter Component with alias
+paths:
+  /:
+    parameters:
+      - $ref: '#/components/parameters/UserAlias'
+components:
+  parameters:
+    User:
+      in: query
+      name: foo
+    UserAlias:
+      $ref: '#/components/parameters/User'

--- a/packages/openapi3-parser/test/integration/fixtures/components/schema-alias.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/schema-alias.json
@@ -1,0 +1,175 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Schemas Component with alias"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\"name\":\"\"}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "UserAlias"
+                          }
+                        },
+                        {
+                          "element": "copy",
+                          "content": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "User"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "name"
+                      },
+                      "value": {
+                        "element": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "User",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "UserAlias"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/openapi3-parser/test/integration/fixtures/components/schema-alias.yaml
+++ b/packages/openapi3-parser/test/integration/fixtures/components/schema-alias.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Schemas Component with alias
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: ''
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/UserAlias'
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name:
+          type: string
+    UserAlias:
+      $ref: '#/components/schemas/User'

--- a/packages/openapi3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -91,6 +91,34 @@ describe('Components Object', () => {
       expect(userState).to.be.instanceof(namespace.elements.Member);
       expect(userState.value).to.be.undefined;
     });
+
+    it('parses valid schemas with alias into data structures', () => {
+      const components = new namespace.elements.Object({
+        schemas: {
+          User: {
+            type: 'object',
+          },
+          UserAlias: { $ref: '#/components/schemas/User' },
+        },
+      });
+
+      const parseResult = parse(context, components);
+      expect(parseResult.length).to.equal(1);
+
+      const parsedComponents = parseResult.get(0);
+      expect(parsedComponents).to.be.instanceof(namespace.elements.Object);
+
+      const schemas = parsedComponents.get('schemas');
+      expect(schemas).to.be.instanceof(namespace.elements.Object);
+
+      const userSchema = schemas.get('User');
+      expect(userSchema).to.be.instanceof(namespace.elements.DataStructure);
+      expect(userSchema.content).to.be.instanceof(namespace.elements.Object);
+
+      const userSchemaAlias = schemas.get('UserAlias');
+      expect(userSchemaAlias).to.be.instanceof(namespace.elements.DataStructure);
+      expect(userSchemaAlias.content.element).to.equal('User');
+    });
   });
 
   describe('#parameters', () => {


### PR DESCRIPTION
I think it might be a bit hard for a reviewer to get their head around some of these changes as the referencing logic is some of the most complicated code in the project, so I'll try do my best at explaining these changes.

The following OpenAPI 3 document was not being parsed correctly:

```yaml
openapi: 3.0.0
info:
  title: example
  version: 1.0.0
paths: {}
components:
  schemas:
    User:
      type: object
    UserAlias:
      $ref: '#/components/schemas/User'
```

Support for using `$ref` directly in a reusable component against another reusable component wasn't supported. If users did that, they'd get incorrect behaviour and possibly incorrect errors (in the case for parameters which have required properties which a `$ref` object wouldn't contain).

To fix this I've made 3 changes which are broken into separate commits:

1. Before parsing, we create internal state of all the possible schemas. This allows us to parse schema A which references schema B (which isn't parsed yet), it's also part of supporting circular references. This is done by storing `context.state.components.set('schemas', ...)` where there is a collection of member elements with all the nessecery schema names. That way we can validate schemas exist. This particular code was specific to schemas only, in the first commit I have made this generic to apply to all reusable components. This internal state is needed to support references in other components.
2. Updated `parseReferenceObject` (which has dereferencing capabilities) to support multi-level referencing. This function supports returning "dereferenced" elements, this is used in areas such as `parseParametersObject` where parameter validation against a `href` uses the dereferenced parameter to get hold of the 'name'. Without this change, the function would return an element such as `{"element": "LimitAlias"}` instead the dereferenced limit parameter such as `{"element": "member", ...}`.
3. This is the core part of the fix, which is updating the logic that parses each component member to support referencing via the existing `parseReference` function. I've had to add the argument `returnReferenceElement` of `parseReferenceObject` to `parseReference` so it can be used here. Since we do actually want a referenced element back instead of a dereference element in this case (which isn't common with the rest of the uses of `parseReference`).

The last commit also contains integration tests to ensure this works end-to-end (for example JSON message body is created from the reference, etc). I want to ensure it works at all levels.