### PR TITLE
chore(oas2): recursive generateBody

### DIFF
--- a/packages/openapi2-parser/lib/generator.js
+++ b/packages/openapi2-parser/lib/generator.js
@@ -26,7 +26,7 @@ function generateBody(schema) {
   }
 
   if (schemaIsArrayAndHasItems(schema)) {
-    return [generateBody(schema.items)];
+    return Array.from({ length: Math.min(5, schema.minItems || 1) }, () => generateBody(schema.items));
   }
 
   if (schema.allOf && schema.allOf.length === 1) {

--- a/packages/openapi2-parser/lib/generator.js
+++ b/packages/openapi2-parser/lib/generator.js
@@ -17,16 +17,20 @@ faker.option({
   random: () => 0,
 });
 
-const schemaIsArrayAndHasItems = schema => schema.type && schema.type === 'array' && schema.items;
+const schemaIsArrayAndHasItems = schema => schema.type === 'array' && typeof schema.items === 'object';
 const isEmptyArray = value => value && Array.isArray(value) && value.length === 0;
 
 function generateBody(schema) {
-  if (schema.allOf && schema.allOf.length === 1 && schema.allOf[0].examples && schema.allOf[0].examples.length > 0) {
-    return schema.allOf[0].examples[0];
-  }
-
   if (schema.examples && schema.examples.length > 0) {
     return schema.examples[0];
+  }
+
+  if (schemaIsArrayAndHasItems(schema)) {
+    return [generateBody(schema.items)];
+  }
+
+  if (schema.allOf && schema.allOf.length === 1) {
+    return generateBody(schema.allOf[0]);
   }
 
   const body = faker.generate(schema);

--- a/packages/openapi2-parser/test/generator-test.js
+++ b/packages/openapi2-parser/test/generator-test.js
@@ -220,5 +220,58 @@ describe('bodyFromSchema', () => {
         expect(body).to.deep.equal({ name: 'doe' });
       });
     });
+
+    describe('allOf w/length 1', () => {
+      it('can generate an object', () => {
+        const schema = {
+          allOf: [
+            {
+              type: 'object',
+              examples: [{ name: 'doe' }],
+            },
+          ],
+        };
+
+        const body = generate(schema);
+
+        expect(body).to.deep.equal({ name: 'doe' });
+      });
+
+      it('can generate an array', () => {
+        const schema = {
+          allOf: [
+            {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              examples: [['doe']],
+            },
+          ],
+        };
+
+        const body = generate(schema);
+
+        expect(body).to.deep.equal(['doe']);
+      });
+
+      it('can generate an array with items', () => {
+        const schema = {
+          allOf: [
+            {
+              type: 'array',
+              items: {
+                type: 'string',
+                examples: ['doe'],
+              },
+            },
+          ],
+        };
+
+        const body = generate(schema);
+
+        expect(body).to.deep.equal(['doe']);
+      });
+    });
   });
 });


### PR DESCRIPTION
This makes the `generateBody` more likely to pick the `examples` defined in the ADD. e.g. `allOf[array[item]]`.