### PR TITLE
Handle unknown YAML tags

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API Elements: CLI Changelog
 
+## 0.10.1 (2020-06-24)
+
+This update incorporates changes from API Element Adapters:
+
+- openapi3-parser 0.14.0
+
 ## 0.10.0 (2020-06-12)
 
 The package has been renamed to `@apielements/cli`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "@apielements/apib-serializer": "^0.16.0",
     "@apielements/core": "^0.1.0",
     "@apielements/openapi2-parser": "^0.32.0",
-    "@apielements/openapi3-parser": "^0.13.0",
+    "@apielements/openapi3-parser": "^0.14.0",
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",
     "js-yaml": "^3.12.0",

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -22,6 +22,9 @@
           type: object
     ```
 
+- Prevents the parser from throwing an error upon encountering an unknown or
+  invalid YAML node tag, such as `!!unknown`.
+
 ## 0.13.1 (2020-06-22)
 
 ### Bug Fixes

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Fury OAS3 Parser Changelog
+# API Elements: OpenAPI 3 Parser Changelog
 
-## Master
+## 0.14.0 (2020-06-24)
 
 ### Enhancements
 

--- a/packages/openapi3-parser/lib/parser/parseYAML.js
+++ b/packages/openapi3-parser/lib/parser/parseYAML.js
@@ -90,7 +90,11 @@ function convert(node, annotations, context) {
     copySourceMap(node.start_mark, node.end_mark, warning, namespace);
     annotations.push(warning);
   } else {
-    throw new Error(`Unsupported YAML node '${node.tag}'`);
+    const error = new namespace.elements.Annotation(`YAML Syntax: Unsupported YAML node ${node.tag}`, { classes: ['error'] });
+    copySourceMap(node.start_mark, node.end_mark, error, namespace);
+    annotations.push(error);
+
+    element = new namespace.elements.Null();
   }
 
   copySourceMap(node.start_mark, node.end_mark, element, namespace);

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/openapi3-parser/test/unit/parser/parseYAML-test.js
+++ b/packages/openapi3-parser/test/unit/parser/parseYAML-test.js
@@ -32,6 +32,15 @@ describe('#parseYAML', () => {
       expect(parseResult).contain.error('YAML Syntax: found character \\t that cannot start any token, while scanning for the next token').with.sourceMap([[14, 0]]);
     });
 
+    it('fails to parse YAML document with unknown tags', () => {
+      const parseResult = parseYAML('!!unknown\n', context);
+
+      expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
+      expect(parseResult.errors.length).to.equal(1);
+
+      expect(parseResult).contain.error('YAML Syntax: Unsupported YAML node tag:yaml.org,2002:unknown').with.sourceMap([[0, 9]]);
+    });
+
     it('can handle internal YAML parser error', () => {
       // Protection against YAML parser bug where source map information isn't available
       // Particular case: https://github.com/connec/yaml-js/issues/46


### PR DESCRIPTION
Prevents the parser from throwing an error upon encountering an unknown or invalid YAML node tag, such as `!!unknown`. Previously this would throw an error, now we will return parsing error.