### PR TITLE
Only emit a single warning per warning type (with identical message)

### DIFF
--- a/packages/openapi3-parser/lib/parser.js
+++ b/packages/openapi3-parser/lib/parser.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+
 const R = require('ramda');
 const parseYAML = require('./parser/parseYAML');
 
@@ -9,12 +11,81 @@ const parseOpenAPIObject = require('./parser/oas/parseOpenAPIObject');
 
 const isObjectOrAnnotation = R.either(isObject, isAnnotation);
 
+const recurseSkippingAnnotations = R.curry((visitor, e) => {
+  if (isAnnotation(e)) {
+    return e;
+  }
+  if (e) {
+    if (!e.element) {
+      return e;
+    }
+
+    visitor(e);
+
+    if (e._attributes) {
+      e.attributes.forEach((value, key, member) => {
+        recurseSkippingAnnotations(visitor, member);
+      });
+    }
+    if (e._meta) {
+      e.meta.forEach((value, key, member) => {
+        recurseSkippingAnnotations(visitor, member);
+      });
+    }
+    if (e.content) {
+      if (Array.isArray(e.content)) {
+        e.content.forEach((value) => {
+          recurseSkippingAnnotations(visitor, value);
+        });
+      }
+      if (e.content.key) {
+        recurseSkippingAnnotations(visitor, e.content.key);
+        if (e.content.value) {
+          recurseSkippingAnnotations(visitor, e.content.value);
+        }
+      }
+      if (e.content.element) {
+        recurseSkippingAnnotations(visitor, e.content);
+      }
+    }
+  }
+  return e;
+});
+
+function removeSourceMap(e) {
+  if (e._attributes) {
+    e.attributes.remove('sourceMap');
+  }
+}
+
+function removeColumnLine(result) {
+  if (result._attributes) {
+    const sourceMaps = result.attributes.get('sourceMap');
+    if (sourceMaps) {
+      sourceMaps.content.forEach((sourceMap) => {
+        sourceMap.content.forEach((sourcePoint) => {
+          sourcePoint.content.forEach((sourceCoordinate) => {
+            if (sourceCoordinate._attributes) {
+              sourceCoordinate.attributes.remove('line');
+              sourceCoordinate.attributes.remove('column');
+            }
+          });
+        });
+      });
+    }
+  }
+}
+
+const filterColumnLine = recurseSkippingAnnotations(removeColumnLine);
+const filterSourceMaps = recurseSkippingAnnotations(removeSourceMap);
+
 function parse(source, context) {
   const document = parseYAML(source, context);
 
   const parseDocument = pipeParseResult(context.namespace,
     R.unless(isObjectOrAnnotation, createError(context.namespace, 'Source document is not an object')),
-    R.unless(isAnnotation, parseOpenAPIObject(context)));
+    R.unless(isAnnotation, parseOpenAPIObject(context)),
+    context.options.generateSourceMap ? filterColumnLine : filterSourceMaps);
 
   return R.chain(parseDocument, document);
 }

--- a/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 const R = require('ramda');
 
 const {
@@ -30,74 +28,6 @@ const unsupportedKeys = ['tags', 'externalDocs'];
  * @private
  */
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
-
-const recurseSkippingAnnotations = R.curry((visitor, e) => {
-  if (isAnnotation(e)) {
-    return e;
-  }
-  if (e) {
-    if (!e.element) {
-      return e;
-    }
-
-    visitor(e);
-
-    if (e._attributes) {
-      e.attributes.forEach((value, key, member) => {
-        recurseSkippingAnnotations(visitor, member);
-      });
-    }
-    if (e._meta) {
-      e.meta.forEach((value, key, member) => {
-        recurseSkippingAnnotations(visitor, member);
-      });
-    }
-    if (e.content) {
-      if (Array.isArray(e.content)) {
-        e.content.forEach((value) => {
-          recurseSkippingAnnotations(visitor, value);
-        });
-      }
-      if (e.content.key) {
-        recurseSkippingAnnotations(visitor, e.content.key);
-        if (e.content.value) {
-          recurseSkippingAnnotations(visitor, e.content.value);
-        }
-      }
-      if (e.content.element) {
-        recurseSkippingAnnotations(visitor, e.content);
-      }
-    }
-  }
-  return e;
-});
-
-function removeSourceMap(e) {
-  if (e._attributes) {
-    e.attributes.remove('sourceMap');
-  }
-}
-
-function removeColumnLine(result) {
-  if (result._attributes) {
-    const sourceMaps = result.attributes.get('sourceMap');
-    if (sourceMaps) {
-      sourceMaps.content.forEach((sourceMap) => {
-        sourceMap.content.forEach((sourcePoint) => {
-          sourcePoint.content.forEach((sourceCoordinate) => {
-            if (sourceCoordinate._attributes) {
-              sourceCoordinate.attributes.remove('line');
-              sourceCoordinate.attributes.remove('column');
-            }
-          });
-        });
-      });
-    }
-  }
-}
-
-const filterColumnLine = recurseSkippingAnnotations(removeColumnLine);
-const filterSourceMaps = recurseSkippingAnnotations(removeSourceMap);
 
 function parseOASObject(context, object) {
   const { namespace } = context;
@@ -183,10 +113,7 @@ function parseOASObject(context, object) {
       return api;
     });
 
-  if (context.options.generateSourceMap) {
-    return filterColumnLine(parseOASObject(object));
-  }
-  return filterSourceMaps(parseOASObject(object));
+  return parseOASObject(object);
 }
 
 module.exports = R.curry(parseOASObject);

--- a/packages/openapi3-parser/lib/predicates.js
+++ b/packages/openapi3-parser/lib/predicates.js
@@ -1,5 +1,22 @@
 const R = require('ramda');
 
+const hasClass = R.curry((cls, element) => {
+  // eslint-disable-next-line no-underscore-dangle
+  if (element._meta === undefined) {
+    // accessing meta will create and attach empty ObjectElement
+    // which we can avoid by checking `_meta`.
+    // We do not want to mutate the provided element.
+    return false;
+  }
+
+  const classes = element.meta.get('classes');
+  if (classes === undefined) {
+    return false;
+  }
+
+  return classes.includes(cls);
+});
+
 /**
  * @module predicates
  * @private
@@ -14,6 +31,7 @@ const isString = element => element.element === 'string';
 const isBoolean = element => element.element === 'boolean';
 const isNull = element => element.element === 'null';
 const isDataStructure = element => element.element === 'dataStructure';
+const isWarningAnnotation = R.both(isAnnotation, hasClass('warning'));
 
 // Member
 
@@ -69,6 +87,7 @@ module.exports = {
   isBoolean,
   isNull,
   isDataStructure,
+  isWarningAnnotation,
 
   hasKey: R.curry(hasKey),
   hasValue: R.curry(hasValue),

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.json
@@ -934,7 +934,7 @@
           ]
         }
       },
-      "content": "'Operation Object' contains unsupported key 'tags'"
+      "content": "'Operation Object' contains unsupported key 'tags' (3 occurances)"
     },
     {
       "element": "annotation",
@@ -994,7 +994,7 @@
           ]
         }
       },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
+      "content": "'Parameter Object' contains unsupported key 'schema' (2 occurances)"
     },
     {
       "element": "annotation",
@@ -1144,186 +1144,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 45
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 7
-                        }
-                      },
-                      "content": 1083
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 45
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 4
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1504
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 15
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 67
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 7
-                        }
-                      },
-                      "content": 1620
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 67
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 4
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 92
                         },
                         "column": {
@@ -1354,67 +1174,7 @@
           ]
         }
       },
-      "content": "'Schema Object' contains unsupported key 'format'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 109
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 2506
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 109
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 17
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Schema Object' contains unsupported key 'format'"
+      "content": "'Schema Object' contains unsupported key 'format' (2 occurances)"
     }
   ]
 }

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -1884,7 +1884,7 @@
           ]
         }
       },
-      "content": "'Operation Object' contains unsupported key 'tags'"
+      "content": "'Operation Object' contains unsupported key 'tags' (3 occurances)"
     },
     {
       "element": "annotation",
@@ -1944,7 +1944,7 @@
           ]
         }
       },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
+      "content": "'Parameter Object' contains unsupported key 'schema' (2 occurances)"
     },
     {
       "element": "annotation",
@@ -2094,186 +2094,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 45
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 7
-                        }
-                      },
-                      "content": 1083
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 45
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 4
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 9
-                        }
-                      },
-                      "content": 1504
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 62
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 15
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Parameter Object' contains unsupported key 'schema'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 67
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 7
-                        }
-                      },
-                      "content": 1620
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 67
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 4
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Operation Object' contains unsupported key 'tags'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 92
                         },
                         "column": {
@@ -2304,67 +2124,7 @@
           ]
         }
       },
-      "content": "'Schema Object' contains unsupported key 'format'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 109
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 2506
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 109
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 17
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Schema Object' contains unsupported key 'format'"
+      "content": "'Schema Object' contains unsupported key 'format' (2 occurances)"
     }
   ]
 }


### PR DESCRIPTION
This change introduces a limit of 1 warning per warning type (a warning with an identical message). Some documents which use unsupported features many times, or use produce other mistakes multiple times result in usability problems due to other tooling, editor integrations etc falling down on processing multiple thousands of warnings. This is a suboptimal loss of information, but I do not see a better solution (I welcome anyone challenging the ideas around this here). I could tweak some of the behaviour slightly, impose higher warning count, and even separate limits to the unsupported key warnings.

The goal is to convert the following output (exerpt from my reproduction document):

```
...
warning: 'Schema Object' contains unsupported key 'format' - line 77599
warning: 'Schema Object' contains unsupported key 'format' - line 77605
warning: 'Schema Object' contains unsupported key 'format' - line 77609
warning: 'Schema Object' contains unsupported key 'format' - line 77616
warning: 'Schema Object' contains unsupported key 'format' - line 77620
warning: 'Schema Object' contains unsupported key 'format' - line 77627
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77628
warning: 'Schema Object' contains unsupported key 'format' - line 77636
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77637
warning: 'Schema Object' contains unsupported key 'format' - line 77672
warning: 'Schema Object' contains unsupported key 'format' - line 77676
warning: 'Schema Object' contains unsupported key 'format' - line 77680
warning: 'Schema Object' contains unsupported key 'format' - line 77684
warning: 'Schema Object' contains unsupported key 'format' - line 77688
warning: 'Schema Object' contains unsupported key 'format' - line 77695
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77696
warning: 'Schema Object' contains unsupported key 'format' - line 77709
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77710
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77716
warning: 'Schema Object' contains unsupported key 'format' - line 77731
warning: 'Schema Object' contains unsupported key 'format' - line 77735
warning: 'Schema Object' contains unsupported key 'format' - line 77739
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77740
warning: 'Schema Object' contains unsupported key 'format' - line 77744
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77745
warning: 'Schema Object' contains unsupported key 'format' - line 77749
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77750
warning: 'Schema Object' contains unsupported key 'format' - line 77760
warning: 'Schema Object' contains unsupported key 'format' - line 77764
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77765
warning: 'Schema Object' contains unsupported key 'format' - line 77769
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77773
warning: 'Schema Object' contains unsupported key 'format' - line 77784
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77785
warning: 'Schema Object' contains unsupported key 'format' - line 77798
warning: 'Schema Object' contains unsupported key 'readOnly' - line 77799
...
```

Into a more condensed form:

```
warning: 'OpenAPI Object' contains unsupported key 'tags' - line 7
warning: 'Operation Object' contains unsupported key 'tags' (1236 occurances) - line 662
warning: 'Request Body Object' contains unsupported key 'required' (408 occurances) - line 707
warning: 'Schema Object' contains unsupported key 'format' (3851 occurances) - line 763
warning: 'Parameter Object' contains unsupported key 'schema' (1156 occurances) - line 788
warning: 'Media Type Object' media type '*/*' is invalid (17 occurances) - line 1396
warning: 'Media Type Object' 'examples' only one example is supported, other examples have been ignored (237 occurances)
warning: 'Example Object' contains unsupported key 'summary' (537 occurances) - line 1574
warning: 'Example Object' contains unsupported key 'description' (537 occurances) - line 1575
warning: 'Schema Object' 'type' must be either boolean, object, array, number, string, integer (61 occurances) - line 2042
warning: 'Schema Object' contains unsupported key 'additionalProperties' - line 17335
warning: 'Parameter Object' contains unsupported key 'content' - line 25913
warning: 'Schema Object' contains unsupported key 'readOnly' (909 occurances) - line 45314
warning: 'Schema Object' contains unsupported key 'uniqueItems' (2 occurances) - line 45373
warning: 'Schema Object' contains unsupported key 'writeOnly' (11 occurances) - line 46528
warning: 'Schema Object' contains unsupported key 'maxLength' (124 occurances) - line 48129
warning: 'Schema Object' contains unsupported key 'minLength' (97 occurances) - line 48130
warning: 'Schema Object' contains unsupported key 'maximum' (2 occurances) - line 49077
warning: 'Schema Object' contains unsupported key 'minimum' (2 occurances) - line 49078
warning: 'Schema Object' contains unsupported key 'xml' (29 occurances) - line 60661
```

Originally, I was thinking about only doing this for the unsupported key warnings. However with the document I am testing I saw multiple hundread occurances for other warnings too and thus doesn't really solve the problem.

This brings a significant improvement to processing with fury cli (since it loops over each annotation). There will be other improvements to various aspects of handling the document (serialising API Elements to JSON, deserialising, converting to DOMs and such).

```
$ time npx fury document.yaml /dev/null 2> warnings.master
       59.58 real        55.41 user         3.56 sys

$ time npx fury document.yaml /dev/null 2> warnings.712fb908
       12.18 real        13.89 user         0.57 sys
```

```
$ wc warnings.*
      20     248    1823 warnings.712fb908
    9219   94183  687418 warnings.master
    9239   94431  689241 total
```

Originally I was trying to approach this differently to prevent creating the elements upfront (in the branch [kylef/oas-annotations](https://github.com/apiaryio/api-elements.js/compare/kylef/oas-annotations?expand=1), however this approach touched all annotation handling, and comes with some rough edges (such as `createWarning` could return empty ParseResult etc).