### PR TITLE
Handle header without value during serialization

### DIFF
--- a/packages/apib-serializer/CHANGELOG.md
+++ b/packages/apib-serializer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API Elements: API Blueprint Serializer Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixes handling of headers which do not contain values.
+
 ## 0.16.2 (2020-08-31)
 
 ### Enhancements

--- a/packages/apib-serializer/template.nunjucks
+++ b/packages/apib-serializer/template.nunjucks
@@ -19,7 +19,7 @@ FORMAT: 1A
     + Headers
 
       {% for header in example.headers.exclude('Content-Type').elements %}
-            {{ header.key.toValue() }}: {{ header.value.toValue() }}{% endfor %}
+            {{ header.key.toValue() }}:{% if header.value %} {{ header.value.toValue() }}{% endif %}{% endfor %}
 
   {% endif %}
   {% if example.dataStructure %}

--- a/packages/apib-serializer/test/fixtures/header-no-value.apib
+++ b/packages/apib-serializer/test/fixtures/header-no-value.apib
@@ -1,0 +1,15 @@
+FORMAT: 1A
+
+# API Documentation
+
+### /
+
+#### GET
+
++ Request
+
+    + Headers
+
+            Accept:
+
++ Response 204

--- a/packages/apib-serializer/test/fixtures/header-no-value.json
+++ b/packages/apib-serializer/test/fixtures/header-no-value.json
@@ -1,0 +1,74 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "204"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #584

This is caused by handling header's where the member element does not contain a value.