### PR TITLE
feat(json): add indentation to serialize output

### DIFF
--- a/packages/json-serializer/CHANGELOG.md
+++ b/packages/json-serializer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JSON Serializer Changelog
 
+## 0.1.3 (2020-08-20)
+
+### Enhancements
+
+- Add indentation to the output.
+
 ## 0.1.2 (2020-08-19)
 
 ### Enhancements

--- a/packages/json-serializer/README.md
+++ b/packages/json-serializer/README.md
@@ -19,6 +19,8 @@ const api = new fury.minim.elements.Object({ name });
 const mediaType = 'application/json';
 fury.serialize({ api, mediaType }, (error, body) => {
   console.log(body);
-  // { "name": "Doe" }
+  // {
+  //   "name": "Doe"
+  // }
 });
 ```

--- a/packages/json-serializer/lib/serializeJSON.js
+++ b/packages/json-serializer/lib/serializeJSON.js
@@ -30,7 +30,7 @@ function serializeJSON(element) {
   const dataStructures = collectElementByIDs(element);
   const value = element.valueOf(undefined, dataStructures);
 
-  return JSON.stringify(value);
+  return JSON.stringify(value, null, 2);
 }
 
 module.exports = serializeJSON;

--- a/packages/json-serializer/package.json
+++ b/packages/json-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/json-serializer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JSON serializer for API Elements",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
I didn't add a parameter to set the indentation as, at least for now, there is no use case for it. Also it would require releasing the core.