### PR TITLE
chore: loosen ramda dependency range for openapi3-parser

### DIFF
--- a/packages/openapi3-parser/package.json
+++ b/packages/openapi3-parser/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "content-type": "^1.0.4",
     "media-typer": "^1.0.1",
-    "ramda": "0.27.0",
+    "ramda": "^0.27.0",
     "yaml-js": "^0.2.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Goal: Widen ramda dependency range to allow use of version `ramda@0.27.2` in `openapi3-parser`.

Adding the carat in `openapi3-parser`'s dependency configuration is consistent with the use of ramda in the `api-elements` package in this same monorepo: https://github.com/apiaryio/api-elements.js/blob/0b3d0622b2310e91bbf0915a9912c9a1920c03f6/packages/api-elements/package.json#L25

Additionally, allowing downstream consumers to utilize `ramda@0.27.2` allows them to use a version which includes this security fix https://github.com/ramda/ramda/pull/3177

Bigger picture, as both of the libraries mentioned are included in the dependency tree of `dredd` (by way of `dredd-transactions`), unifying their use of this dependency will allow deduplication when using that project. The two independent versions of ramda can be seen here 

```
└─┬ dredd@14.1.0
  ├─┬ dredd-transactions@10.1.0
  │ ├─┬ @apielements/core@0.2.1
  │ │ └─┬ api-elements@0.3.2
  │ │   └── ramda@0.27.2
  │ └─┬ @apielements/openapi3-parser@0.16.0
  │   └── ramda@0.27.0
```

# Alternatives

This dependency could be updated to `^0.28.0`, which is latest at time of writing, but this change seemed less invasive and aligned `api-elements` and `openapi3-parser` to be upgraded in tandem later