### PR TITLE
Include nullable with Schema Object without a type on OAS 3.1

### DIFF
--- a/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
@@ -285,6 +285,10 @@ function parseSchema(context) {
           constructObjectStructure(namespace, schema),
           constructArrayStructure(namespace, schema),
         ];
+
+        if (context.isOpenAPIVersionMoreThanOrEqual(3, 1)) {
+          element.attributes.set('typeAttributes', ['nullable']);
+        }
       }
 
       const title = schema.getValue('title');

--- a/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
@@ -41,7 +41,7 @@ describe('Schema Object', () => {
       );
     });
 
-    it('returns a data structure representing all types for no type limitations', () => {
+    it('returns a data structure representing all types excluding null for no type limitations on OpenAPI less than 3.1', () => {
       const schema = new namespace.elements.Object({});
       const parseResult = parse(context, schema);
 
@@ -58,6 +58,28 @@ describe('Schema Object', () => {
       expect(element.enumerations.get(2)).to.be.instanceof(namespace.elements.Boolean);
       expect(element.enumerations.get(3)).to.be.instanceof(namespace.elements.Object);
       expect(element.enumerations.get(4)).to.be.instanceof(namespace.elements.Array);
+      expect(element.attributes.getValue('typeAttributes')).to.be.undefined;
+    });
+
+    it('returns a data structure representing all types for no type limitations on OpenAPI 3.1', () => {
+      context.openapiVersion = { major: 3, minor: 1 };
+      const schema = new namespace.elements.Object({});
+      const parseResult = parse(context, schema);
+
+      expect(parseResult.length).to.equal(1);
+      expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+      expect(parseResult).to.not.contain.annotations;
+
+      const element = parseResult.get(0).content;
+      expect(element).to.be.instanceof(namespace.elements.Enum);
+
+      expect(element.enumerations.length).to.equal(5);
+      expect(element.enumerations.get(0)).to.be.instanceof(namespace.elements.String);
+      expect(element.enumerations.get(1)).to.be.instanceof(namespace.elements.Number);
+      expect(element.enumerations.get(2)).to.be.instanceof(namespace.elements.Boolean);
+      expect(element.enumerations.get(3)).to.be.instanceof(namespace.elements.Object);
+      expect(element.enumerations.get(4)).to.be.instanceof(namespace.elements.Array);
+      expect(element.attributes.getValue('typeAttributes')).to.deep.equal(['nullable']);
     });
 
     it('returns a boolean structure for boolean type', () => {
@@ -547,6 +569,7 @@ describe('Schema Object', () => {
 
     it('adds nullable type attribute to element', () => {
       const schema = new namespace.elements.Object({
+        type: 'array',
         nullable: true,
       });
       const parseResult = parse(context, schema);


### PR DESCRIPTION
In OpenAPI 3.1, `null` is permitted in `type`. This causes the behaviour when you have a schema without a type restriction to allow null. This wasn't the case in OpenAPI 3.0 or older, because these version removes `null` from JSON Schema's type system.