### PR TITLE
Warn for pathItems in components on 3.1

### DIFF
--- a/packages/openapi3-parser/lib/parser/oas/parseComponentsObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseComponentsObject.js
@@ -224,6 +224,7 @@ function parseComponentsObject(context, element) {
       return parseResult;
     });
 
+  const isOpenAPI31OrHigher = () => context.isOpenAPIVersionMoreThanOrEqual(3, 1);
   const parseMember = R.cond([
     [hasKey('schemas'), parseSchemas],
     [hasKey('parameters'), parseComponentObjectMember(parseParameterObject)],
@@ -232,6 +233,7 @@ function parseComponentsObject(context, element) {
     [hasKey('examples'), parseComponentObjectMember(parseExampleObject)],
     [hasKey('headers'), parseComponentObjectMember(parseHeaderObject)],
     [hasKey('securitySchemes'), parseSecuritySchemes],
+    [R.both(hasKey('pathItems'), isOpenAPI31OrHigher), createUnsupportedMemberWarning(namespace, name)],
 
     [isUnsupportedKey, createUnsupportedMemberWarning(namespace, name)],
 

--- a/packages/openapi3-parser/test/unit/parser/oas/parseComponentsObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseComponentsObject-test.js
@@ -239,6 +239,27 @@ describe('Components Object', () => {
     });
   });
 
+  describe('#pathItems', () => {
+    it('provides a warning when using OpenAPI < 3.1', () => {
+      const components = new namespace.elements.Object({
+        pathItems: {},
+      });
+
+      const parseResult = parse(context, components);
+      expect(parseResult).to.contain.warning("'Components Object' contains invalid key 'pathItems'");
+    });
+
+    it('provides an unsupported warning when using OpenAPI >= 3.1', () => {
+      context.openapiVersion = { major: 3, minor: 1 };
+      const components = new namespace.elements.Object({
+        pathItems: {},
+      });
+
+      const parseResult = parse(context, components);
+      expect(parseResult).to.contain.warning("'Components Object' contains unsupported key 'pathItems'");
+    });
+  });
+
   describe('#requestBodies', () => {
     it('provides a warning when requestBodies is not an object', () => {
       const components = new namespace.elements.Object({


### PR DESCRIPTION
3.1.0-rc0 brings:

> Components Object now has a new entry pathItems, to allow for reusable Path Item Objects to be defined within a valid OpenAPI document

I looked into supporting this but it will require a bit of refactoring to do first because right now the pathItemsParser returns concrete values which use the member's key (the path itself). Whereas we won't know that upfront when parsing reusable path items as they don't have a "path" (key) until use.

Path Item Object parser already has warning for `$ref` as use.