### PR TITLE
Disallow non-string text body example in OpenAPI 3

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Return a warning when parsing a document with a 'Media Type Object'
+  using a text based media type when the example value is not a string.
+  Previously an invalid asset element was created which contained non-string
+  content.
+
 ## 0.14.2 (2020-07-20)
 
 ### Bug Fixes

--- a/packages/openapi3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseMediaTypeObject-test.js
@@ -143,6 +143,22 @@ describe('Media Type Object', () => {
         "'Media Type Object' 'example' is not supported for media type 'application/plist'"
       );
     });
+
+    it('warns for non-string example with text type', () => {
+      const mediaType = new namespace.elements.Member('text/plain', {
+        example: { message: 'Hello World' },
+      });
+
+      const parseResult = parse(context, messageBodyClass, mediaType);
+
+      expect(parseResult).to.contain.warning(
+        "'Media Type Object' 'example' should be a string for media type 'text/plain'"
+      );
+
+      const message = parseResult.get(0);
+      expect(message).to.be.instanceof(messageBodyClass);
+      expect(message.messageBody).to.be.undefined;
+    });
   });
 
   describe('#examples', () => {


### PR DESCRIPTION
Discovered by @patricksmms that the included OpenAPI 3 document was emitting an invalid asset element. The asset element contained an object contents instead of a string as per API Elements spec. Asset element is a string element.

I've altered the parser behaviour so that it will warn user that the example is not a string and should be for text based media types. We will not produce a messageBody asset in this case, as we don't know how to serialise non-strings as text for text based media types. The OpenAPI 3 spec states the following for the example field:

> Example of the media type. The example object SHOULD be in the correct format as specified by the media type.

```yaml
openapi: 3.0.1
info:
  title: My API
  version: '2.0'
paths:
  /questions:
    post:
      summary: Description of the resource
      requestBody:
        content:
          application/json:
            schema:
              type: object
            example:
              message: hello world
      responses:
        '200':
          description: Created
          content:
            text/plain:
              schema:
                type: object
              example:
                message: hello world
```

`$ npx fury 526.yaml | jq .content[0].content[0].content[0].content[0].content[1].content[0]`:

```json
{
  "element": "asset",
  "meta": {
    "classes": {
      "element": "array",
      "content": [
        {
          "element": "string",
          "content": "messageBody"
        }
      ]
    }
  },
  "attributes": {
    "contentType": {
      "element": "string",
      "content": "text/plain"
    }
  },
  "content": [
    {
      "element": "member",
      "content": {
        "key": {
          "element": "string",
          "content": "message"
        },
        "value": {
          "element": "string",
          "content": "hello world"
        }
      }
    }
  ]
}
``