### PR TITLE
Prefer sample/default over empty primitive array when generating values

### DIFF
--- a/packages/api-elements/CHANGELOG.md
+++ b/packages/api-elements/CHANGELOG.md
@@ -1,5 +1,12 @@
 # API Elements (JavaScript) CHANGELOG
 
+## Master
+
+### Bug Fixes
+
+- Generating a value from an element will now prefer sample/default values for
+  arrays which contain empty primitive values.
+
 ## 0.2.6 (2020-07-01)
 
 ### Bug Fixes

--- a/packages/api-elements/test/value-of-test.js
+++ b/packages/api-elements/test/value-of-test.js
@@ -700,6 +700,25 @@ describe('valueOf ArrayElement', () => {
     expect(value).to.deep.equal([4, 2]);
   });
 
+  it('prefers samples over empty primitive value', () => {
+    const element = new ArrayElement([new NumberElement()]);
+    element.attributes.set('default', new ArrayElement([4, 2]));
+    element.attributes.set('samples', new ArrayElement([
+      new ArrayElement([2, 'hello']),
+    ]));
+    const value = element.valueOf();
+
+    expect(value).to.deep.equal([2, 'hello']);
+  });
+
+  it('prefers default over empty primitive value', () => {
+    const element = new ArrayElement([new NumberElement()]);
+    element.attributes.set('default', new ArrayElement([4, 2]));
+    const value = element.valueOf();
+
+    expect(value).to.deep.equal([4, 2]);
+  });
+
   it('generates [] if no content, default, samples and not nullable', () => {
     const element = new ArrayElement();
     const value = element.valueOf();

--- a/packages/api-elements/test/value-of-test.js
+++ b/packages/api-elements/test/value-of-test.js
@@ -24,9 +24,9 @@ describe('valueOf NullElement', () => {
   it('returns null with default and samples', () => {
     const element = new NullElement();
     element.attributes.set('default', new NullElement());
-    element.attributes.set('samples', new ArrayElement(
-      new NullElement()
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new NullElement(),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.equal(null);
@@ -92,9 +92,9 @@ describe('valueOf BooleanElement', () => {
   it('prefers content over default and samples', () => {
     const element = new BooleanElement(true);
     element.attributes.set('default', new BooleanElement(false));
-    element.attributes.set('samples', new ArrayElement(
-      new BooleanElement(false)
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new BooleanElement(false),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.equal(true);
@@ -148,9 +148,9 @@ describe('valueOf BooleanElement with source', () => {
   it('prefers content over default and samples', () => {
     const element = new BooleanElement(true);
     element.attributes.set('default', new BooleanElement(false));
-    element.attributes.set('samples', new ArrayElement(
-      new BooleanElement(false)
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new BooleanElement(false),
+    ]));
     const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal([true, 'content']);
@@ -204,9 +204,9 @@ describe('valueOf NumberElement', () => {
   it('prefers content over default and samples', () => {
     const element = new NumberElement(3);
     element.attributes.set('default', new NumberElement(42));
-    element.attributes.set('samples', new ArrayElement(
-      new NumberElement(27)
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new NumberElement(27),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.equal(3);
@@ -260,9 +260,9 @@ describe('valueOf NumberElement with source', () => {
   it('prefers content over default and samples', () => {
     const element = new NumberElement(3);
     element.attributes.set('default', new NumberElement(42));
-    element.attributes.set('samples', new ArrayElement(
-      new NumberElement(27)
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new NumberElement(27),
+    ]));
     const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal([3, 'content']);
@@ -316,9 +316,9 @@ describe('valueOf StringElement', () => {
   it('prefers content over default and samples', () => {
     const element = new StringElement('hello');
     element.attributes.set('default', new StringElement('moin'));
-    element.attributes.set('samples', new ArrayElement(
-      new StringElement('zdravicko')
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new StringElement('zdravicko'),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.equal('hello');
@@ -372,9 +372,9 @@ describe('valueOf StringElement with source', () => {
   it('prefers content over default and samples', () => {
     const element = new StringElement('hello');
     element.attributes.set('default', new StringElement('moin'));
-    element.attributes.set('samples', new ArrayElement(
-      new StringElement('zdravicko')
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new StringElement('zdravicko'),
+    ]));
     const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal(['hello', 'content']);
@@ -450,9 +450,9 @@ describe('valueOf EnumElement', () => {
       new StringElement(),
     ]);
     element.attributes.set('default', new EnumElement('moin'));
-    element.attributes.set('samples', new ArrayElement(
-      new EnumElement('zdravicko')
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new EnumElement('zdravicko'),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.equal('hello');
@@ -555,9 +555,9 @@ describe('valueOf EnumElement with source', () => {
       new StringElement(),
     ]);
     element.attributes.set('default', new EnumElement('moin'));
-    element.attributes.set('samples', new ArrayElement(
-      new EnumElement(new EnumElement('zdravicko'))
-    )); const value = element.valueOf({ source: true });
+    element.attributes.set('samples', new ArrayElement([
+      new EnumElement(new EnumElement('zdravicko')),
+    ])); const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal(['hello', 'content']);
   });
@@ -673,9 +673,9 @@ describe('valueOf ArrayElement', () => {
   it('prefers content over default and samples', () => {
     const element = new ArrayElement([1, 2, 3]);
     element.attributes.set('default', new ArrayElement([4, 2]));
-    element.attributes.set('samples', new ArrayElement(
-      new ArrayElement([2, 'hello'])
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new ArrayElement([2, 'hello']),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.deep.equal([1, 2, 3]);
@@ -765,9 +765,9 @@ describe('valueOf ArrayElement with source', () => {
   it('prefers content over default and samples', () => {
     const element = new ArrayElement([1, 2, 3]);
     element.attributes.set('default', new ArrayElement([4, 2]));
-    element.attributes.set('samples', new ArrayElement(
-      new ArrayElement([2, 'hello'])
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new ArrayElement([2, 'hello']),
+    ]));
     const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal([[1, 2, 3], 'content']);
@@ -922,9 +922,9 @@ describe('valueOf ObjectElement', () => {
   it('prefers content over default and samples', () => {
     const element = new ObjectElement({ abc: 3, c: 4 });
     element.attributes.set('default', new ObjectElement({ gaga: 'bing' }));
-    element.attributes.set('samples', new ArrayElement(
-      new ObjectElement({ a: 3 })
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new ObjectElement({ a: 3 }),
+    ]));
     const value = element.valueOf();
 
     expect(value).to.deep.equal({ abc: 3, c: 4 });
@@ -1071,9 +1071,9 @@ describe('valueOf ObjectElement with source', () => {
   it('prefers content over default and samples', () => {
     const element = new ObjectElement({ abc: 3, c: 4 });
     element.attributes.set('default', new ObjectElement({ gaga: 'bing' }));
-    element.attributes.set('samples', new ArrayElement(
-      new ObjectElement({ a: 3 })
-    ));
+    element.attributes.set('samples', new ArrayElement([
+      new ObjectElement({ a: 3 }),
+    ]));
     const value = element.valueOf({ source: true });
 
     expect(value).to.deep.equal([{ abc: 3, c: 4 }, 'content']);


### PR DESCRIPTION
In API Blueprint, the "value" of a type definition takes presidence over samples and defaults. For example take the following:

```apib
+ tags: one (array)
    + Sample
        + 1
        + 2
        + 3
```

-/-

We treat the followign JSON Schema (OAS Schema) roughly equivilent (as fixed-type):

```json
{
  "type": "array",
  "items": {
    "type": "string",
    "examples": ["one"]
  },
  "examples": [
    ["1", "2", "3"]
  ]
}
```

-/-

```json
{
  "element": "array",
  "attributes": {
    "samples": {
      "element": "array",
      "content": [
        {
          "element": "array",
          "content": [
            {
              "element": "string",
              "content": "1"
            },
            {
              "element": "string",
              "content": "2"
            },
            {
              "element": "string",
              "content": "3"
            }
          ]
        }
      ]
    }
  },
  "content": [
    {
      "element": "string",
      "content": "one"
    }
  ]
}
```

The above describes an array, with the value of an array containing `one` and an example `1`, `2`, and `3`. When retiving a value from an element, the value is preferred over samples and default. If a value is not present in the above array then it would fall back to samples and then default before generating an empty value.

This behaviour leads to a less ideal scenario where an empty value (such as primitive which does not contain its own value/samples/default) may produce an empty value disregarding samples or default. Such as with the following:

```apib
+ tags (array[string])
    + Sample
        + 1
        + 2
        + 3
```

-/-

We treat the followign JSON Schema (OAS Schema) roughly equivilent (as fixed-type):

```json
{
  "type": "array",
  "items": {
    "type": "string"
  },
  "examples": [
    ["1", "2", "3"]
  ]
}
```

Which manifests itself as a bug in https://github.com/apiaryio/dredd/issues/1796

-/-

```json
{
  "element": "array",
  "attributes": {
    "samples": {
      "element": "array",
      "content": [
        {
          "element": "array",
          "content": [
            {
              "element": "string",
              "content": "1"
            },
            {
              "element": "string",
              "content": "2"
            },
            {
              "element": "string",
              "content": "3"
            }
          ]
        }
      ]
    }
  },
  "content": [
    {
      "element": "string"
    }
  ]
}
```

The `valueOf` method would consider the array element is not empty, and then solely use the content elements to determine a value disregarding the samples. The change proposed here make it so that if the array contains primitive elements such as string, number or boolean which do not have a value of their own (or samples/default), then we will consider samples/defaults of the outter array before producing a value.

Before the above would result in `[""]` as a value because the value of a `StringElement` without value/samples/default/nullable ends up as an empty string `""` and thus is used to compute the value of the item in an array.

---

The first commit here is another problem I realised with the existing tests using incorrect samples definition. In API Elements the ArrayElement's content should contain an array, the existing code placed the sample value directly in array element's content which is incorrect form for an ArrayElement. It happens to be that these tests contain the sample values to ensure that the sample values are ignored and the content is not used thus they do affect test status.