### PR TITLE
Add accept header to requests

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Adds support for the Schema Object title property.
 
+### Bug Fixes
+
+- Adds an accept header to requests with the matching responses content type.
+
 ## 0.14.0 (2020-06-24)
 
 ### Enhancements

--- a/packages/openapi3-parser/lib/parser/oas/parseOperationObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseOperationObject.js
@@ -47,6 +47,18 @@ function createTransactions(namespace, member, operation) {
       const clonedRequest = request.clone();
       clonedRequest.method = method;
 
+      const { contentType } = response;
+      if (contentType) {
+        let { headers } = clonedRequest;
+
+        if (!headers) {
+          headers = new namespace.elements.HttpHeaders();
+          clonedRequest.headers = headers;
+        }
+
+        headers.unshift(new namespace.elements.Member('Accept', contentType.toValue()));
+      }
+
       transactions.push(new namespace.elements.HttpTransaction([
         clonedRequest,
         response.clone(),

--- a/packages/openapi3-parser/test/integration/fixtures/auth-scheme-does-not-exist.json
+++ b/packages/openapi3-parser/test/integration/fixtures/auth-scheme-does-not-exist.json
@@ -52,6 +52,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/auth-scheme-does-not-exist.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/auth-scheme-does-not-exist.sourcemap.json
@@ -177,6 +177,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/auth-scheme-global.json
+++ b/packages/openapi3-parser/test/integration/fixtures/auth-scheme-global.json
@@ -114,6 +114,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -188,6 +206,24 @@
                         "method": {
                           "element": "string",
                           "content": "PATCH"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -252,6 +288,24 @@
                         "method": {
                           "element": "string",
                           "content": "PUT"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/auth-scheme-global.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/auth-scheme-global.sourcemap.json
@@ -314,6 +314,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -463,6 +481,24 @@
                             }
                           },
                           "content": "PATCH"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -602,6 +638,24 @@
                             }
                           },
                           "content": "PUT"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/auth-scheme.json
+++ b/packages/openapi3-parser/test/integration/fixtures/auth-scheme.json
@@ -87,6 +87,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/auth-scheme.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/auth-scheme.sourcemap.json
@@ -237,6 +237,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/media-type-object-examples.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/media-type-object-examples.json
@@ -52,6 +52,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/media-type-object-schema-multiple.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/media-type-object-schema-multiple.json
@@ -52,6 +52,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -126,6 +144,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/yaml"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/media-type-object-schema.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/media-type-object-schema.json
@@ -52,6 +52,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters-unsupported-parameter.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters-unsupported-parameter.json
@@ -52,6 +52,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/path-item-object-parameters.json
@@ -109,6 +109,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/responses-object-response-with-schema.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/responses-object-response-with-schema.json
@@ -52,6 +52,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/components/schema-alias.json
+++ b/packages/openapi3-parser/test/integration/fixtures/components/schema-alias.json
@@ -46,6 +46,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/messageBody.json
+++ b/packages/openapi3-parser/test/integration/fixtures/messageBody.json
@@ -57,6 +57,19 @@
                               "content": {
                                 "key": {
                                   "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
                                   "content": "Content-Type"
                                 },
                                 "value": {

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.json
@@ -142,6 +142,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -228,6 +246,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -342,6 +378,24 @@
                         "method": {
                           "element": "string",
                           "content": "POST"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -469,6 +523,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -543,6 +615,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -417,6 +417,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -578,6 +596,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -842,6 +878,24 @@
                             }
                           },
                           "content": "POST"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -1144,6 +1198,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },
@@ -1268,6 +1340,24 @@
                             }
                           },
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     },

--- a/packages/openapi3-parser/test/unit/parser/oas/parseOperationObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseOperationObject-test.js
@@ -647,6 +647,7 @@ describe('Operation Object', () => {
       expect(transaction1.length).to.equal(2);
 
       expect(transaction1.request).to.be.instanceof(namespace.elements.HttpRequest);
+      expect(transaction1.request.header('Accept')[0].toValue()).to.equal('application/json');
       expect(transaction1.response).to.be.instanceof(namespace.elements.HttpResponse);
       expect(transaction1.response.contentType.toValue()).to.be.equal('application/json');
 
@@ -655,6 +656,7 @@ describe('Operation Object', () => {
       expect(transaction2.length).to.equal(2);
 
       expect(transaction2.request).to.be.instanceof(namespace.elements.HttpRequest);
+      expect(transaction2.request.header('Accept')[0].toValue()).to.equal('application/xml');
       expect(transaction2.response).to.be.instanceof(namespace.elements.HttpResponse);
       expect(transaction2.response.contentType.toValue()).to.be.equal('application/xml');
     });


### PR DESCRIPTION
Discovered via https://stackoverflow.com/questions/60264392/openapi3-and-csv-response-for-dredd.

```yaml
openapi: 3.0.0
info:
  title: example
  version: 1.0.0
paths:
  /:
    get:
      summary: csv
      responses:
        '200':
          description: test
          content:
            text/csv:
              schema:
                type: string
                example: 'cell1, cell2'

```

I'd expect the httpRequest element to include the Accept header, it does not:

```
$ npx fury issue.yaml | jq .content[0].content[0].content[0].content[0].content[0]
{
  "element": "httpRequest",
  "attributes": {
    "method": {
      "element": "string",
      "content": "GET"
    }
  }
}
```

Fixes #413