### PR TITLE
Warn for unsupported OpenAPI 3.1 feature jsonSchemaDialect

### DIFF
--- a/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseOpenAPIObject.js
@@ -19,6 +19,7 @@ const parseSecurityRequirementsArray = require('./parseSecurityRequirementsArray
 const name = 'OpenAPI Object';
 const requiredKeys = ['openapi', 'info', 'paths'];
 const unsupportedKeys = ['tags', 'externalDocs'];
+const unsupportedOpenAPI31Keys = ['webhooks', 'jsonSchemaDialect'];
 
 /**
  * Returns whether the given member element is unsupported
@@ -28,6 +29,7 @@ const unsupportedKeys = ['tags', 'externalDocs'];
  * @private
  */
 const isUnsupportedKey = R.anyPass(R.map(hasKey, unsupportedKeys));
+const isUnsupportedOpenAPI31Key = R.anyPass(R.map(hasKey, unsupportedOpenAPI31Keys));
 
 function parseOASObject(context, object) {
   const { namespace } = context;
@@ -52,7 +54,7 @@ function parseOASObject(context, object) {
     [isExtension, () => new namespace.elements.ParseResult()],
 
     [
-      R.both(hasKey('webhooks'), isOpenAPI31OrHigher),
+      R.both(isUnsupportedOpenAPI31Key, isOpenAPI31OrHigher),
       createUnsupportedMemberWarning(namespace, name),
     ],
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],

--- a/packages/openapi3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
@@ -255,6 +255,38 @@ describe('#parseOpenAPIObject', () => {
     expect(parseResult.warnings.get(1).toValue()).to.equal("'OpenAPI Object' contains unsupported key 'webhooks'");
   });
 
+  it('provides warning for invalid key jsonSchemaDialect in OpenAPI 3.0', () => {
+    const object = new namespace.elements.Object({
+      openapi: '3.0.0',
+      info: {
+        title: 'My API',
+        version: '1.0.0',
+      },
+      paths: {},
+      jsonSchemaDialect: 'https://spec.openapis.org/oas/3.1/dialect/base',
+    });
+
+    const parseResult = parse(context, object);
+
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains invalid key 'jsonSchemaDialect'");
+  });
+
+  it('provides warning for unsupported jsonSchemaDialect key in OpenAPI 3.1', () => {
+    const object = new namespace.elements.Object({
+      openapi: '3.1.0',
+      info: {
+        title: 'My API',
+        version: '1.0.0',
+      },
+      paths: {},
+      jsonSchemaDialect: 'https://spec.openapis.org/oas/3.1/dialect/base',
+    });
+
+    const parseResult = parse(context, object);
+
+    expect(parseResult.warnings.get(1).toValue()).to.equal("'OpenAPI Object' contains unsupported key 'jsonSchemaDialect'");
+  });
+
   it('provides warning for invalid key webhooks in OpenAPI 3.0', () => {
     const object = new namespace.elements.Object({
       openapi: '3.0.0',


### PR DESCRIPTION
Continuation of https://github.com/apiaryio/api-elements.js/pull/567.

Note we don't generate JSON Schema yet at all, support for jsonSchemaDilect should be considered when implementing that feature (https://github.com/apiaryio/api-elements.js/issues/96).