### PR TITLE
fix(oas3): attach description to hrefVariables' member

### DIFF
--- a/packages/openapi3-parser/lib/parser/oas/parseServerVariableObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseServerVariableObject.js
@@ -50,7 +50,7 @@ const parseMember = context => R.cond([
  * @returns ParseResult<Member>
  * @private
  */
-const parseServerVariableObject = (context, element) => pipeParseResult(context.namespace,
+const parseServerVariableObject = (context, element, variableName) => pipeParseResult(context.namespace,
   R.unless(isObject, createWarning(context.namespace, `'${name}' is not an object`)),
   parseObject(context, name, parseMember(context), requiredKeys, [], true),
   (object) => {
@@ -58,11 +58,13 @@ const parseServerVariableObject = (context, element) => pipeParseResult(context.
 
     variable.attributes.set('default', object.get('default'));
 
+    const member = new context.namespace.elements.Member(variableName, variable);
+
     if (object.hasKey('description')) {
-      variable.description = object.getValue('description');
+      member.description = object.getValue('description');
     }
 
-    return variable;
+    return member;
   })(element);
 
 module.exports = R.curry(parseServerVariableObject);

--- a/packages/openapi3-parser/lib/parser/parseMap.js
+++ b/packages/openapi3-parser/lib/parser/parseMap.js
@@ -1,10 +1,12 @@
 const R = require('ramda');
 const pipeParseResult = require('../pipeParseResult');
 const {
-  isObject, getValue, isAnnotation,
+  isObject, getValue, isAnnotation, isMember,
 } = require('../predicates');
 const { createWarning } = require('./annotations');
 const parseObject = require('./parseObject');
+
+const isAnnotationOrMember = R.anyPass([isAnnotation, isMember]);
 
 const validateMapValueIsObject = (namespace, name, key) => R.unless(R.pipe(getValue, isObject), createWarning(namespace, `'${name}' '${key}' is not an object`));
 
@@ -15,8 +17,8 @@ const parseMapMember = R.curry((context, parser, member) => {
   const Member = R.constructN(2, context.namespace.elements.Member)(member.key);
 
   const parseResult = R.map(
-    R.unless(isAnnotation, Member),
-    parser(context, member.value)
+    R.unless(isAnnotationOrMember, Member),
+    parser(context, member.value, member.key)
   );
 
   if (isParseResultEmpty(parseResult)) {

--- a/packages/openapi3-parser/test/unit/parser/oas/parseServerObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseServerObject-test.js
@@ -137,7 +137,7 @@ describe('#parseServerObject', () => {
       expect(firstHrefVariable).to.be.instanceof(namespace.elements.Member);
       expect(firstHrefVariable.key.toValue()).to.equal('username');
       expect(firstHrefVariable.value.attributes.get('default').toValue()).to.equal('Mario');
-      expect(firstHrefVariable.value.description.toValue()).to.equal('API user name');
+      expect(firstHrefVariable.description.toValue()).to.equal('API user name');
 
       expect(secondHrefVariable).to.be.instanceof(namespace.elements.Member);
       expect(secondHrefVariable.key.toValue()).to.equal('version');
@@ -196,7 +196,7 @@ describe('#parseServerObject', () => {
       expect(firstHrefVariable).to.be.instanceof(namespace.elements.Member);
       expect(firstHrefVariable.key.toValue()).to.equal('username');
       expect(firstHrefVariable.value.attributes.get('default').toValue()).to.equal('Mario');
-      expect(firstHrefVariable.value.description.toValue()).to.equal('API user name');
+      expect(firstHrefVariable.description.toValue()).to.equal('API user name');
 
       expect(secondHrefVariable).to.be.instanceof(namespace.elements.Member);
       expect(secondHrefVariable.key.toValue()).to.equal('version');
@@ -234,7 +234,7 @@ describe('#parseServerObject', () => {
       expect(firstHrefVariable).to.be.instanceof(namespace.elements.Member);
       expect(firstHrefVariable.key.toValue()).to.equal('username');
       expect(firstHrefVariable.value.attributes.get('default').toValue()).to.equal('Mario');
-      expect(firstHrefVariable.value.description.toValue()).to.equal('API user name');
+      expect(firstHrefVariable.description.toValue()).to.equal('API user name');
 
       expect(secondHrefVariable).to.be.instanceof(namespace.elements.Member);
       expect(secondHrefVariable.key.toValue()).to.equal('version');

--- a/packages/openapi3-parser/test/unit/parser/oas/parseServerVariableObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseServerVariableObject-test.js
@@ -15,7 +15,7 @@ describe('#parseServerVariableObject', () => {
   it('provides warning when server variable is non-object', () => {
     const serverVariable = new namespace.elements.String();
 
-    const parseResult = parse(context)(serverVariable);
+    const parseResult = parse(context)(serverVariable, 'name');
 
     expect(parseResult.length).to.equal(1);
     expect(parseResult).to.contain.warning("'Server Variable Object' is not an object");
@@ -26,7 +26,7 @@ describe('#parseServerVariableObject', () => {
       const serverVariable = new namespace.elements.Object({
       });
 
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
       expect(parseResult.length).to.equal(1);
       expect(parseResult).to.contain.warning("'Server Variable Object' is missing required property 'default'");
     });
@@ -37,7 +37,7 @@ describe('#parseServerVariableObject', () => {
         description: 'API user name',
       });
 
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
       expect(parseResult).to.contain.error("'Server Variable Object' 'default' is not a string");
     });
 
@@ -46,12 +46,13 @@ describe('#parseServerVariableObject', () => {
         default: 'Mario',
       });
 
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
       expect(parseResult).to.not.contain.annotations;
 
       const member = parseResult.get(0);
-      expect(member).to.be.instanceof(namespace.elements.String);
-      expect(member.attributes.get('default').toValue()).to.be.equal('Mario');
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.String);
+      expect(member.value.attributes.get('default').toValue()).to.be.equal('Mario');
     });
   });
 
@@ -62,22 +63,24 @@ describe('#parseServerVariableObject', () => {
         description: 1234,
       });
 
-      const parseResult = parse(context)(serverVariable);
-      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.String);
+      const parseResult = parse(context)(serverVariable, 'name');
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.Member);
+      expect(parseResult.get(0).value).to.be.instanceof(namespace.elements.String);
+      expect(parseResult.get(1)).to.be.instanceof(namespace.elements.Annotation);
       expect(parseResult).to.contain.warning("'Server Variable Object' 'description' is not a string");
     });
 
-    it('parse server variable object with description', () => {
+    it('attaches description to member', () => {
       const serverVariable = new namespace.elements.Object({
         default: 'Mario',
         description: 'API user name',
       });
 
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
       expect(parseResult).to.not.contain.annotations;
 
       const member = parseResult.get(0);
-      expect(member).to.be.instanceof(namespace.elements.String);
+      expect(member).to.be.instanceof(namespace.elements.Member);
 
       const description = member.description.toValue();
       expect(description).to.be.equal('API user name');
@@ -90,7 +93,7 @@ describe('#parseServerVariableObject', () => {
         default: 'Mario',
         enum: 1,
       });
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
 
       expect(parseResult).to.contain.warning(
         "'Server Variable Object' 'enum' is not an array"
@@ -103,13 +106,14 @@ describe('#parseServerVariableObject', () => {
         enum: ['Tony', 'Nina'],
       });
 
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
       expect(parseResult).to.not.contain.annotations;
 
-      const enumElement = parseResult.get(0);
-      expect(enumElement).to.be.instanceof(namespace.elements.Enum);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Enum);
 
-      const { enumerations } = enumElement;
+      const { enumerations } = member.value;
       expect(enumerations).to.be.instanceof(namespace.elements.Array);
       expect(enumerations.length).to.equal(2);
       expect(enumerations.toValue()).to.deep.equal(['Tony', 'Nina']);
@@ -125,17 +129,18 @@ describe('#parseServerVariableObject', () => {
         enum: ['Tony', 1, 'Nina', true],
       });
 
-      const parseResult = parse(context)(serverVariable);
+      const parseResult = parse(context)(serverVariable, 'name');
       expect(parseResult).to.contain.annotations;
 
       const { annotations } = parseResult;
       expect(annotations.length).to.equal(2);
       expect(annotations.get(0).toValue()).to.deep.equal("'Server Variable Object' 'enum' array value is not a string");
 
-      const enumElement = parseResult.get(0);
-      expect(enumElement).to.be.instanceof(namespace.elements.Enum);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Enum);
 
-      const { enumerations } = enumElement;
+      const { enumerations } = member.value;
       expect(enumerations).to.be.instanceof(namespace.elements.Array);
       expect(enumerations.length).to.equal(2);
       expect(enumerations.toValue()).to.deep.equal(['Tony', 'Nina']);

--- a/packages/openapi3-parser/test/unit/parser/parseMap-test.js
+++ b/packages/openapi3-parser/test/unit/parser/parseMap-test.js
@@ -68,6 +68,38 @@ describe('#parseMap', () => {
     expect(member2.value.toValue()).to.be.equal('dummy');
   });
 
+  it('propagate members from parser', () => {
+    const member = new context.namespace.elements.Member('key', {
+      uno: {},
+    });
+
+    const parseToMember = (context, object, key) => pipeParseResult(
+      namespace,
+      () => {
+        const member = new context.namespace.elements.Member(key, 'dummy');
+        member.description = `${key.toValue()} description`;
+        return member;
+      }
+    )(object);
+
+    const result = parseMap(context, 'dummy', 'key', parseToMember)(member);
+
+    expect(result).to.not.contain.annotations;
+    expect(result.length).to.be.equal(1);
+
+    const members = result.get(0);
+
+    expect(members.length).to.be.equal(1);
+
+    const member1 = members.content[0];
+    expect(member1).to.be.instanceof(context.namespace.elements.Member);
+    expect(member1.key.toValue()).to.be.equal('uno');
+    expect(member1.value).to.be.instanceof(context.namespace.elements.String);
+    expect(member1.value.toValue()).to.be.equal('dummy');
+    expect(member1.description).to.be.instanceof(context.namespace.elements.String);
+    expect(member1.description.toValue()).to.equal('uno description');
+  });
+
   it('propagate annotations from parser', () => {
     const member = new context.namespace.elements.Member('key', {
       uno: {},


### PR DESCRIPTION
Fix to make `hosts` category `resource` `hrefVariables` members conform to this https://github.com/apiaryio/api-elements.js/search?q=attaches+description+to+member&unscoped_q=attaches+description+to+member

