### PR TITLE
Simple support for Parameter Object's schema

### DIFF
--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Enhancements
 
-- Minimal support for 'Parameter Object' schemas, simplest schemas using 'type'
-  are supported.
+- Minimal support for 'Parameter Object' schemas, simple schemas using 'type'
+  and 'example' are supported.
 
 ## 0.15.1 (2020-11-10)
 

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
+## TBD
+
+### Enhancements
+
+- Minimal support for 'Parameter Object' schemas, simplest schemas using 'type'
+  are supported.
+
 ## 0.15.1 (2020-11-10)
 
 ### Bug Fixes

--- a/packages/openapi3-parser/STATUS.md
+++ b/packages/openapi3-parser/STATUS.md
@@ -124,7 +124,7 @@ Key:
 | style | ✕ |
 | explode | ~ |
 | allowReserved | ✕ |
-| schema | ✕ |
+| schema | ~ (minimal) |
 | example | ✕ |
 | examples | ✕ |
 

--- a/packages/openapi3-parser/lib/parser/oas/parseParameterObjectSchemaObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseParameterObjectSchemaObject.js
@@ -1,0 +1,86 @@
+const R = require('ramda');
+const {
+  isExtension, hasKey, hasValue, getValue,
+} = require('../../predicates');
+const {
+  createWarning,
+  createUnsupportedMemberWarning,
+  createInvalidMemberWarning,
+} = require('../annotations');
+const pipeParseResult = require('../../pipeParseResult');
+const parseObject = require('../parseObject');
+const parseString = require('../parseString');
+
+const name = 'Schema Object';
+const unsupportedKeys = [
+  '$ref', 'multipleOf', 'maximum', 'exclusiveMaximum', 'minimum',
+  'exclusiveMinimum', 'maxLength', 'minLength', 'pattern', 'maxItems',
+  'minItems', 'uniqueItems', 'maxProperties', 'minProperties', 'enum',
+  'properties', 'items', 'required', 'nullable', 'title', 'description',
+  'default', 'oneOf', 'allOf', 'anyOf', 'not', 'additionalProperties',
+  'format', 'discriminator', 'readOnly', 'writeOnly', 'xml', 'externalDocs',
+  'deprecated', 'example',
+];
+const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
+
+// purposely in the order defined in the JSON Schema spec, integer is an OAS 3 specific addition and thus is at the end
+const types = ['boolean', 'object', 'array', 'number', 'string', 'integer'];
+const isValidType = R.anyPass(R.map(hasValue, types));
+
+/**
+ * Parse Parameter Object's Schema Object
+ *
+ * @note Parameter Object's schema should be parsed using the standard schema
+ * object parser (which also will handle references). At the moment many
+ * other tooling does not expect references or complex elements in the
+ * API Elements result and thus a simple schema object parser is used
+ * directly so we can support simple cases.
+ */
+function parseSchemaObject(context) {
+  const { namespace } = context;
+
+  const ensureValidType = R.unless(
+    isValidType,
+    R.compose(
+      createWarning(namespace, `'${name}' 'type' must be either ${types.join(', ')}`),
+      getValue
+    )
+  );
+
+  const parseType = pipeParseResult(namespace,
+    parseString(context, name, false),
+    ensureValidType);
+
+  const parseMember = R.cond([
+    [hasKey('type'), parseType],
+
+    [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],
+    [isExtension, () => new namespace.elements.ParseResult()],
+    [R.T, createInvalidMemberWarning(namespace, name)],
+  ]);
+
+  return pipeParseResult(namespace,
+    parseObject(context, name, parseMember, []),
+    (schema) => {
+      const type = schema.getValue('type');
+      let element;
+
+      if (type === 'object') {
+        element = new namespace.elements.Object();
+      } else if (type === 'array') {
+        element = new namespace.elements.Array();
+      } else if (type === 'string') {
+        element = new namespace.elements.String();
+      } else if (type === 'number' || type === 'integer') {
+        element = new namespace.elements.Number();
+      } else if (type === 'boolean') {
+        element = new namespace.elements.Boolean();
+      } else {
+        element = new namespace.elements.ParseResult([]);
+      }
+
+      return element;
+    });
+}
+
+module.exports = parseSchemaObject;

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.json
@@ -126,6 +126,9 @@
                         "key": {
                           "element": "string",
                           "content": "limit"
+                        },
+                        "value": {
+                          "element": "number"
                         }
                       }
                     }
@@ -494,6 +497,9 @@
                     "key": {
                       "element": "string",
                       "content": "petId"
+                    },
+                    "value": {
+                      "element": "string"
                     }
                   }
                 }
@@ -964,25 +970,25 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 21
+                          "content": 23
                         },
                         "column": {
                           "element": "number",
-                          "content": 11
+                          "content": 13
                         }
                       },
-                      "content": 414
+                      "content": 460
                     },
                     {
                       "element": "number",
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 21
+                          "content": 23
                         },
                         "column": {
                           "element": "number",
-                          "content": 17
+                          "content": 19
                         }
                       },
                       "content": 6
@@ -994,7 +1000,7 @@
           ]
         }
       },
-      "content": "'Parameter Object' contains unsupported key 'schema' (2 occurances)"
+      "content": "'Schema Object' contains unsupported key 'format' (3 occurances)"
     },
     {
       "element": "annotation",
@@ -1115,66 +1121,6 @@
         }
       },
       "content": "'Header Object' contains unsupported key 'schema'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 92
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 2192
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 92
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 17
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Schema Object' contains unsupported key 'format' (2 occurances)"
     }
   ]
 }

--- a/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
+++ b/packages/openapi3-parser/test/integration/fixtures/petstore.sourcemap.json
@@ -376,6 +376,9 @@
                             }
                           },
                           "content": "limit"
+                        },
+                        "value": {
+                          "element": "number"
                         }
                       }
                     }
@@ -1094,6 +1097,9 @@
                         }
                       },
                       "content": "petId"
+                    },
+                    "value": {
+                      "element": "string"
                     }
                   }
                 }
@@ -1914,25 +1920,25 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 21
+                          "content": 23
                         },
                         "column": {
                           "element": "number",
-                          "content": 11
+                          "content": 13
                         }
                       },
-                      "content": 414
+                      "content": 460
                     },
                     {
                       "element": "number",
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 21
+                          "content": 23
                         },
                         "column": {
                           "element": "number",
-                          "content": 17
+                          "content": 19
                         }
                       },
                       "content": 6
@@ -1944,7 +1950,7 @@
           ]
         }
       },
-      "content": "'Parameter Object' contains unsupported key 'schema' (2 occurances)"
+      "content": "'Schema Object' contains unsupported key 'format' (3 occurances)"
     },
     {
       "element": "annotation",
@@ -2065,66 +2071,6 @@
         }
       },
       "content": "'Header Object' contains unsupported key 'schema'"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 92
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 11
-                        }
-                      },
-                      "content": 2192
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 92
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 17
-                        }
-                      },
-                      "content": 6
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "'Schema Object' contains unsupported key 'format' (2 occurances)"
     }
   ]
 }

--- a/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -469,6 +469,157 @@ describe('Parameter Object', () => {
     });
   });
 
+  describe('#schema', () => {
+    it('uses boolean type schema as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'boolean',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Boolean);
+      expect(member.value.content).to.be.undefined;
+    });
+
+    it('uses number type schema as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'number',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Number);
+      expect(member.value.content).to.be.undefined;
+    });
+
+    it('uses integer type schema as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'integer',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Number);
+      expect(member.value.content).to.be.undefined;
+    });
+
+    it('uses string type schema as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'integer',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Number);
+      expect(member.value.content).to.be.undefined;
+    });
+
+    it('uses array type schema as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'array',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Array);
+      expect(member.value.content).to.deep.equal([]);
+    });
+
+    it('uses object type schema as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'object',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Object);
+      expect(member.value.content).to.deep.equal([]);
+    });
+
+    it('ignores empty schema', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {},
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.undefined;
+    });
+
+    it('provides a warning when schema is not an object', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: [],
+      });
+
+      const parseResult = parse(context, parameter);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult).to.contain.warning("'Schema Object' is not an object");
+    });
+
+    it('provides a warning when schema is a reference', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          $ref: '#/components/schema/Date',
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult).to.contain.warning("'Schema Object' contains unsupported key '$ref'");
+    });
+  });
+
   describe('warnings for unsupported properties', () => {
     it('provides warning for unsupported deprecated property', () => {
       const parameter = new namespace.elements.Object({
@@ -516,18 +667,6 @@ describe('Parameter Object', () => {
       const parseResult = parse(context, parameter);
 
       expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'allowReserved'");
-    });
-
-    it('provides warning for unsupported schema property', () => {
-      const parameter = new namespace.elements.Object({
-        name: 'example',
-        in: 'query',
-        schema: { type: 'string' },
-      });
-
-      const parseResult = parse(context, parameter);
-
-      expect(parseResult).to.contain.warning("'Parameter Object' contains unsupported key 'schema'");
     });
 
     it('provides warning for unsupported examples property', () => {

--- a/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseParameterObject-test.js
@@ -593,6 +593,43 @@ describe('Parameter Object', () => {
       expect(member.value).to.be.undefined;
     });
 
+    it('warns when example does not match expected type', () => {
+      const schema = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'integer',
+          example: true,
+        },
+      });
+      const parseResult = parse(context, schema);
+
+      expect(parseResult.length).to.equal(2);
+      expect(parseResult).to.contain.warning(
+        "'Schema Object' 'example' does not match expected type 'integer'"
+      );
+    });
+
+    it('uses example with type as value', () => {
+      const parameter = new namespace.elements.Object({
+        name: 'example',
+        in: 'query',
+        schema: {
+          type: 'integer',
+          example: 2048,
+        },
+      });
+
+      const parseResult = parse(context, parameter);
+
+      expect(parseResult.length).to.equal(1);
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.Number);
+      expect(member.value.content).to.be.undefined;
+      expect(member.value.attributes.get('samples').toValue()).to.deep.equal([2048]);
+    });
+
     it('provides a warning when schema is not an object', () => {
       const parameter = new namespace.elements.Object({
         name: 'example',


### PR DESCRIPTION
This change brings very primitive support for the schema field in a Parameter Object. Full support is not that simple because there are numerous limitations in both API Elements and the surrounding tooling (Apiary v3 documentation, Apiary Style Guides) which may not expect references and more complex structures found in parameter value's. Typically parameter values are a flat structure.

Thus this is a very simple support for the Parameter Object schema field, only the `type` and `example` are supported only. `$ref` or any other property will produce warnings.

There is a little bit of duplication between the existing schema parser and the parameter object specific one, I don't think it is worth refactoring the old schema object to be more generic for this one-off case, and no-doubt if there was future changes to it, it would make it harder to achieve without having to consider the implications in parameters. The long term goal would be removing parameter specific schema parser to use a single schema parser. This can be a good first step.

These changes took me 10 mins in my free time to produce this, if there are major feedback against then I would just close this instead of investing any further time into it (imo its not worth it). By all means, that doesn't mean I don't want to put this in without good review :smile:.

With propagation to Dredd it would solve https://github.com/apiaryio/dredd/issues/1363.