### PR TITLE
Gracefully handle non-string path keys in OpenAPI 3

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Return a parsing warning when Paths Object contains keys which are not
+  strings. Previously the parser would throw an error.
+
 ## 0.15.0 (2020-08-06)
 
 ### Enhancements

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
-## TBD
+## 0.15.1 (2020-11-10)
 
 ### Bug Fixes
 

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/openapi3-parser/test/integration/parser/oas/parseOpenAPI-test.js
+++ b/packages/openapi3-parser/test/integration/parser/oas/parseOpenAPI-test.js
@@ -35,7 +35,7 @@ describe('#parseOpenAPIObject', () => {
     expect(result.annotations.toValue()).to.deep.equal([
       "Version '3.1337.0' is not fully supported",
       "'Info Object' contains invalid key 'invalid'",
-      "'Paths Object' contains invalid key 'invalid'",
+      "'Paths Object' contains invalid key 'invalid', key must be a path starting with a leading forward slash '/', or an extension starting with 'x-'",
       "'Components Object' contains invalid key 'invalid'",
       "'OpenAPI Object' contains invalid key 'invalid'",
     ]);

--- a/packages/openapi3-parser/test/unit/parser/oas/parsePathsObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parsePathsObject-test.js
@@ -28,6 +28,16 @@ describe('#parsePathsObject', () => {
     expect(parseResult.isEmpty).to.be.true;
   });
 
+  it('provides a warning when paths contains non-string field', () => {
+    const paths = new namespace.elements.Object();
+    paths.push(new namespace.elements.Member(true, {}));
+
+    const parseResult = parse(context, paths);
+
+    expect(parseResult.length).to.equal(1);
+    expect(parseResult).to.contain.warning("'Paths Object' path must be a string, found boolean");
+  });
+
   it('provides a warning when paths contains non-path field pattern', () => {
     const paths = new namespace.elements.Object({
       test: {},
@@ -36,7 +46,9 @@ describe('#parsePathsObject', () => {
     const parseResult = parse(context, paths);
 
     expect(parseResult.length).to.equal(1);
-    expect(parseResult).to.contain.warning("'Paths Object' contains invalid key 'test'");
+    expect(parseResult).to.contain.warning(
+      "'Paths Object' contains invalid key 'test', key must be a path starting with a leading forward slash '/', or an extension starting with 'x-'"
+    );
   });
 
   it('ignores extension objects', () => {


### PR DESCRIPTION
While processing an OpenAPI 3 document such which contains disallowed path values which are not strings, the parser would previously crash as it expected a string:

```yaml
openapi: 3.0.3
info:
  title: x
  version: 1.0.0
paths:
  true: {}
```

```
TypeError: member.key.toValue(...).startsWith is not a function
    at isPathField (/home/kyle/Projects/apiaryio/api-elements.js/packages/openapi3-parser/lib/parser/oas/parsePathsObject.js:10:52)
```

Now we will return a more helpful error message:

> warning: 'Paths Object' path must be a string, found boolean - line 6

This can be an easy mistaken because the user may think what they've put is a string when it is not, for example the following:

```yaml
paths:
  {name}:
    get: {}
```

Since the user may expect that they have written a string `{name}` whereas in YAML, this is actually an object. It represents an object with a key `name` which does not have a value. Now the user will get an appropriate error message:

> warning: 'Paths Object' path must be a string, found object - line 7

I've also made the error message for string keys which are not paths or extensions clearer. I think there was a bit of room to make it easier to understand the failure, so now if there is a key such as `users` you would get an error message informing you to add the leading forward slash:

> warning: 'Paths Object' contains invalid key 'users', key must be a path starting with a leading forward slash '/', or an extension starting with 'x-' - line 7