### PR TITLE
Release core + adapters

### DIFF
--- a/packages/api-elements/CHANGELOG.md
+++ b/packages/api-elements/CHANGELOG.md
@@ -1,6 +1,6 @@
 # API Elements (JavaScript) CHANGELOG
 
-## Master
+## 0.3.0 (2020-08-05)
 
 ### Bug Fixes
 

--- a/packages/api-elements/package.json
+++ b/packages/api-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-elements",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "API Elements JavaScript",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/apiaryb-parser/CHANGELOG.md
+++ b/packages/apiaryb-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # API Elements: Apiary Blueprint Parser Changelog
 
+## 0.2.1 (2020-08-05)
+
+Adds compatibility for @apielements/core 0.2.0.
+
 ## 0.2.0 (2020-06-12)
 
 The package has been updated for compatibility with `@apielements/core`.

--- a/packages/apiaryb-parser/package.json
+++ b/packages/apiaryb-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/apiaryb-parser",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "API Elements parser for deprecated Apiary Blueprint language",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -26,10 +26,10 @@
     "deckardcain": "^1.0.0"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "glob": "^7.1.2",

--- a/packages/apib-parser/CHANGELOG.md
+++ b/packages/apib-parser/CHANGELOG.md
@@ -1,6 +1,8 @@
 # API Elements: API Blueprint Parser Changelog
 
-## Master
+## 0.20.1 (2020-08-05)
+
+Adds compatibility for @apielements/core 0.2.0.
 
 ### Enhancements
 

--- a/packages/apib-parser/package.json
+++ b/packages/apib-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/apib-parser",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "API Blueprint parser for API Elements",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -27,10 +27,10 @@
     "protagonist": "^2.1.0"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "mocha": "^7.1.1"

--- a/packages/apib-serializer/CHANGELOG.md
+++ b/packages/apib-serializer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # API Elements: API Blueprint Serializer Changelog
 
+## 0.16.1 (2020-08-06)
+
+Adds compatibility for @apielements/core 0.2.0.
+
 ## 0.16.0 (2020-06-12)
 
 The package has been updated for compatibility with `@apielements/core`.

--- a/packages/apib-serializer/package.json
+++ b/packages/apib-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/apib-serializer",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "API Blueprint serializer for API Elements",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -24,10 +24,10 @@
     "nunjucks": "^3.2.0"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "glob": "^7.1.2",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API Elements: CLI Changelog
 
+## 0.10.2 (2020-08-05)
+
+This update incorporates changes from API Element Adapters:
+
+- openapi3-parser 0.15.0
+
 ## 0.10.1 (2020-06-24)
 
 This update incorporates changes from API Element Adapters:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -22,12 +22,12 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@apielements/apiaryb-parser": "^0.2.0",
-    "@apielements/apib-parser": "^0.20.0",
-    "@apielements/apib-serializer": "^0.16.0",
-    "@apielements/core": "^0.1.0",
-    "@apielements/openapi2-parser": "^0.32.0",
-    "@apielements/openapi3-parser": "^0.14.0",
+    "@apielements/apiaryb-parser": "^0.2.1",
+    "@apielements/apib-parser": "^0.20.1",
+    "@apielements/apib-serializer": "^0.16.1",
+    "@apielements/core": ">=0.1.0 <0.3.0",
+    "@apielements/openapi2-parser": "^0.32.3",
+    "@apielements/openapi3-parser": "^0.15.0",
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",
     "js-yaml": "^3.12.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API Elements: Core
 
+## 0.2.0 (2020-08-05)
+
+This package updates the version of `api-elements` being used. See
+[api-elements@0.2.0](https://github.com/apiaryio/api-elements.js/releases/tag/%40apielements%2Fcore%400.2.0)
+for more details on the contents of the change.
+
 ## 0.1.0 (2020-06-12)
 
 The package has been renamed to `@apielements/core`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "API Description SDK",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "api-elements": "^0.2.4"
+    "api-elements": "^0.3.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/packages/form-serializer/CHANGELOG.md
+++ b/packages/form-serializer/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Form Serializer Changelog
+
+## 0.1.1 (2020-08-06)
+
+Adds compatibility for @apielements/core 0.2.0.
+
+## 0.1.0
+
+Initial release

--- a/packages/form-serializer/package.json
+++ b/packages/form-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/form-serializer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Multipart/form-data serializer for API Elements",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -21,13 +21,13 @@
     "test": "mocha test"
   },
   "devDependencies": {
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
-    "@apielements/core": "^0.1.0",
     "mocha": "^7.1.1"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "dependencies": {
     "lodash": "^4.17.15"

--- a/packages/json-serializer/CHANGELOG.md
+++ b/packages/json-serializer/CHANGELOG.md
@@ -1,0 +1,9 @@
+# JSON Serializer Changelog
+
+## 0.1.1 (2020-08-06)
+
+Adds compatibility for @apielements/core 0.2.0.
+
+## 0.1.0
+
+Initial release

--- a/packages/json-serializer/package.json
+++ b/packages/json-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/json-serializer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JSON serializer for API Elements",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -21,10 +21,10 @@
     "test": "mocha test"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "mocha": "^7.1.1"

--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # API Elements: OpenAPI 2 Parser Changelog
 
+## 0.32.3 (2020-08-06)
+
+Adds compatibility for @apielements/core 0.2.0.
+
 ## 0.32.2 (2020-07-22)
 
 ### Bug Fixes

--- a/packages/openapi2-parser/package.json
+++ b/packages/openapi2-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi2-parser",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -30,10 +30,10 @@
     "z-schema": "^4.1.0"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "glob": "^7.1.2",

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,6 +1,12 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
-## Master
+## 0.15.0 (2020-08-06)
+
+### Enhancements
+
+- The parser will only emit warnings for unsupported features a single time.
+  This can dramatically increase the performance when dealing with documents
+  which use many unsupported features.
 
 ### Bug Fixes
 
@@ -8,6 +14,16 @@
   using a text based media type when the example value is not a string.
   Previously an invalid asset element was created which contained non-string
   content.
+
+- Moves the description from 'Server Object' variable values into the member
+  element which contain it for consistency.
+
+- Fixes a case where source map information for the description of a 'Server
+  Object' variable would be missing.
+
+- Prevent the generation of message body examples for text-based media types
+  when the value is not string based. A warning will now be emitted under this
+  circumstance.
 
 ## 0.14.2 (2020-07-20)
 

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -29,10 +29,10 @@
     "yaml-js": "^0.2.3"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "mocha": "^7.1.1"

--- a/packages/remote/CHANGELOG.md
+++ b/packages/remote/CHANGELOG.md
@@ -1,5 +1,9 @@
 # API Elements: Remote Adapter Changelog
 
+## 0.6.2 (2020-08-06)
+
+Adds compatibility for @apielements/core 0.2.0.
+
 ## 0.6.1 (2020-06-22)
 
 ### Bug Fixes

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/remote",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "API Elements adapter for performing actions via a remote API",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -26,10 +26,10 @@
     "deckardcain": "^1.0.0"
   },
   "peerDependencies": {
-    "@apielements/core": "^0.1.0"
+    "@apielements/core": ">=0.1.0 <0.3.0"
   },
   "devDependencies": {
-    "@apielements/core": "^0.1.0",
+    "@apielements/core": ">=0.1.0 <0.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "mocha": "^7.1.1"


### PR DESCRIPTION
- api-elements 0.2.0 -> 0.3.0 - while contains a bug fix, this may change behaviour of tooling using it and thus did minor release instead patch to be cautious.
- @apielements/core 0.2.0 - to bring in api-elements@0.3.0
- @apielements/openapi3-parser 0.14.2 -> 0.15.0 - see CHANGELOG in diff.
- @apielements/apib-parser 0.20.0 -> 0.20.1 - fixes adapter to respect generateMessageBody{,Schema} options
- all adapters + cli receive a patch release to add peer version compatibility with new core (they remain compatible with the old core too - these are API compatible)