### PR TITLE
Publish apib-serializer, openapi3-parser

### DIFF
--- a/packages/apib-serializer/CHANGELOG.md
+++ b/packages/apib-serializer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # API Elements: API Blueprint Serializer Changelog
 
-## TBD
+## 0.16.3 (2021-02-15)
 
 ### Bug Fixes
 

--- a/packages/apib-serializer/package.json
+++ b/packages/apib-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/apib-serializer",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "API Blueprint serializer for API Elements",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # API Elements: CLI Changelog
 
+## 0.10.3 (2021-02-15)
+
+This update incorporates changes from API Element Adapters:
+
+- apib-serializer 0.16.3
+- openapi3-parser 0.15.2
+
 ## 0.10.2 (2020-08-05)
 
 This update incorporates changes from API Element Adapters:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -24,10 +24,10 @@
   "dependencies": {
     "@apielements/apiaryb-parser": "^0.2.1",
     "@apielements/apib-parser": "^0.20.1",
-    "@apielements/apib-serializer": "^0.16.2",
+    "@apielements/apib-serializer": "^0.16.3",
     "@apielements/core": ">=0.1.0 <0.3.0",
     "@apielements/openapi2-parser": "^0.32.4",
-    "@apielements/openapi3-parser": "^0.15.0",
+    "@apielements/openapi3-parser": "^0.15.2",
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",
     "js-yaml": "^3.12.0",

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
-## TBD
+## 0.15.2 (2021-02-15)
 
 ### Enhancements
 

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
 - @apielements/apib-serializer@0.16.3
 - @apielements/cli@0.10.3
 - @apielements/openapi3-parser@0.15.2

Changes:

```
fix(apib): handle header without value during serialization
feat(oas3): support example inside Parameter Object schema
feat(oas3): support example inside Parameter Object schema
fix(oas3): fix missing source map for media type examples >1
```