### PR TITLE
Support `null` with other types on OpenAPI 3.1

### DIFF
--- a/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
+++ b/packages/openapi3-parser/lib/parser/oas/parseSchemaObject.js
@@ -330,13 +330,19 @@ function parseSchema(context) {
     return element;
   };
 
+  const parseNullable = R.ifElse(
+    R.always(context.isOpenAPIVersionMoreThanOrEqual(3, 1)),
+    createWarning(context.namespace, `'${name}' 'nullable' is removed in OpenAPI 3.1, use 'null' in type`),
+    parseBoolean(context, name, false)
+  );
+
   const parseMember = R.cond([
     [hasKey('type'), R.compose(parseType(context), getValue)],
     [hasKey('enum'), R.compose(parseEnum(context, name), getValue)],
     [hasKey('properties'), R.compose(parseProperties, getValue)],
     [hasKey('items'), R.compose(parseSubSchema, getValue)],
     [hasKey('required'), R.compose(parseRequired, getValue)],
-    [hasKey('nullable'), parseBoolean(context, name, false)],
+    [hasKey('nullable'), parseNullable],
     [hasKey('title'), parseString(context, name, false)],
     [hasKey('description'), parseString(context, name, false)],
     [hasKey('default'), e => e.clone()],

--- a/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
@@ -702,6 +702,20 @@ describe('Schema Object', () => {
   });
 
   describe('#nullable', () => {
+    it('warns when nullable is used with OpenAPI 3.1', () => {
+      context.openapiVersion = { major: 3, minor: 1 };
+      const schema = new namespace.elements.Object({
+        nullable: true,
+      });
+      const parseResult = parse(context, schema);
+
+      expect(parseResult.length).to.equal(2);
+
+      expect(parseResult).to.contain.warning(
+        "'Schema Object' 'nullable' is removed in OpenAPI 3.1, use 'null' in type"
+      );
+    });
+
     it('warns when nullable is not boolean', () => {
       const schema = new namespace.elements.Object({
         nullable: 1,


### PR DESCRIPTION
* Removes nullable on OAS 3.1 (this is breaking change in 3.1 spec)
* Supports type with array of 1 item alongside null (but no other case -- that will come)