### PR TITLE
Remove unsupported warning for OpenAPI 3.1

### DIFF
--- a/packages/openapi3-parser/lib/parser/openapi.js
+++ b/packages/openapi3-parser/lib/parser/openapi.js
@@ -4,7 +4,7 @@ const { isString } = require('../predicates');
 
 const semanticVersionRE = /^(\d+)\.(\d+).(\d+)$/;
 
-const supportedMinorVersion = 0;
+const supportedMinorVersion = 1;
 const supportedMajorVersion = 3;
 
 // Parse the OpenAPI Version member

--- a/packages/openapi3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseOpenAPIObject-test.js
@@ -252,7 +252,7 @@ describe('#parseOpenAPIObject', () => {
 
     const parseResult = parse(context, object);
 
-    expect(parseResult.warnings.get(1).toValue()).to.equal("'OpenAPI Object' contains unsupported key 'webhooks'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'webhooks'");
   });
 
   it('provides warning for invalid key jsonSchemaDialect in OpenAPI 3.0', () => {
@@ -284,7 +284,7 @@ describe('#parseOpenAPIObject', () => {
 
     const parseResult = parse(context, object);
 
-    expect(parseResult.warnings.get(1).toValue()).to.equal("'OpenAPI Object' contains unsupported key 'jsonSchemaDialect'");
+    expect(parseResult).to.contain.warning("'OpenAPI Object' contains unsupported key 'jsonSchemaDialect'");
   });
 
   it('provides warning for invalid key webhooks in OpenAPI 3.0', () => {

--- a/packages/openapi3-parser/test/unit/parser/openapi-test.js
+++ b/packages/openapi3-parser/test/unit/parser/openapi-test.js
@@ -46,6 +46,15 @@ describe('#parseOpenAPI', () => {
     expect(parseResult.get(0).value.toValue()).to.equal('3.0.0');
   });
 
+  it('allows openapi 3.1.0', () => {
+    const openapi = new namespace.elements.Member('openapi', '3.1.0');
+
+    const parseResult = parseOpenAPI(context, openapi);
+    expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
+    expect(parseResult).to.not.contain.annotations;
+    expect(parseResult.get(0).value.toValue()).to.equal('3.1.0');
+  });
+
   it('allows openapi patch version 3.0.11', () => {
     const openapi = new namespace.elements.Member('openapi', '3.0.11');
 
@@ -56,12 +65,12 @@ describe('#parseOpenAPI', () => {
   });
 
   it('warns for unsuported minor versions', () => {
-    const openapi = new namespace.elements.Member('openapi', '3.1.0');
+    const openapi = new namespace.elements.Member('openapi', '3.2.0');
 
     const parseResult = parseOpenAPI(context, openapi);
     expect(parseResult).to.be.instanceof(namespace.elements.ParseResult);
-    expect(parseResult).to.contain.warning("Version '3.1.0' is not fully supported");
-    expect(parseResult.get(0).value.toValue()).to.equal('3.1.0');
+    expect(parseResult).to.contain.warning("Version '3.2.0' is not fully supported");
+    expect(parseResult.get(0).value.toValue()).to.equal('3.2.0');
   });
 
   it('adds the version to context', () => {


### PR DESCRIPTION
Removes the warning

> Version '3.1.0' is not fully supported

Depends on:

- https://github.com/apiaryio/api-elements.js/pull/603
- https://github.com/apiaryio/api-elements.js/pull/602
- https://github.com/apiaryio/api-elements.js/pull/601
- https://github.com/apiaryio/api-elements.js/pull/600
- https://github.com/apiaryio/api-elements.js/pull/599

and one more un-pushed change. Once these are wrapped up, all the unsupported 3.1 behaviours will have their own warning messages, or the functionality should be functional.