### PR TITLE
Initial OpenAPI 3.1 support

### DIFF
--- a/packages/openapi3-parser/lib/context.js
+++ b/packages/openapi3-parser/lib/context.js
@@ -3,6 +3,11 @@ const State = require('./state.js');
 class Context {
   constructor(namespace, options) {
     this.namespace = namespace;
+    this.openapiVersion = {
+      major: 3,
+      minor: 0,
+      patch: 0,
+    };
     this.options = options || {};
 
     if (this.options.generateSourceMap === undefined) {

--- a/packages/openapi3-parser/lib/context.js
+++ b/packages/openapi3-parser/lib/context.js
@@ -36,6 +36,11 @@ class Context {
   hasScheme(id) {
     return this.state.hasScheme(id);
   }
+
+  // Versioning
+  isOpenAPIVersionLessThan(major, minor) {
+    return this.openapiVersion.major < major || (this.openapiVersion.major === major && this.openapiVersion.minor < minor);
+  }
 }
 
 module.exports = Context;

--- a/packages/openapi3-parser/lib/context.js
+++ b/packages/openapi3-parser/lib/context.js
@@ -41,6 +41,10 @@ class Context {
   isOpenAPIVersionLessThan(major, minor) {
     return this.openapiVersion.major < major || (this.openapiVersion.major === major && this.openapiVersion.minor < minor);
   }
+
+  isOpenAPIVersionMoreThanOrEqual(major, minor) {
+    return this.openapiVersion.major > major || (this.openapiVersion.major === major && this.openapiVersion.minor >= minor);
+  }
 }
 
 module.exports = Context;

--- a/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -38,6 +38,8 @@ function parseOASObject(context, object) {
     return new namespace.elements.ParseResult([array].concat(parseResult.annotations.elements));
   };
 
+  const isOpenAPI31OrHigher = () => context.isOpenAPIVersionMoreThanOrEqual(3, 1);
+
   const parseMember = R.cond([
     [hasKey('openapi'), parseOpenAPI(context)],
     [hasKey('servers'), R.compose(parseServersArray(context, name), getValue)],
@@ -49,6 +51,10 @@ function parseOASObject(context, object) {
     // FIXME Support exposing extensions into parse result
     [isExtension, () => new namespace.elements.ParseResult()],
 
+    [
+      R.both(hasKey('webhooks'), isOpenAPI31OrHigher),
+      createUnsupportedMemberWarning(namespace, name),
+    ],
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],
 
     // Return a warning for additional properties

--- a/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -56,7 +56,7 @@ function parseOASObject(context, object) {
   ]);
 
   const parseOASObject = pipeParseResult(namespace,
-    parseObject(context, name, parseMember, requiredKeys, ['components']),
+    parseObject(context, name, parseMember, requiredKeys, ['openapi', 'components']),
     (object) => {
       const api = object.get('info');
       const hosts = object.get('servers');

--- a/packages/openapi3-parser/lib/parser/openapi.js
+++ b/packages/openapi3-parser/lib/parser/openapi.js
@@ -21,6 +21,11 @@ function parseOpenAPI(context, openapi) {
     return new namespace.elements.ParseResult([createError(namespace, `OpenAPI version does not contain valid semantic version string '${openapi.value.toValue()}'`, openapi.value)]);
   }
 
+  /* eslint-disable no-param-reassign */
+  context.openapiVersion.major = Number(versionInfo[1]);
+  context.openapiVersion.minor = Number(versionInfo[2]);
+  context.openapiVersion.patch = Number(versionInfo[3]);
+
   if (parseInt(versionInfo[1], 10) !== supportedMajorVersion) {
     return new namespace.elements.ParseResult([createError(namespace, `Unsupported OpenAPI version '${openapi.value.toValue()}'`, openapi.value)]);
   }
@@ -28,7 +33,6 @@ function parseOpenAPI(context, openapi) {
   if (parseInt(versionInfo[2], 10) > supportedMinorVersion) {
     return new namespace.elements.ParseResult([openapi, createWarning(namespace, `Version '${openapi.value.toValue()}' is not fully supported`, openapi.value)]);
   }
-
 
   return new namespace.elements.ParseResult([openapi]);
 }

--- a/packages/openapi3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
@@ -239,6 +239,38 @@ describe('#parseOpenAPIObject', () => {
     expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'externalDocs'");
   });
 
+  it('provides warning for unsupported webhooks key in OpenAPI 3.1', () => {
+    const object = new namespace.elements.Object({
+      openapi: '3.1.0',
+      info: {
+        title: 'My API',
+        version: '1.0.0',
+      },
+      paths: {},
+      webhooks: {},
+    });
+
+    const parseResult = parse(context, object);
+
+    expect(parseResult.warnings.get(1).toValue()).to.equal("'OpenAPI Object' contains unsupported key 'webhooks'");
+  });
+
+  it('provides warning for invalid key webhooks in OpenAPI 3.0', () => {
+    const object = new namespace.elements.Object({
+      openapi: '3.0.0',
+      info: {
+        title: 'My API',
+        version: '1.0.0',
+      },
+      paths: {},
+      webhooks: {},
+    });
+
+    const parseResult = parse(context, object);
+
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains invalid key 'webhooks'");
+  });
+
   it('provides warning for invalid keys', () => {
     const object = new namespace.elements.Object({
       openapi: '3.0.0',

--- a/packages/openapi3-parser/test/unit/parser/oas/parseOperationObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseOperationObject-test.js
@@ -129,18 +129,6 @@ describe('Operation Object', () => {
     expect(parseResult).to.contain.warning("'Operation Object' contains invalid key 'invalid'");
   });
 
-  describe('missing required properties', () => {
-    it('provides error for missing responses', () => {
-      const operation = new namespace.elements.Member('get', {});
-
-      const parseResult = parse(context, path, operation);
-
-      expect(parseResult.length).to.equal(1);
-      expect(parseResult).to.contain.error("'Operation Object' is missing required property 'responses'");
-    });
-  });
-
-
   describe('#summary', () => {
     it('warns when summary is not a string', () => {
       const operation = new namespace.elements.Member('get', {
@@ -621,6 +609,26 @@ describe('Operation Object', () => {
   });
 
   describe('#responses', () => {
+    it('provides error for missing responses for OpenAPI 3.0', () => {
+      const operation = new namespace.elements.Member('get', {});
+
+      const parseResult = parse(context, path, operation);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult).to.contain.error("'Operation Object' is missing required property 'responses'");
+    });
+
+    it('does not require responses for OpenAPI >= 3.1', () => {
+      context.openapiVersion.minor = 1;
+      const operation = new namespace.elements.Member('get', {});
+
+      const parseResult = parse(context, path, operation);
+
+      expect(parseResult.length).to.equal(1);
+      const transition = parseResult.get(0);
+      expect(transition).to.be.instanceof(namespace.elements.Transition);
+    });
+
     it('returns a transition including a transaction', () => {
       const operation = new namespace.elements.Member('get', {
         responses: {

--- a/packages/openapi3-parser/test/unit/parser/openapi-test.js
+++ b/packages/openapi3-parser/test/unit/parser/openapi-test.js
@@ -63,4 +63,14 @@ describe('#parseOpenAPI', () => {
     expect(parseResult).to.contain.warning("Version '3.1.0' is not fully supported");
     expect(parseResult.get(0).value.toValue()).to.equal('3.1.0');
   });
+
+  it('adds the version to context', () => {
+    const openapi = new namespace.elements.Member('openapi', '3.1.2');
+
+    parseOpenAPI(context, openapi);
+
+    expect(context.openapiVersion.major).to.equal(3);
+    expect(context.openapiVersion.minor).to.equal(1);
+    expect(context.openapiVersion.patch).to.equal(2);
+  });
 });


### PR DESCRIPTION
These changes include initial support for some OpenAPI 3.1 changes, there's a lot more, this change is more to explore the way the parser will operate and conditionally support 3.1 features.

The following changes have been done:

> responses are no longer required to be defined under the Operation Object.
> Introduced a new top-level field - webhooks. This allows describing out-of-band webhooks that are available as part of the API.

We don't fully support `webhooks`, but with 3.1 the appropriate warning will be shown.