### PR TITLE
Support boolean additionalProperties in OpenAPI 2

### DIFF
--- a/packages/openapi2-parser/lib/schema.js
+++ b/packages/openapi2-parser/lib/schema.js
@@ -120,6 +120,12 @@ class DataStructureGenerator {
     });
     element.content.push(...requiredMembers);
 
+    if (schema.additionalProperties === false) {
+      const typeAttributes = element.attributes.get('typeAttributes') || new this.minim.elements.Array([]);
+      typeAttributes.push('fixed-type');
+      element.attributes.set('typeAttributes', typeAttributes);
+    }
+
     return element;
   }
 

--- a/packages/openapi2-parser/test/schema-test.js
+++ b/packages/openapi2-parser/test/schema-test.js
@@ -692,6 +692,36 @@ describe('JSON Schema to Data Structure', () => {
       expect(samples).to.be.instanceof(ArrayElement);
       expect(samples.toValue()).to.be.deep.equal([{ name: 'Doe' }]);
     });
+
+    it('produces object with additionalProperties as true', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: true,
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+
+      expect(dataStructure.content.length).to.equal(0);
+      expect(dataStructure.content.attributes.getValue('typeAttributes')).to.be.undefined;
+    });
+
+    it('produces object with additionalProperties as false', () => {
+      const schema = {
+        type: 'object',
+        additionalProperties: false,
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+
+      expect(dataStructure.content.length).to.equal(0);
+      expect(dataStructure.content.attributes.getValue('typeAttributes')).to.deep.equal(['fixed-type']);
+    });
   });
 
   context('array schema', () => {


### PR DESCRIPTION
Boolean additional properties, for example (`additionalProperties: false` which indicates no additional properties are permittied), in API Elements that is an object with the `fixed-type` typeAttribute.

`additionalProperties` may also contain a subschema which all undeclared properties must conform to, I'll try prepare a follow up with that. That can become tricky due to the implications with the `required` keyword.