### PR TITLE
Switch to .mocharc

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,2 @@
+---
+recursive: true

--- a/packages/api-elements/test/mocha.opts
+++ b/packages/api-elements/test/mocha.opts
@@ -1,1 +1,0 @@
---recursive

--- a/packages/openapi3-parser/test/mocha.opts
+++ b/packages/openapi3-parser/test/mocha.opts
@@ -1,1 +1,0 @@
---recursive


### PR DESCRIPTION
Mocha has deprecated mocha.opts and running some of the tests results in a warning:

    (node:93714) DeprecationWarning: Configuration via mocha.opts is DEPRECATED and will be removed from a future version of Mocha. Use RC files or package.json instead.

We can go ahead and move to this sooner, and that is one step in upgrading mocha (https://github.com/apiaryio/api-elements.js/pull/484).