### PR TITLE
Respect generateMessageBody and generateMessageBodySchema in the API Blueprint adapter

### DIFF
--- a/packages/apib-parser/CHANGELOG.md
+++ b/packages/apib-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # API Elements: API Blueprint Parser Changelog
 
+## Master
+
+### Enhancements
+
+- The parser can now be configured to disable generation of example message
+  bodies and message body schemas by providing the adapter options
+  `generateMessageBody` and/or `generateMessageBodySchema` as `false` during
+  parse.
+
 ## 0.20.0 (2020-06-12)
 
 The package has been updated for compatibility with `@apielements/core`.

--- a/packages/apib-parser/lib/adapter.js
+++ b/packages/apib-parser/lib/adapter.js
@@ -31,9 +31,14 @@ function validate({ source, requireBlueprintName }) {
 /*
  * Parse an API Blueprint into refract elements.
  */
-function parse({ source, generateSourceMap, requireBlueprintName }) {
+function parse({
+  source, generateSourceMap, generateMessageBody, generateMessageBodySchema,
+  requireBlueprintName,
+}) {
   const options = {
     exportSourcemap: !!generateSourceMap,
+    generateMessageBody,
+    generateMessageBodySchema,
     requireBlueprintName,
   };
 

--- a/packages/apib-parser/test/adapter-test.js
+++ b/packages/apib-parser/test/adapter-test.js
@@ -9,6 +9,14 @@ const adapter = require('../lib/adapter');
 const fury = new Fury();
 fury.use(adapter);
 
+const source = `
+# GET /
++ Response 200 (application/json)
+    + Attributes
+        + message: Hello World
+`;
+
+
 describe('API Blueprint parser adapter', () => {
   context('detection', () => {
     it('detects FORMAT: 1A', () => {
@@ -28,7 +36,6 @@ describe('API Blueprint parser adapter', () => {
     let result;
 
     before((done) => {
-      const source = 'FORMAT: 1A\n# My API\n## Foo [/foo]\n';
       fury.parse({ source }, (err, output) => {
         if (err) {
           return done(err);
@@ -59,6 +66,100 @@ describe('API Blueprint parser adapter', () => {
       expect(parseResult.length).to.equal(1);
       expect(parseResult.errors.length).to.equal(1);
       done();
+    });
+  });
+
+  describe('generateMessageBody option', () => {
+    it('should generate message bodies when generateMessageBody is not set', (done) => {
+      fury.parse({ source }, (error, parseResult) => {
+        expect(error).to.be.null;
+
+        const resource = parseResult.api.resources.get(0);
+        const transaction = resource.transitions.get(0).transactions.get(0);
+        const { response } = transaction;
+
+        expect(response.messageBody).to.be.instanceof(fury.minim.elements.Asset);
+        expect(response.messageBodySchema).to.be.instanceof(fury.minim.elements.Asset);
+
+        done();
+      });
+    });
+
+    it('should generate message bodies when generateMessageBody is enabled', (done) => {
+      fury.parse({ source, adapterOptions: { generateMessageBody: true } }, (error, parseResult) => {
+        expect(error).to.be.null;
+
+        const resource = parseResult.api.resources.get(0);
+        const transaction = resource.transitions.get(0).transactions.get(0);
+        const { response } = transaction;
+
+        expect(response.messageBody).to.be.instanceof(fury.minim.elements.Asset);
+        expect(response.messageBodySchema).to.be.instanceof(fury.minim.elements.Asset);
+
+        done();
+      });
+    });
+
+    it('should not generate message bodies when generateMessageBody is disabled', (done) => {
+      fury.parse({ source, adapterOptions: { generateMessageBody: false } }, (error, parseResult) => {
+        expect(error).to.be.null;
+
+        const resource = parseResult.api.resources.get(0);
+        const transaction = resource.transitions.get(0).transactions.get(0);
+        const { response } = transaction;
+
+        expect(response.messageBody).to.be.undefined;
+        expect(response.messageBodySchema).to.be.instanceof(fury.minim.elements.Asset);
+
+        done();
+      });
+    });
+  });
+
+  describe('generateMessageBodySchema option', () => {
+    it('should generate message bodies when generateMessageBodySchema is not set', (done) => {
+      fury.parse({ source }, (error, parseResult) => {
+        expect(error).to.be.null;
+
+        const resource = parseResult.api.resources.get(0);
+        const transaction = resource.transitions.get(0).transactions.get(0);
+        const { response } = transaction;
+
+        expect(response.messageBody).to.be.instanceof(fury.minim.elements.Asset);
+        expect(response.messageBodySchema).to.be.instanceof(fury.minim.elements.Asset);
+
+        done();
+      });
+    });
+
+    it('should generate message bodies when generateMessageBodySchema is enabled', (done) => {
+      fury.parse({ source, adapterOptions: { generateMessageBodySchema: true } }, (error, parseResult) => {
+        expect(error).to.be.null;
+
+        const resource = parseResult.api.resources.get(0);
+        const transaction = resource.transitions.get(0).transactions.get(0);
+        const { response } = transaction;
+
+        expect(response.messageBody).to.be.instanceof(fury.minim.elements.Asset);
+        expect(response.messageBodySchema).to.be.instanceof(fury.minim.elements.Asset);
+
+        done();
+      });
+    });
+
+    it('should not generate message bodies when generateMessageBodySchema is disabled', (done) => {
+      fury.parse({ source, adapterOptions: { generateMessageBodySchema: false } }, (error, parseResult) => {
+        expect(error).to.be.null;
+
+        const resource = parseResult.api.resources.get(0);
+        const transaction = resource.transitions.get(0).transactions.get(0);
+        const { response } = transaction;
+
+        expect(response.messageBody).to.be.instanceof(fury.minim.elements.Asset);
+        expect(response.messageBodySchema).to.be.undefined;
+
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
The OpenAPI 2, OpenAPI 3 and remote adapters already support these options. Support in API Blueprint has been forgotten, the underlying parser supports them, this is just a matter of passing the options down.