### PR TITLE
Prevent treating overlapping paths as a circular reference 

### DIFF
--- a/packages/openapi2-parser/CHANGELOG.md
+++ b/packages/openapi2-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # API Elements: OpenAPI 2 Parser Changelog
 
+## 0.32.6 (2021-07-21)
+
+### Bug Fixes
+
+- Fixes generating example JSON bodies from Swagger Schema when the schema
+  contains a reference to a JSON path which prefixes the current path, for
+  example when handling a path such as `$ref: '#/definitions/User'` from a path
+  which prefixes it such as `$ref: '#/definitions/UserList'`.
+
 ## 0.32.5 (2020-02-24)
 
 ### Enhancements

--- a/packages/openapi2-parser/lib/json-schema.js
+++ b/packages/openapi2-parser/lib/json-schema.js
@@ -76,12 +76,12 @@ const pathHasCircularReference = (paths, path, reference) => {
   const currentPath = (path || []).join('/');
 
   // Check for direct circular reference
-  if (currentPath.startsWith(reference)) {
+  if (currentPath === reference || currentPath.startsWith(`${reference}/`)) {
     return true;
   }
 
   // Check for indirect circular Reference
-  if ((paths || []).find(p => p.startsWith(reference))) {
+  if ((paths || []).find(p => p === reference || p.startsWith(`${reference}/`))) {
     return true;
   }
 
@@ -393,5 +393,11 @@ const convertSchemaDefinitions = (definitions) => {
 };
 
 module.exports = {
-  isExtension, parseReference, lookupReference, dereference, convertSchema, convertSchemaDefinitions,
+  isExtension,
+  parseReference,
+  lookupReference,
+  dereference,
+  convertSchema,
+  convertSchemaDefinitions,
+  pathHasCircularReference,
 };

--- a/packages/openapi2-parser/package.json
+++ b/packages/openapi2-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi2-parser",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "description": "Swagger 2.0 parser for Fury.js",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",

--- a/packages/openapi3-parser/CHANGELOG.md
+++ b/packages/openapi3-parser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # API Elements: OpenAPI 3 Parser Changelog
 
-## TBD
+## 0.16.1 (2021-07-15)
 
 ### Enhancements
 

--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apielements/openapi3-parser",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Open API Specification 3 API Elements Parser",
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",


### PR DESCRIPTION
A check that a reference to `#/definitions/User` from within `#/definitions/UserList` would incorrectly been interpreted as a circular reference as a simplistic check that the current path starts with the current reference. We should ensure that the reference is either identical, or relative from another (such as with a trailing slash).

This was easiest to test at a unit level so I have added unit tests for this method. The top 4 added tests would already pass, just increasing test coverage to account for all the branches in the circular reference checker.

To aid review, the circular reference checker is passed all the references we've traversed (this is the first argument). If we would follow a series of references (such as if we are currently at `#/items`, and then we followed a reference to `#/definitions/User` which inside `#/definitions/User/properties/comments/items` referenced ` `#/definitions/Comment`. The current path would become `#/definitions/Comment` and the current traversed path would be something like `['#/items', '#/definitions/User', '#/definitions/User/properties/comments/items']`. These parts of the current resolution are pushed and popped as we resolve a schema.