### PR TITLE
Validate server variable enum is not empty

### DIFF
--- a/packages/openapi3-parser/lib/parser/oas/parseServerVariableObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseServerVariableObject.js
@@ -20,9 +20,15 @@ const parseEnumStrings = R.curry((context, element) => {
   const parseEnumString = R.unless(isString,
     createWarning(namespace, `'${name}' 'enum' array value is not a string`));
 
+  const validateArrayNotEmpty = R.when(
+    array => array.isEmpty,
+    createWarning(namespace, `'${name}' 'enum' array must contain 1 or more values`)
+  );
+
   const parseEnum = pipeParseResult(
     namespace,
     parseArray(context, `${name}' 'enum`, parseEnumString),
+    validateArrayNotEmpty,
     (array) => {
       const element = new context.namespace.elements.Enum();
       element.enumerations = array.map((value) => {

--- a/packages/openapi3-parser/test/unit/parser/oas/parseServerVariableObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseServerVariableObject-test.js
@@ -149,5 +149,20 @@ describe('#parseServerVariableObject', () => {
       expect(enumeration.toValue()).to.deep.equal('Tony');
       expect(enumeration.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
     });
+
+    it('warns when enum is empty', () => {
+      const serverVariable = new namespace.elements.Object({
+        default: 'Mario',
+        enum: [],
+      });
+
+      const parseResult = parse(context)(serverVariable, 'name');
+
+      expect(parseResult).to.contain.warning("'Server Variable Object' 'enum' array must contain 1 or more values");
+
+      const member = parseResult.get(0);
+      expect(member).to.be.instanceof(namespace.elements.Member);
+      expect(member.value).to.be.instanceof(namespace.elements.String);
+    });
   });
 });


### PR DESCRIPTION
This was from OpenAPI 3.1 rc1 changelog:

> Server Variable's enum now MUST not be empty (changed from SHOULD).

Technically before it was also a should and we didn't warn. The behaviour in our parser is that MUST's generally behave as warn and discard the value instead of erroring out completely (to be less hostile). So the behaviour is same for both versions in this parser.