### PR TITLE
Release openapi3-parser@0.16.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API Elements: CLI Changelog
 
+## 0.10.4 (2021-02-23)
+
+This update incorporates changes from API Element Adapters:
+
+- openapi3-parser 0.16.0
+
 ## 0.10.3 (2021-02-15)
 
 This update incorporates changes from API Element Adapters:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Command line tool interface for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "@apielements/apib-serializer": "^0.16.3",
     "@apielements/core": ">=0.1.0 <0.3.0",
     "@apielements/openapi2-parser": "^0.32.4",
-    "@apielements/openapi3-parser": "^0.15.2",
+    "@apielements/openapi3-parser": "^0.16.0",
     "cardinal": "^2.1.1",
     "commander": "^5.1.0",
     "js-yaml": "^3.12.0",

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,8 +1,13 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
-## TBD
+## 0.16.0 (2021-02-23)
 
 ### Enhancements
+
+- Support for OpenAPI 3.1, some features and fields are not supported (these
+  will emit the appropriate unsupported warnings).
+
+  This includes support for `const` and array `type` in 'Schema Object'.
 
 - Support for the 'title', 'description', and 'enum' properties in 'Schema
   Object's found within 'Parameter Object'.

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
## openapi3-parser 0.16.0 (2021-02-23)

### Enhancements

- Support for OpenAPI 3.1, some features and fields are not supported (these will emit the appropriate unsupported warnings).

  This includes support for `const` and array `type` in 'Schema Object'.

- Support for the 'title', 'description', and 'enum' properties in 'Schema Object's found within 'Parameter Object'.

## cli 0.10.4 (2021-02-23)

This update incorporates changes from API Element Adapters:

- openapi3-parser 0.16.0