### PR TITLE
Support multiple types in Schema Object

### DIFF
--- a/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
+++ b/packages/openapi3-parser/test/unit/parser/oas/parseSchemaObject-test.js
@@ -268,18 +268,6 @@ describe('Schema Object', () => {
         );
       });
 
-      it('warns when array items contain more than 1 entry', () => {
-        // FIXME support more than one entry :)
-        const schema = new namespace.elements.Object({
-          type: ['string', 'number'],
-        });
-        const parseResult = parse(context, schema);
-
-        expect(parseResult).to.contain.warning(
-          "'Schema Object' 'type' more than one type is current unsupported"
-        );
-      });
-
       it('when type contains a single value', () => {
         const schema = new namespace.elements.Object({
           type: ['string'],
@@ -307,6 +295,44 @@ describe('Schema Object', () => {
         const string = parseResult.get(0).content;
         expect(string).to.be.instanceof(namespace.elements.String);
         expect(string.attributes.getValue('typeAttributes')).to.deep.equal(['nullable']);
+      });
+
+      it('when type contains multiple values', () => {
+        const schema = new namespace.elements.Object({
+          type: ['string', 'number'],
+        });
+        const parseResult = parse(context, schema);
+
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+        expect(parseResult).to.not.contain.annotations;
+
+        const element = parseResult.get(0).content;
+        expect(element).to.be.instanceof(namespace.elements.Enum);
+
+        expect(element.enumerations.length).to.equal(2);
+        expect(element.enumerations.get(0)).to.be.instanceof(namespace.elements.String);
+        expect(element.enumerations.get(1)).to.be.instanceof(namespace.elements.Number);
+        expect(element.attributes.getValue('typeAttributes')).to.be.undefined;
+      });
+
+      it('when type contains multiple values with null', () => {
+        const schema = new namespace.elements.Object({
+          type: ['string', 'number', 'null'],
+        });
+        const parseResult = parse(context, schema);
+
+        expect(parseResult.length).to.equal(1);
+        expect(parseResult.get(0)).to.be.instanceof(namespace.elements.DataStructure);
+        expect(parseResult).to.not.contain.annotations;
+
+        const element = parseResult.get(0).content;
+        expect(element).to.be.instanceof(namespace.elements.Enum);
+
+        expect(element.enumerations.length).to.equal(2);
+        expect(element.enumerations.get(0)).to.be.instanceof(namespace.elements.String);
+        expect(element.enumerations.get(1)).to.be.instanceof(namespace.elements.Number);
+        expect(element.attributes.getValue('typeAttributes')).to.deep.equal(['nullable']);
       });
     });
   });


### PR DESCRIPTION
This completes full support for multiple types in OpenAPI 3.1 schemas, this builds up on the work from other recent changes:

- [Support null 3.1 type in Schema Object ](https://github.com/apiaryio/api-elements.js/pull/597)
- [Normalise OpenAPI type as an array internally](https://github.com/apiaryio/api-elements.js/pull/598) - this brings some upfront refactoring so the code base deals with array of types. The internal interfaces are updated, with assumption that type can never be more than one.
- [Support array of type in Schema Object](https://github.com/apiaryio/api-elements.js/pull/600) - brings array of types to our public interface (i.e, support from input), but restricts the types to only allow 1. That changes brings all the logic for parsing arrays, duplicate detection, and the various test cases for parsing the array.
- [Support `null` with other types on OpenAPI 3.1](https://github.com/apiaryio/api-elements.js/pull/605) - brings support for specifying a type alongside null (and removes nullable for OpenAPI 3.1 which is replaced by null). Null is more of a special case in terms of types because for most part, in API Elements null alongside another type is that type with a nullable attribute.