### PR TITLE
Fallback to https for missing schemes on HOST

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "@apielements/apib-parser": "^0.20.1",
     "@apielements/apib-serializer": "^0.16.2",
     "@apielements/core": ">=0.1.0 <0.3.0",
-    "@apielements/openapi2-parser": "^0.32.3",
+    "@apielements/openapi2-parser": "^0.32.4",
     "@apielements/openapi3-parser": "^0.15.0",
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",

--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # API Elements: OpenAPI 2 Parser Changelog
 
+## 0.32.4 (2020-10-13)
+
+### Bug Fixes
+
+- The HOST URI metadata produced from `schemes`, `host` and `basePath` will now
+  default to `https` when `schemes` is not defined. Previously a partial URI
+  without a scheme was returned.
+
 ## 0.32.3 (2020-08-06)
 
 Adds compatibility for @apielements/core 0.2.0.

--- a/packages/openapi2-parser/lib/parser.js
+++ b/packages/openapi2-parser/lib/parser.js
@@ -449,6 +449,8 @@ class Parser {
           }
 
           hostname = `${this.swagger.schemes[0]}://${hostname}`;
+        } else {
+          hostname = `https://${hostname}`;
         }
 
         const metadata = [];

--- a/packages/openapi2-parser/package.json
+++ b/packages/openapi2-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi2-parser",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "eslint": "^5.16.0",
     "glob": "^7.1.2",
     "mocha": "^7.1.1",
-    "swagger-zoo": "^3.1.3"
+    "swagger-zoo": "^3.1.4"
   },
   "engines": {
     "node": ">=8"

--- a/packages/openapi2-parser/test/fixtures/circular-example.json
+++ b/packages/openapi2-parser/test/fixtures/circular-example.json
@@ -46,7 +46,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "petstore.swagger.io"
+                  "content": "https://petstore.swagger.io"
                 }
               }
             }

--- a/packages/openapi2-parser/test/fixtures/circular-example.sourcemap.json
+++ b/packages/openapi2-parser/test/fixtures/circular-example.sourcemap.json
@@ -121,7 +121,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "petstore.swagger.io"
+                  "content": "https://petstore.swagger.io"
                 }
               }
             }

--- a/packages/openapi2-parser/test/fixtures/invalid-media-type.json
+++ b/packages/openapi2-parser/test/fixtures/invalid-media-type.json
@@ -46,7 +46,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "petstore.swagger.io"
+                  "content": "https://petstore.swagger.io"
                 }
               }
             }

--- a/packages/openapi2-parser/test/fixtures/invalid-media-type.sourcemap.json
+++ b/packages/openapi2-parser/test/fixtures/invalid-media-type.sourcemap.json
@@ -121,7 +121,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "petstore.swagger.io"
+                  "content": "https://petstore.swagger.io"
                 }
               }
             }

--- a/packages/swagger-zoo/fixtures/features/api-elements/payload-as-string.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/payload-as-string.json
@@ -46,7 +46,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "custom-instance.filter.ly"
+                  "content": "https://custom-instance.filter.ly"
                 }
               }
             }

--- a/packages/swagger-zoo/fixtures/features/api-elements/payload-as-string.sourcemap.json
+++ b/packages/swagger-zoo/fixtures/features/api-elements/payload-as-string.sourcemap.json
@@ -121,7 +121,7 @@
                 },
                 "value": {
                   "element": "string",
-                  "content": "custom-instance.filter.ly"
+                  "content": "https://custom-instance.filter.ly"
                 }
               }
             }

--- a/packages/swagger-zoo/package.json
+++ b/packages/swagger-zoo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Swagger example files for testing",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
OpenAPI 2.0 specification states:

> If the schemes is not included, the default scheme to be used is the one used to access the Swagger definition itself.

Thus since all our stack uses https, I would default to `https`. This avoids exposing the `HOST` metadata as a hostname (with possibly `basePath`) instead of a valid URI with a scheme.